### PR TITLE
Incorporating Fengming's commits 844f5044 and b65c9f88.

### DIFF
--- a/src/assembler/Runner.cpp
+++ b/src/assembler/Runner.cpp
@@ -204,7 +204,7 @@ void Runner::setupIDs(){
 	}
 
 	// 1) assign grid-level data IDs (in 'grid.nc') for 'chtid' in 'cohortid.nc': related key - 'GRIDID'
-	//    note: one 'chtid' only has one set of grid=level data IDs, while not in reverse
+	//    note: one 'chtid' only has one set of grid-level data IDs, while not in reverse
 	unsigned int icht;
 	unsigned int igrd;
 	vector<int>:: iterator it;
@@ -241,6 +241,13 @@ void Runner::setupIDs(){
 		jt    = find(rungrd.grdids.begin(), rungrd.grdids.end(), runcht.chtgridids.at(jcht));
 		jdata = (int)(jt - rungrd.grdids.begin());
 		reclistgrid.push_back(jdata);
+
+		float lat = -999.0f;
+		float lon = -999.0f;
+		rungrd.ginputer.getLatlon(lat, lon, jdata);
+		runchtlats.push_back(lat);
+		runchtlons.push_back(lon);
+
 		// drainage-type record no. (in 'drainage.nc') for 'chtid'
 		jt    = find(rungrd.drainids.begin(), rungrd.drainids.end(), runcht.chtdrainids.at(jcht));
 		jdata = (int)(jt - rungrd.drainids.begin());
@@ -416,7 +423,7 @@ void Runner::runmode3(){
 	if(md.runsp){
 		timer.stageyrind = 0;
 		timer.eqend = true;
-	    runcht.used_atmyr = min(MAX_ATM_NOM_YR, runcht.cht.cd.act_atm_drv_yr);
+	    runcht.used_atmyr = min(MAX_ATM_NOM_YR, md.act_clmyr);
 	    runcht.yrstart = timer.spbegyr;
 	    runcht.yrend   = timer.spendyr;
 	    md.friderived= false;
@@ -425,7 +432,7 @@ void Runner::runmode3(){
 		timer.stageyrind = 0;
 		timer.eqend = true;
 		timer.spend = true;
-		runcht.used_atmyr = runcht.cht.cd.act_atm_drv_yr;
+		runcht.used_atmyr = md.act_clmyr;
 		runcht.yrstart = timer.trbegyr;
 		runcht.yrend   = timer.trendyr;
 	    md.friderived= false;
@@ -435,7 +442,7 @@ void Runner::runmode3(){
 		timer.eqend = true;
 		timer.spend = true;
 		timer.trend = true;
-		runcht.used_atmyr = runcht.cht.cd.act_atm_drv_yr;
+		runcht.used_atmyr = md.act_clmyr;
 		runcht.yrstart = timer.scbegyr;
 		runcht.yrend   = timer.scendyr;
 	    md.friderived= false;
@@ -461,11 +468,14 @@ void Runner::runSpatially(const int icalyr, const int im) {
 		chtid = runchtlist.at(jj);
 
 		// may need to clear up data containers for new cohort
-		runcht.cht.clearData();
- 		runcht.cht.setModelData(&md);
- 		runcht.cht.setTime(&timer);
- 		runcht.cht.setInputData(&runreg.region.rd, &rungrd.grid.gd);
- 		runcht.cht.setProcessData(&chted, &chtbd, &chtfd);  //
+		chted = EnvData();
+		chtbd = BgcData();
+		chtfd = FirData();
+		rungrd.grid = Grid();
+		runcht.cht = Cohort();
+
+		//reset data pointer connection
+		setupData();
 
  		// starting new cohort here
 		runcht.cht.cd.chtid = chtid;

--- a/src/assembler/Runner.h
+++ b/src/assembler/Runner.h
@@ -44,10 +44,11 @@ class Runner {
     	void runmode3();  /* multi-site (regional) run-mode 2, i.e., spatially */
     	void runSpatially(const int icalyr, const int im);
 
-    private:
+    	vector<int> runchtlist;  //a vector listing all cohort id
+ 	    vector<int> runchtlats;  //a vector of latitudes for all cohorts in order of 'runchtlist'
+ 	    vector<int> runchtlons;  //a vector of longitudes for all cohorts in order of 'runchtlist'
 
-    	vector<int> runchtlist;
- 		/* all data record no. lists FOR all cohorts in 'runchtlist', IN EXACTLY SAME ORDER, for all !
+    	/* all data record no. lists FOR all cohorts in 'runchtlist', IN EXACTLY SAME ORDER, for all !
     	 * the 'record' no. (starting from 0) is the order in the netcdf files
     	 * for all 'chort (cell)' in the 'runchtlist',
     	 * so, the length of all these lists are same as that of 'runchtlist'
@@ -65,6 +66,8 @@ class Runner {
     	vector<int> reclistclm;
     	vector<int> reclistveg;
     	vector<int> reclistfire;
+
+	private:
 
     	//TEM domains (hiarchy)
     	RunRegion runreg;

--- a/src/inc/cohortconst.h
+++ b/src/inc/cohortconst.h
@@ -15,11 +15,4 @@
 	const int NUM_FSEASON  = 4;   // no. of fire season categories: season: 1 (pre-season), 2(early fire), 3(late fire), and 4 (after-season) with 3 months in the order
 	const int NUM_FSIZE    = 5;   // no. of fire size categories
 
-	enum CMTKEY{SEDGETUNDRA = 0,
-		          SHRUBTUNDRA,
-		          UPBSPRUCE,    LOWBSPRUCE,
-		          UPWSPRUCE,    LOWWSPRUCE,
-		          UPDECIDUOUS,  LOWDECIDUOUS,
-		          };
-
 #endif /*COHORTCONST_H_*/

--- a/src/runmodule/Cohort.cpp
+++ b/src/runmodule/Cohort.cpp
@@ -147,7 +147,7 @@ void Cohort::clearData(){
 
    	edall->clear();
     bdall->clear();
-    fd    = NULL;
+    fd->clear();
 
 };
 

--- a/src/runmodule/Cohort.h
+++ b/src/runmodule/Cohort.h
@@ -103,27 +103,27 @@
             Integrator solintegrator;
 
 
-     	void updateMonthly_DIMveg(const int & currmind, const bool & dvmmodule);
-     	void updateMonthly_DIMgrd(const int & currmind, const bool & dslmodule);
+     	    void updateMonthly_DIMveg(const int & currmind, const bool & dvmmodule);
+     	    void updateMonthly_DIMgrd(const int & currmind, const bool & dslmodule);
 
-     	void updateMonthly_Env(const int & currmind, const int & dinmcurr);
- 	 	void updateMonthly_Bgc(const int & currmind);
-     	void updateMonthly_Fir(const int & yrcnt, const int & currmind);
+     	    void updateMonthly_Env(const int & currmind, const int & dinmcurr);
+ 	 	    void updateMonthly_Bgc(const int & currmind);
+     	    void updateMonthly_Fir(const int & yrcnt, const int & currmind);
 
-		// update root distribution
-		void getSoilFineRootFrac_Monthly();
-		double assignSoilLayerRootFrac(const double & topz, const double & botz,
+		    // update root distribution
+		    void getSoilFineRootFrac_Monthly();
+		    double assignSoilLayerRootFrac(const double & topz, const double & botz,
 		           const double csumrootfrac[MAX_ROT_LAY], const double dzrotlay[MAX_ROT_LAY]);
 
-		//
-     	void assignAtmEd2pfts_daily();
-     	void assignGroundEd2pfts_daily();
-		void getSoilTransfactor4all_daily();
-		void getEd4allveg_daily();
-     	void getEd4land_daily();
+		   //
+     	   void assignAtmEd2pfts_daily();
+     	   void assignGroundEd2pfts_daily();
+		   void getSoilTransfactor4all_daily();
+		   void getEd4allveg_daily();
+     	   void getEd4land_daily();
 
-     	void assignSoilBd2pfts_monthly();
-     	void getBd4allveg_monthly();
+     	   void assignSoilBd2pfts_monthly();
+     	   void getBd4allveg_monthly();
 
 };
 #endif /*COHORT_H_*/

--- a/src/runmodule/Integrator.cpp
+++ b/src/runmodule/Integrator.cpp
@@ -223,7 +223,7 @@ int Integrator::adapt(float pstate[], const int & numeq){
   	float time = 0.0;
   	float dt = 1.0;
   	int mflag = 0;
-  	long nintmon = 0;
+  	int nintmon = 0;
   	float oldstate[numeq];
   	float  ptol =0.01;
 

--- a/src/runmodule/Integrator.h
+++ b/src/runmodule/Integrator.h
@@ -123,7 +123,7 @@ class Integrator{
        int blackhol;
        float inittol;
        int maxit;
-       long maxitmon;
+       int maxitmon;
        int retry;
 
        int syint;

--- a/src/snowsoil/SoilParent_Env.cpp
+++ b/src/snowsoil/SoilParent_Env.cpp
@@ -61,11 +61,12 @@ void SoilParent_Env::retrieveDailyTM(Layer* lstsoill){
 
 	Layer *currl = lstsoill->nextl;
 
+	double trock = lstsoill->tem;
 	int rcind = -1;
 	while (currl!=NULL) {
 		if (currl->isRock) {
 			rcind++;
-			ed->d_sois.trock[rcind] = lstsoill->tem;
+			ed->d_sois.trock[rcind] = trock;
 		}
 		currl = currl->nextl;
 	}


### PR DESCRIPTION
Again doing this by hand to avoid mode change conflicts and to
be able to retain the Argument handling code and DATA/ directory
organization that has taken place...still looking for a better
workflow. Here were the steps:
- pull fmyuan/dvm-dos-tem:devel into the junk repository.
- delete everything in the src/ directory of this repo.
- copy the src/ directory from the junk repo into this repo.
- using git-gui to go thru and add the fengming's edits to this
  commit.
- make sure fengming's comments get included in this message
- next is to test on aeshna, and then issue pull request to ua-snap?

Commit: 844f5044...
two bugs fixed, data clean-up simplified, and 'long' type avoided
(1) front-type in 'restart' bug fixed;
(2) Tobey caught a bug in 'climate' data processing for non-eq
runstages. It's fixed;
(3) data clean-up after one cohort is done previously is implemented
individually for data structure. It's too complicated and prone to
error. It can be done just by calling relevant constructor.
(4) When moving code from 32-bit to 64-bit, 'long' type definition could
cause issues. This is totally checked in this version of code. This
issue was found when comparing running DOS-TEM on my 32-bit windows XP
and on aeshna.

Commit: b65c9f88...
read all cohort grid-location in runner.

Two vectors of grid latitude/longitude for
each 'cohort' in'runchtlist' vector are explicitly
read in during data preparation stage ('setupIDs').
Those are in exactly order as in 'runchtlist' so
that they can be inter-exchange with coupler.
