### PR TITLE
Fix to PI check, alter runmode3 to allow manual control over run steps

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,8 +3,8 @@
 CC=g++
 CFLAGS=-c -Wall -ansi -O2 -g -fPIC
 LIBS=-lnetcdf_c++ -lnetcdf -lboost_system -lboost_filesystem -lboost_program_options
-LIBDIR=-L/home/tobey/usr/local/lib
-INCLUDES=-I/home/tobey/usr/local/include
+LIBDIR=
+INCLUDES=
 SOURCES= 	src/TEM.o \
 		src/ArgHandler.o \
 		src/assembler/RunCohort.o \

--- a/src/assembler/Runner.cpp
+++ b/src/assembler/Runner.cpp
@@ -442,11 +442,12 @@ void Runner::runmode3(){
 	}
 
 	//loop through time-step
-	for (int icalyr=runcht.yrstart; icalyr<=runcht.yrend; icalyr++){
+/*	for (int icalyr=runcht.yrstart; icalyr<=runcht.yrend; icalyr++){
 		for (int im=0; im<12; im++) {
 			runSpatially(icalyr, im);
 		}
 	}
+*/
 };
 
 void Runner::runSpatially(const int icalyr, const int im) {

--- a/src/inc/physicalconst.h
+++ b/src/inc/physicalconst.h
@@ -18,7 +18,9 @@
 	const float LHSUB  = 2.8338e6 ; // latent heat of sublimation  J/kg
 	
 	const float G        = 9.80616 ;  //  acceleration of gravity m/s2
+#ifndef PI
 	const float PI       = 3.14159265358979; // pi -
+#endif
 	const float Pstd     = 101325 ; // standard pressure Pa
 	const float STFBOLTZ = 5.67e-8 ;// Stefan-Boltzmann constant W/m2K4
 	const float BOLTZ    = 1.38e-23 ; // Boltzmann constant J/Kmolecule


### PR DESCRIPTION
Added ifdef to check for PI (ALFRESCO and DVM use the same #define, so it just checks to see if previously defined for linking).

Also broke the month run for a single cell out so it can be controlled on month by month.

Finally removed specific used data from INCLUDES/LIBDIR, as it can be set on a per user basis.
