### PR TITLE
Plotting adjustment

### DIFF
--- a/calibration/ExpandingWindow.py
+++ b/calibration/ExpandingWindow.py
@@ -94,7 +94,7 @@ class ExpandingWindow(object):
 
     self.targets = targets
 
-    self.fig = plt.figure()
+    self.fig = plt.figure(figsize=(6*1.3,8*1.3))
     self.fig.suptitle(figtitle)
 
     # build a list of the pft specific traces

--- a/calibration/configured_suites.py
+++ b/calibration/configured_suites.py
@@ -91,4 +91,38 @@ configured_suites = {
       { 'jsontag': 'NitrogenUptake', 'axesnum': 4, 'units': 'gC/m^2', 'pft': '', }
     ] 
   },
+  'VegSoil':{
+    'desc': "The standard targetted vegetation outputs",
+    'rows': 8,
+    'cols': 1,
+    'traces': [
+      { 'jsontag': 'GPPAllIgnoringNitrogen', 'units': 'gC/m^2', 'axesnum': 0, 'pft': '', },
+      { 'jsontag': 'NPPAllIgnoringNitrogen', 'units': 'gC/m^2', 'axesnum': 0, 'pft': '', },
+
+      { 'jsontag': 'GPPAll', 'axesnum': 1, 'units': 'gC/m^2', 'pft': '', },
+      { 'jsontag': 'NPPAll', 'axesnum': 1, 'units': 'gC/m^2', 'pft': '', },
+
+      { 'jsontag': 'VegCarbon', 'axesnum': 2, 'units': 'gC/m^2', 'pft': '', 'pftpart': 'Leaf'},
+      { 'jsontag': 'VegCarbon', 'axesnum': 2, 'units': 'gC/m^2', 'pft': '', 'pftpart': 'Stem'},
+      { 'jsontag': 'VegCarbon', 'axesnum': 2, 'units': 'gC/m^2', 'pft': '', 'pftpart': 'Root'},
+      { 'jsontag': 'LitterfallCarbonAll', 'axesnum': 2, 'units': 'gC/m^2', 'pft': '', },
+
+      { 'jsontag': 'VegStructuralNitrogen', 'axesnum': 3, 'units': 'gN/m^2', 'pft': '', 'pftpart': 'Leaf'},
+      { 'jsontag': 'VegStructuralNitrogen', 'axesnum': 3, 'units': 'gN/m^2', 'pft': '', 'pftpart': 'Stem'},
+      { 'jsontag': 'VegStructuralNitrogen', 'axesnum': 3, 'units': 'gN/m^2', 'pft': '', 'pftpart': 'Root'},
+
+      { 'jsontag': 'LitterfallNitrogenAll', 'axesnum': 4, 'units': 'gN/m^2', 'pft': '', },
+      { 'jsontag': 'NitrogenUptake', 'axesnum': 4, 'units': 'gN/m^2', 'pft': '', },
+
+      { 'jsontag': 'CarbonShallow', 'axesnum': 5, 'units': 'gC/m^2', },
+      { 'jsontag': 'CarbonDeep', 'axesnum': 5, 'units': 'gC/m^2', },
+      { 'jsontag': 'CarbonMineralSum', 'axesnum': 5, 'units': 'gC/m^2', },
+      { 'jsontag': 'MossdeathCarbon', 'axesnum': 5, 'units': 'gC/m^2', },
+
+      { 'jsontag': 'OrganicNitrogenSum', 'axesnum':6, 'units': 'gN/m^2', },
+
+      { 'jsontag': 'AvailableNitrogenSum', 'axesnum':7, 'units': 'gN/m^2', },
+      { 'jsontag': 'NitrogenUptakeAll', 'axesnum':7, 'units': 'gN/m^2', },
+    ] 
+  },
 }


### PR DESCRIPTION
I added a new configured suite that has all of the variable we calibrate to in one window.  I had to adjust the size of the figure to accomodate the plots.  At this point, all of the figures, and all of the pfts we calibrate can be accomodated in one window, and we don't need to mess around with multiple windows.  However, shifting between pfts is still a little clunky.
