### PR TITLE
Updates to dvm-dos-tem

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,9 @@
 
 CC=g++
 CFLAGS=-c -Wall -ansi -O2 -g -fPIC
-LNX_LIBS=-lnetcdf_c++ -lnetcdf
+LIBS=-lnetcdf_c++ -lnetcdf
+LIBDIR=
+INCLUDES=
 SOURCES= 	src/TEM.o \
 		src/assembler/RunCohort.o \
 		src/assembler/RunGrid.o \
@@ -128,11 +130,12 @@ OBJECTS = 	RunCohort.o \
 		SoilLayer.o
 TEMOBJ=	TEM.o
 
+
 dvm: $(SOURCES) $(TEMOBJ)
-	$(CC) -o DVMDOSTEM $(OBJECTS) $(TEMOBJ) $(LINUX_LIBPATH) $(LNX_LIBS)
+	$(CC) -o DVMDOSTEM $(INCLUDES) $(OBJECTS) $(TEMOBJ) $(LIBDIR) $(LIBS)
 
 lib: $(SOURCES) 
-	$(CC) -o libTEM.so -shared $(OBJECTS) $(LINUX_LIBPATH) $(LNX_LIBS)
+	$(CC) -o libTEM.so -shared $(INCLUDES) $(OBJECTS) $(LIBDIR) $(LIBS)
 
 .cpp.o:  
 	$(CC) $(CFLAGS) $(INCLUDES) $<

--- a/src/inc/physicalconst.h
+++ b/src/inc/physicalconst.h
@@ -18,7 +18,9 @@
 	const float LHSUB  = 2.8338e6 ; // latent heat of sublimation  J/kg
 	
 	const float G        = 9.80616 ;  //  acceleration of gravity m/s2
+	#ifndef PI
 	const float PI       = 3.14159265358979; // pi -
+	#endif
 	const float Pstd     = 101325 ; // standard pressure Pa
 	const float STFBOLTZ = 5.67e-8 ;// Stefan-Boltzmann constant W/m2K4
 	const float BOLTZ    = 1.38e-23 ; // Boltzmann constant J/Kmolecule


### PR DESCRIPTION
Added some fixes in Makefile to handle:
- changes in location of dvm dir
- netcdf library checks, now works with standard installed netcdf as included version is now dynamically linked

Added #ifndef check for PI, as otherwise compilation fails for AIEM
