### PR TITLE
Add a special setup script folder and script for building/running on aeshna.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,8 +3,8 @@
 CC=g++
 CFLAGS=-c -Wall -ansi -O2 -g -fPIC
 LIBS=-lnetcdf_c++ -lnetcdf -lboost_system -lboost_filesystem -lboost_program_options
-LIBDIR=
-INCLUDES=
+LIBDIR=$(SITE_SPECIFIC_LIBS)
+INCLUDES=$(SITE_SPECIFIC_INCLUDES)
 SOURCES= 	src/TEM.o \
 		src/ArgHandler.o \
 		src/assembler/RunCohort.o \

--- a/env-setup-scripts/setup-env-for-aeshna.sh
+++ b/env-setup-scripts/setup-env-for-aeshna.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+# Set environment variables for working with dvm-dos-tem on aeshna.
+# NetCDF and Boost's Program Options are not available as system libraries on
+# aeshna. The user tobey has compiled these and made them available for others to use.
+# 
+# This script sets a couple environment variables to make that happen.
+# You can either source this script each time you logon to aeshna, before compiling and 
+# running, or you can add a line to your .bashrc or .bash_profile that will source this 
+# script each time you logon to the machine.
+
+# For compiling and linking
+export SITE_SPECIFIC_INCLUDES="-I/home/tobey/usr/local/include"
+export SITE_SPECIFIC_LIBS="-L/home/tobey/usr/local/lib"
+
+# For locating the boost libs at run time
+export LD_LIBRARY_PATH="/home/tobey/usr/local/lib"


### PR DESCRIPTION
Idea is that more site-specific setup options can be held in their
own scripts as people are able to compile and run the model on
different platforms.
