### PR TITLE
Cal targets and configured suites

### DIFF
--- a/calibration/calibration_targets.py
+++ b/calibration/calibration_targets.py
@@ -5,7 +5,85 @@
 
 calibration_targets = {
   ## WARNING: JUNK, PLACEHOLDER VALUES! USE AT YOUR OWN RISK!
-  "deciduous": {
+  "BLANK": {
+    'cmtnumber': 0,
+                                 #    pft0     pft1      pft2      pft3     pft4     pft5     pft6     pft7     pft8    pft9   
+                                 #    Misc.    Misc.     Misc.     Misc.    Misc.    Misc.    Misc.    Misc.    Misc.   Misc.
+    'GPPAllIgnoringNitrogen':    [     0.0,     0.0,      0.0,      0.0,     0.0,     0.0,     0.0,     0.0,     0.0,    0.0 ], # ingpp     (gC/m2/year)   GPP without N limitation
+    'NPPAllIgnoringNitrogen':    [     0.0,     0.0,      0.0,      0.0,     0.0,     0.0,     0.0,     0.0,     0.0,    0.0 ], # innpp     (gC/m2/year)   NPP without N limitation 
+    'NPPAll':                    [     0.0,     0.0,      0.0,      0.0,     0.0,     0.0,     0.0,     0.0,     0.0,    0.0 ], # npp       (gC/m2/year)   NPP with N limitation
+    'Nuptake':                   [     0.0,     0.0,      0.0,      0.0,     0.0,     0.0,     0.0,     0.0,     0.0,    0.0 ], # nuptake   (gN/m2/year)
+    'VegCarbon': {
+      'Leaf':                    [     0.0,     0.0,      0.0,      0.0,     0.0,     0.0,     0.0,     0.0,     0.0,    0.0 ], # vegcl     (gC/m2)
+      'Stem':                    [     0.0,     0.0,      0.0,      0.0,     0.0,     0.0,     0.0,     0.0,     0.0,    0.0 ], # vegcw     (gC/m2)
+      'Root':                    [     0.0,     0.0,      0.0,      0.0,     0.0,     0.0,     0.0,     0.0,     0.0,    0.0 ], # vegcr     (gC/m2)
+    },
+    'VegStructuralNitrogen': {
+      'Leaf':                    [     0.0,     0.0,      0.0,      0.0,     0.0,     0.0,     0.0,     0.0,     0.0,    0.0 ], # vegnl     (gN/m2)
+      'Stem':                    [     0.0,     0.0,      0.0,      0.0,     0.0,     0.0,     0.0,     0.0,     0.0,    0.0 ], # vegnw     (gN/m2)
+      'Root':                    [     0.0,     0.0,      0.0,      0.0,     0.0,     0.0,     0.0,     0.0,     0.0,    0.0 ], # vegnr     (gN/m2)
+    },
+    'MossDeathC':                0.00,    #  dmossc
+    'CarbonShallow':             0.00,    #  shlwc
+    'CarbonDeep':                0.00,    #  deepc
+    'CarbonMineralSum':          0.00,    #  minec
+    'OrganicNitrogenSum':        0.00,    #  soln
+    'AvailableNitrogenSum':      0.00,    #  avln
+  },
+  ## WARNING: JUNK, PLACEHOLDER VALUES! USE AT YOUR OWN RISK!
+  "black spruce forest": {
+    'cmtnumber': 1,
+                                 #    pft0     pft1      pft2      pft3     pft4     pft5     pft6     pft7     pft8    pft9   
+                                 #  Spruce    Salix    Decid.   E.green   Sedges    Forbs  Grasses  Lichens  Feather.   Misc.
+    'GPPAllIgnoringNitrogen':    [  468.74,   81.73,    27.51,    22.23,   29.85,   28.44,   11.29,    7.75,   42.18,   0.00 ], # ingpp     (gC/m2/year)   GPP without N limitation
+    'NPPAllIgnoringNitrogen':    [  200.39,   61.30,    25.73,    20.79,   27.91,   26.59,   10.56,    7.25,   39.44,   0.00 ], # innpp     (gC/m2/year)   NPP without N limitation 
+    'NPPAll':                    [  133.59,   40.87,    13.76,    11.12,   14.92,   14.22,    5.65,    3.87,   21.09,   0.00 ], # npp       (gC/m2/year)   NPP with N limitation
+    'Nuptake':                   [    0.67,    0.42,     0.17,     0.17,    0.22,    0.21,    0.08,    0.01,    0.24,   0.00 ], # nuptake   (gN/m2/year)
+    'VegCarbon': {
+      'Leaf':                    [  121.92,   13.17,     8.85,     6.03,    5.60,    5.33,    2.12,   35.22,  100.35,   0.00 ], # vegcl     (gC/m2)
+      'Stem':                    [ 1519.45,  129.81,    76.07,    13.10,    0.00,    0.00,    0.00,    0.00,    0.00,   0.00 ], # vegcw     (gC/m2)
+      'Root':                    [  410.34,    4.00,     4.20,     1.17,    9.33,    8.89,    3.53,    0.00,    0.00,   0.00 ], # vegcr     (gC/m2)
+    },
+    'VegStructuralNitrogen': {
+      'Leaf':                    [    1.05,    0.53,     0.38,     0.15,    0.26,    0.25,    0.09,    0.99,    2.31,   0.00 ], # vegnl     (gN/m2)
+      'Stem':                    [    2.74,    3.05,     3.10,     0.23,    0.00,    0.00,    0.00,    0.00,    0.00,   0.00 ], # vegnw     (gN/m2)
+      'Root':                    [    3.52,    0.06,     0.06,     0.01,    0.19,    0.17,    0.07,    0.00,    0.00,   0.00 ], # vegnr     (gN/m2)
+    },
+    'MossDeathC':              178.00,    #  dmossc
+    'CarbonShallow':          1783.00,    #  shlwc
+    'CarbonDeep':             5021.00,    #  deepc
+    'CarbonMineralSum':       9000.00,    #  minec
+    'OrganicNitrogenSum':      363.00,    #  soln
+    'AvailableNitrogenSum':      0.76,    #  avln
+  },
+  ## WARNING: JUNK, PLACEHOLDER VALUES! USE AT YOUR OWN RISK!
+  "white spruce forest": {
+    'cmtnumber': 2,
+                                 #    pft0     pft1      pft2      pft3     pft4     pft5     pft6     pft7     pft8    pft9   
+                                 #  Spruce    Salix    Decid.   E.green   Sedges    Forbs  Grasses  Lichens  Feather.   Misc.
+    'GPPAllIgnoringNitrogen':    [  468.74,   81.73,    27.51,    22.23,   29.85,   28.44,   11.29,    7.75,   42.18,   0.00 ], # ingpp     (gC/m2/year)   GPP without N limitation
+    'NPPAllIgnoringNitrogen':    [  200.39,   61.30,    25.73,    20.79,   27.91,   26.59,   10.56,    7.25,   39.44,   0.00 ], # innpp     (gC/m2/year)   NPP without N limitation 
+    'NPPAll':                    [  133.59,   40.87,    13.76,    11.12,   14.92,   14.22,    5.65,    3.87,   21.09,   0.00 ], # npp       (gC/m2/year)   NPP with N limitation
+    'Nuptake':                   [    0.67,    0.42,     0.17,     0.17,    0.22,    0.21,    0.08,    0.01,    0.24,   0.00 ], # nuptake   (gN/m2/year)
+    'VegCarbon': {
+      'Leaf':                    [  121.92,   13.17,     8.85,     6.03,    5.60,    5.33,    2.12,   35.22,  100.35,   0.00 ], # vegcl     (gC/m2)
+      'Stem':                    [ 1519.45,  129.81,    76.07,    13.10,    0.00,    0.00,    0.00,    0.00,    0.00,   0.00 ], # vegcw     (gC/m2)
+      'Root':                    [  410.34,    4.00,     4.20,     1.17,    9.33,    8.89,    3.53,    0.00,    0.00,   0.00 ], # vegcr     (gC/m2)
+    },
+    'VegStructuralNitrogen': {
+      'Leaf':                    [    1.05,    0.53,     0.38,     0.15,    0.26,    0.25,    0.09,    0.99,    2.31,   0.00 ], # vegnl     (gN/m2)
+      'Stem':                    [    2.74,    3.05,     3.10,     0.23,    0.00,    0.00,    0.00,    0.00,    0.00,   0.00 ], # vegnw     (gN/m2)
+      'Root':                    [    3.52,    0.06,     0.06,     0.01,    0.19,    0.17,    0.07,    0.00,    0.00,   0.00 ], # vegnr     (gN/m2)
+    },
+    'MossDeathC':              178.00,    #  dmossc
+    'CarbonShallow':          1783.00,    #  shlwc
+    'CarbonDeep':             5021.00,    #  deepc
+    'CarbonMineralSum':       9000.00,    #  minec
+    'OrganicNitrogenSum':      363.00,    #  soln
+    'AvailableNitrogenSum':      0.76,    #  avln
+  },
+  ## WARNING: JUNK, PLACEHOLDER VALUES! USE AT YOUR OWN RISK!
+  "deciduous forest": {
     'cmtnumber': 3,
                                  #    pft0     pft1      pft2      pft3     pft4     pft5     pft6     pft7     pft8    pft9   
                                  #  Spruce    Salix    Decid.   E.green   Sedges    Forbs  Grasses  Lichens  Feather.   Misc.
@@ -31,8 +109,112 @@ calibration_targets = {
     'AvailableNitrogenSum':      0.76,    #  avln
   },
   ## WARNING: JUNK, PLACEHOLDER VALUES! USE AT YOUR OWN RISK!
-  "black spruce": {
-    'cmtnumber': 0,
+  "shrub tundra": {
+    'cmtnumber': 4,
+                                 #    pft0     pft1      pft2     pft3     pft4     pft5      pft6      pft7      pft8     pft9   
+                                 #  Spruce    Salix    Decid.  E.green   Sedges    Forbs   Grasses   Lichens   Feather.    Misc.
+    'GPPAllIgnoringNitrogen':    [  143.89,  288.65,   42.33,    9.03,    19.39,   28.44,    11.29,    16.45,     37.38,    0.00 ], # ingpp     (gC/m2/year)   GPP without N limitation
+    'NPPAllIgnoringNitrogen':    [  107.92,  216.49,   39.57,    8.44,    18.13,   26.59,    10.56,    15.38,     34.95,    0.00 ], # innpp     (gC/m2/year)   NPP without N limitation 
+    'NPPAll':                    [   71.95,  144.33,   21.16,    4.51,     9.69,   14.22,     5.65,     8.23,     18.69,    0.00 ], # npp       (gC/m2/year)   NPP with N limitation
+    'Nuptake':                   [    0.81,    1.55,    0.29,    0.06,     0.14,    0.21,     0.08,     0.01,      0.54,    0.00 ], # nuptake   (gN/m2/year)
+    'VegCarbon': {
+      'Leaf':                    [   23.85,    38.1,   14.85,    1.30,     3.64,    5.33,     2.12,     18.7,     89.00,    0.00 ], # vegcl     (gC/m2)
+      'Stem':                    [  194.07,  502.07,   30.67,    9.47,      0.0,     0.0,      0.0,      0.0,       0.0,     0.0 ], # vegcw     (gC/m2)
+      'Root':                    [    6.10,   38.35,    2.25,    0.66,     6.06,    8.89,     3.53,      0.0,       0.0,     0.0 ], # vegcr     (gC/m2)
+    },
+    'VegStructuralNitrogen': {
+      'Leaf':                    [    1.16,    1.84,    0.73,    0.03,     0.17,    0.25,     0.09,     0.67,      2.59,     0.0 ], # vegnl     (gN/m2)
+      'Stem':                    [    1.94,    5.73,    0.66,    0.18,      0.0,     0.0,      0.0,      0.0,       0.0,     0.0 ], # vegnw     (gN/m2)
+      'Root':                    [    0.08,    0.56,    0.04,    0.01,     0.12,    0.17,     0.07,      0.0,       0.0,     0.0 ], # vegnr     (gN/m2)
+    },
+    'MossDeathC':              178.00,    #  dmossc
+    'CarbonShallow':          6607.00,    #  shlwc
+    'CarbonDeep':            10529.00,    #  deepc
+    'CarbonMineralSum':      26758.00,    #  minec
+    'OrganicNitrogenSum':     8444.00,    #  soln
+    'AvailableNitrogenSum':      1.71,    #  avln
+  },
+  ## WARNING: JUNK, PLACEHOLDER VALUES! USE AT YOUR OWN RISK!
+  "tussock tundra": {
+    'cmtnumber': 5,
+                                 #    pft0     pft1      pft2      pft3     pft4     pft5     pft6     pft7     pft8    pft9   
+                                 #  Spruce    Salix    Decid.   E.green   Sedges    Forbs  Grasses  Lichens  Feather.   Misc.
+    'GPPAllIgnoringNitrogen':    [  468.74,   81.73,    27.51,    22.23,   29.85,   28.44,   11.29,    7.75,   42.18,   0.00 ], # ingpp     (gC/m2/year)   GPP without N limitation
+    'NPPAllIgnoringNitrogen':    [  200.39,   61.30,    25.73,    20.79,   27.91,   26.59,   10.56,    7.25,   39.44,   0.00 ], # innpp     (gC/m2/year)   NPP without N limitation 
+    'NPPAll':                    [  133.59,   40.87,    13.76,    11.12,   14.92,   14.22,    5.65,    3.87,   21.09,   0.00 ], # npp       (gC/m2/year)   NPP with N limitation
+    'Nuptake':                   [    0.67,    0.42,     0.17,     0.17,    0.22,    0.21,    0.08,    0.01,    0.24,   0.00 ], # nuptake   (gN/m2/year)
+    'VegCarbon': {
+      'Leaf':                    [  121.92,   13.17,     8.85,     6.03,    5.60,    5.33,    2.12,   35.22,  100.35,   0.00 ], # vegcl     (gC/m2)
+      'Stem':                    [ 1519.45,  129.81,    76.07,    13.10,    0.00,    0.00,    0.00,    0.00,    0.00,   0.00 ], # vegcw     (gC/m2)
+      'Root':                    [  410.34,    4.00,     4.20,     1.17,    9.33,    8.89,    3.53,    0.00,    0.00,   0.00 ], # vegcr     (gC/m2)
+    },
+    'VegStructuralNitrogen': {
+      'Leaf':                    [    1.05,    0.53,     0.38,     0.15,    0.26,    0.25,    0.09,    0.99,    2.31,   0.00 ], # vegnl     (gN/m2)
+      'Stem':                    [    2.74,    3.05,     3.10,     0.23,    0.00,    0.00,    0.00,    0.00,    0.00,   0.00 ], # vegnw     (gN/m2)
+      'Root':                    [    3.52,    0.06,     0.06,     0.01,    0.19,    0.17,    0.07,    0.00,    0.00,   0.00 ], # vegnr     (gN/m2)
+    },
+    'MossDeathC':              178.00,    #  dmossc
+    'CarbonShallow':          1783.00,    #  shlwc
+    'CarbonDeep':             5021.00,    #  deepc
+    'CarbonMineralSum':       9000.00,    #  minec
+    'OrganicNitrogenSum':      363.00,    #  soln
+    'AvailableNitrogenSum':      0.76,    #  avln
+  },
+  ## WARNING: JUNK, PLACEHOLDER VALUES! USE AT YOUR OWN RISK!
+  "wet sedge tundra": {
+    'cmtnumber': 6,
+                                 #    pft0     pft1      pft2      pft3     pft4     pft5     pft6     pft7     pft8    pft9   
+                                 #  Spruce    Salix    Decid.   E.green   Sedges    Forbs  Grasses  Lichens  Feather.   Misc.
+    'GPPAllIgnoringNitrogen':    [  468.74,   81.73,    27.51,    22.23,   29.85,   28.44,   11.29,    7.75,   42.18,   0.00 ], # ingpp     (gC/m2/year)   GPP without N limitation
+    'NPPAllIgnoringNitrogen':    [  200.39,   61.30,    25.73,    20.79,   27.91,   26.59,   10.56,    7.25,   39.44,   0.00 ], # innpp     (gC/m2/year)   NPP without N limitation 
+    'NPPAll':                    [  133.59,   40.87,    13.76,    11.12,   14.92,   14.22,    5.65,    3.87,   21.09,   0.00 ], # npp       (gC/m2/year)   NPP with N limitation
+    'Nuptake':                   [    0.67,    0.42,     0.17,     0.17,    0.22,    0.21,    0.08,    0.01,    0.24,   0.00 ], # nuptake   (gN/m2/year)
+    'VegCarbon': {
+      'Leaf':                    [  121.92,   13.17,     8.85,     6.03,    5.60,    5.33,    2.12,   35.22,  100.35,   0.00 ], # vegcl     (gC/m2)
+      'Stem':                    [ 1519.45,  129.81,    76.07,    13.10,    0.00,    0.00,    0.00,    0.00,    0.00,   0.00 ], # vegcw     (gC/m2)
+      'Root':                    [  410.34,    4.00,     4.20,     1.17,    9.33,    8.89,    3.53,    0.00,    0.00,   0.00 ], # vegcr     (gC/m2)
+    },
+    'VegStructuralNitrogen': {
+      'Leaf':                    [    1.05,    0.53,     0.38,     0.15,    0.26,    0.25,    0.09,    0.99,    2.31,   0.00 ], # vegnl     (gN/m2)
+      'Stem':                    [    2.74,    3.05,     3.10,     0.23,    0.00,    0.00,    0.00,    0.00,    0.00,   0.00 ], # vegnw     (gN/m2)
+      'Root':                    [    3.52,    0.06,     0.06,     0.01,    0.19,    0.17,    0.07,    0.00,    0.00,   0.00 ], # vegnr     (gN/m2)
+    },
+    'MossDeathC':              178.00,    #  dmossc
+    'CarbonShallow':          1783.00,    #  shlwc
+    'CarbonDeep':             5021.00,    #  deepc
+    'CarbonMineralSum':       9000.00,    #  minec
+    'OrganicNitrogenSum':      363.00,    #  soln
+    'AvailableNitrogenSum':      0.76,    #  avln
+  },
+  ## WARNING: JUNK, PLACEHOLDER VALUES! USE AT YOUR OWN RISK!
+  "heath tundra": {
+    'cmtnumber': 7,
+                                 #    pft0     pft1      pft2      pft3     pft4     pft5     pft6     pft7     pft8    pft9   
+                                 #  Spruce    Salix    Decid.   E.green   Sedges    Forbs  Grasses  Lichens  Feather.   Misc.
+    'GPPAllIgnoringNitrogen':    [  468.74,   81.73,    27.51,    22.23,   29.85,   28.44,   11.29,    7.75,   42.18,   0.00 ], # ingpp     (gC/m2/year)   GPP without N limitation
+    'NPPAllIgnoringNitrogen':    [  200.39,   61.30,    25.73,    20.79,   27.91,   26.59,   10.56,    7.25,   39.44,   0.00 ], # innpp     (gC/m2/year)   NPP without N limitation 
+    'NPPAll':                    [  133.59,   40.87,    13.76,    11.12,   14.92,   14.22,    5.65,    3.87,   21.09,   0.00 ], # npp       (gC/m2/year)   NPP with N limitation
+    'Nuptake':                   [    0.67,    0.42,     0.17,     0.17,    0.22,    0.21,    0.08,    0.01,    0.24,   0.00 ], # nuptake   (gN/m2/year)
+    'VegCarbon': {
+      'Leaf':                    [  121.92,   13.17,     8.85,     6.03,    5.60,    5.33,    2.12,   35.22,  100.35,   0.00 ], # vegcl     (gC/m2)
+      'Stem':                    [ 1519.45,  129.81,    76.07,    13.10,    0.00,    0.00,    0.00,    0.00,    0.00,   0.00 ], # vegcw     (gC/m2)
+      'Root':                    [  410.34,    4.00,     4.20,     1.17,    9.33,    8.89,    3.53,    0.00,    0.00,   0.00 ], # vegcr     (gC/m2)
+    },
+    'VegStructuralNitrogen': {
+      'Leaf':                    [    1.05,    0.53,     0.38,     0.15,    0.26,    0.25,    0.09,    0.99,    2.31,   0.00 ], # vegnl     (gN/m2)
+      'Stem':                    [    2.74,    3.05,     3.10,     0.23,    0.00,    0.00,    0.00,    0.00,    0.00,   0.00 ], # vegnw     (gN/m2)
+      'Root':                    [    3.52,    0.06,     0.06,     0.01,    0.19,    0.17,    0.07,    0.00,    0.00,   0.00 ], # vegnr     (gN/m2)
+    },
+    'MossDeathC':              178.00,    #  dmossc
+    'CarbonShallow':          1783.00,    #  shlwc
+    'CarbonDeep':             5021.00,    #  deepc
+    'CarbonMineralSum':       9000.00,    #  minec
+    'OrganicNitrogenSum':      363.00,    #  soln
+    'AvailableNitrogenSum':      0.76,    #  avln
+  },
+  ## WARNING: JUNK, PLACEHOLDER VALUES! USE AT YOUR OWN RISK!
+  "maritime forest": {
+    'cmtnumber': 8,
                                  #    pft0     pft1      pft2      pft3     pft4     pft5     pft6     pft7     pft8    pft9   
                                  #  Spruce    Salix    Decid.   E.green   Sedges    Forbs  Grasses  Lichens  Feather.   Misc.
     'GPPAllIgnoringNitrogen':    [  468.74,   81.73,    27.51,    22.23,   29.85,   28.44,   11.29,    7.75,   42.18,   0.00 ], # ingpp     (gC/m2/year)   GPP without N limitation

--- a/calibration/configured_suites.py
+++ b/calibration/configured_suites.py
@@ -4,7 +4,7 @@
 #
 ##########################################################################
 
-# A suite is an assembelage of variables to plot in one or more sub-plots
+# A suite is an assemblage of variables to plot in one or more sub-plots
 # along with some configuration and meta-data about the variables (i.e.
 # which variables to group in which sub-plots and what units/labels to use.
 
@@ -27,27 +27,46 @@
 #  }
 
 configured_suites = {
-  'standard': {
+  'Environment': {
     'desc': "The basic carbon plot blah blah, some pft vars",
     'rows': 5,
     'cols': 1,
     'traces': [
-      { 'jsontag': 'GPPAll', 'axesnum': 0, 'units': 'gC/m^2', 'pft': '', },
-      { 'jsontag': 'NPPAll', 'axesnum': 0, 'units': 'gC/m^2', 'pft': '', },
+      { 'jsontag': 'TempOrganicLayer', 'axesnum': 0, },
+      { 'jsontag': 'TempMineralLayer', 'axesnum': 0, },
+      { 'jsontag': 'TempAir', 'axesnum': 0, },
 
-      { 'jsontag': 'GPPAllIgnoringNitrogen', 'units': 'gC/m^2', 'axesnum': 1, 'pft': '', },
-      { 'jsontag': 'NPPAllIgnoringNitrogen', 'units': 'gC/m^2', 'axesnum': 1, 'pft': '', },
+      { 'jsontag': 'Snowfall', 'axesnum': 1, },
+      { 'jsontag': 'Rainfall', 'axesnum': 1, },
+      { 'jsontag': 'Evapotranspiration', 'axesnum': 1, },
 
-      { 'jsontag': 'PARAbsorb', 'axesnum': 2, 'units': 'percent', 'pft': '', },
-      { 'jsontag': 'PARDown', 'axesnum': 2, 'units': 'percent', 'pft': '', },
+      { 'jsontag': 'WaterTable', 'axesnum': 2, },
+      { 'jsontag': 'ActiveLayerDepth', 'axesnum': 2, },
 
-      { 'jsontag': 'LitterfallCarbonAll', 'axesnum': 3, 'units': 'gC/m^2', 'pft': '', },
-      { 'jsontag': 'LitterfallNitrogenAll', 'axesnum': 3, 'units': 'gC/m^2', 'pft': '', },
+      { 'jsontag': 'VWCOrganicLayer', 'axesnum': 3, },
+      { 'jsontag': 'VWCMineralLayer', 'axesnum': 3, },
 
-      { 'jsontag': 'WaterTable', 'axesnum': 4, 'units': 'percent', },
+      { 'jsontag': 'PARAbsorb', 'axesnum': 4, },
+      { 'jsontag': 'PARDown', 'axesnum': 4, },
     ]
   },
-  'vegetation':{
+  'Soil': {
+    'desc': "A set of carbon soil variables.",
+    'rows': 3,
+    'cols': 1,
+    'traces': [
+      { 'jsontag': 'CarbonShallow', 'axesnum': 0, },
+      { 'jsontag': 'CarbonDeep', 'axesnum': 0, },
+      { 'jsontag': 'CarbonMineralSum', 'axesnum': 0, },
+      { 'jsontag': 'MossdeathCarbon', 'axesnum': 0, },
+
+      { 'jsontag': 'OrganicNitrogenSum', 'axesnum':1, },
+
+      { 'jsontag': 'AvailableNitrogenSum', 'axesnum':2, },
+      { 'jsontag': 'NitrogenUptakeAll', 'axesnum':2, },
+    ]
+  },
+  'Vegetation':{
     'desc': "The standard targetted vegetation outputs",
     'rows': 5,
     'cols': 1,
@@ -68,36 +87,7 @@ configured_suites = {
       { 'jsontag': 'VegStructuralNitrogen', 'axesnum': 3, 'pft': '', 'pftpart': 'Root'},
 
       { 'jsontag': 'LitterfallNitrogenAll', 'axesnum': 4, 'units': 'gC/m^2', 'pft': '', },
-      { 'jsontag': 'NitrogenUptake', 'axesnum': 4, 'units': 'gC/m^2', 'pft': '', },
-    ]
-  },
-  's2': {
-    'desc': "A set of carbon soil variables.",
-    'rows': 2,
-    'cols': 1,
-    'traces': [
-      # BROKEN: in envmodule only warm up period!
-      # gotta figure out how to handle C++ > json > numpy nan issue.
-      # maybe set to null on encoder side?
-      { 'jsontag': 'CarbonShallow', 'axesnum': 0, },
-      { 'jsontag': 'CarbonDeep', 'axesnum': 0, },
-      { 'jsontag': 'CarbonMineralSum', 'axesnum': 0, },
-      { 'jsontag': 'MossdeathCarbon', 'axesnum': 1, },
-      { 'jsontag': 'MossdeathNitrogen', 'axesnum': 1, },
-    ]
-  },
-  's3': {
-    'desc': "Trying some pft compartment plots",
-    'rows': 2,
-    'cols': 1,
-    'traces': [
-      { 'jsontag': 'VegCarbon', 'axesnum': 0, 'pft': '', 'pftpart': 'Leaf'},
-      { 'jsontag': 'VegCarbon', 'axesnum': 0, 'pft': '', 'pftpart': 'Stem'},
-      { 'jsontag': 'VegCarbon', 'axesnum': 0, 'pft': '', 'pftpart': 'Root'},
-
-      { 'jsontag': 'VegStructuralNitrogen', 'axesnum': 1, 'pft': '', 'pftpart': 'Leaf'},
-      { 'jsontag': 'VegStructuralNitrogen', 'axesnum': 1, 'pft': '', 'pftpart': 'Stem'},
-      { 'jsontag': 'VegStructuralNitrogen', 'axesnum': 1, 'pft': '', 'pftpart': 'Root'},
-    ]
+      { 'jsontag': 'NitrogenUptake', 'axesnum': 4, 'units': 'gC/m^2', 'pft': '', }
+    ] 
   },
 }


### PR DESCRIPTION
Changed the configured suites to include three sets: Environment (ie temperature, water, light), Soil (organic and mineral C and N) and Vegetation (pools and fluxes by pft and compartment).  Also, setup the calibration targets to match the AIEM community structure.  
