### PR TITLE
Modify fri parms

### DIFF
--- a/src/runmodule/Grid.cpp
+++ b/src/runmodule/Grid.cpp
@@ -33,14 +33,14 @@ int Grid::reinit() {
   }
 
   //check for the validity of grid level data
-  if(gd.fri<0|| gd.fri>2000) {
-    gd.fri =2000;
+  if(gd.fri<0|| gd.fri>10000) {
+    gd.fri =10000;
   }
 
   //testing
-  gd.fri = 60;
-  gd.pfseason[1] = 0.80;
-  gd.pfsize[1] = 0.80;
+  //gd.fri = 60;
+  //gd.pfseason[1] = 0.80;
+  //gd.pfsize[1] = 0.80;
 
   if(gd.topsoil <0 || gd.botsoil <0) {
     return -2;


### PR DESCRIPTION
Fri, pfsize and pfseason were fixed to testing values in grid.cpp. This was commented out, so these values are now determined from the input netcdf files.  Also, the max fri is now set to 10000 years (instead of 2000).  This needs to be thought through a lot more before we start simulating wet sedge tundra fires.
