### PR TITLE
Changes the reload calparbgc feature of the calibration interface

### DIFF
--- a/src/CalController.cpp
+++ b/src/CalController.cpp
@@ -186,7 +186,16 @@ void CalController::reload_calparbgc_file() {
   std::string config_dir = this->cohort_ptr->chtlu.dir;
   this->cohort_ptr->chtlu.assignBgcCalpar(config_dir);
   BOOST_LOG_SEV(glg, note) << "Done reloading calparbgc file.";
-  
+
+  BOOST_LOG_SEV(glg, note) << "Next, make sure the veg parameters propogate?";
+  for (int i = 0; i < NUM_PFT; ++i) {
+    BOOST_LOG_SEV(glg, note) << "Assign the cohort's vegbgc params to those held in the chtlu object...";
+    this->cohort_ptr->vegbgc[i].initializeParameter();
+  }
+  BOOST_LOG_SEV(glg, note) << "Finally, make sure the soil parameters propogate?";
+  this->cohort_ptr->soilbgc.initializeParameter();
+
+
 }
 
 void CalController::quit() {

--- a/src/snowsoil/Soil_Bgc.cpp
+++ b/src/snowsoil/Soil_Bgc.cpp
@@ -239,7 +239,7 @@ void Soil_Bgc::initializeState5restart(RestartData* resin){
 };
 
 void Soil_Bgc::initializeParameter(){
-
+  BOOST_LOG_SEV(glg, note) << "Initializing parameters in Soil_Bgc from chtlu (CohortLookup) values.";
 	calpar.micbnup  = chtlu->micbnup;
 	calpar.kdcmoss  = chtlu->kdcmoss;
   	calpar.kdcrawc  = chtlu->kdcrawc;

--- a/src/vegetation/Vegetation_Bgc.cpp
+++ b/src/vegetation/Vegetation_Bgc.cpp
@@ -42,6 +42,7 @@ Vegetation_Bgc::~Vegetation_Bgc(){
 //Yuan: the parameterization and initialization is done for one PFT
 //set the bgc parameters from inputs
 void Vegetation_Bgc::initializeParameter(){
+  BOOST_LOG_SEV(glg, info) << "Initializing parameters in Vegetation_Bgc from chtlu (CohortLookup) values.";
 	
   	bgcpar.kc      = chtlu->kc[ipft];
   	bgcpar.ki      = chtlu->ki[ipft];


### PR DESCRIPTION
so that it 'propogates' the new parameters all the way to the
Cohort's internal data. Prior to this only the CohortLookup
was updated. This meant that the user could edit and reload
the cmt_calparbgc.txt file and successfully reload it, but
the changes would not necessarily be reflected in the simulation.
