### PR TITLE
Fix comparison in Runner that prevented multi-site output from being wri...

### DIFF
--- a/config/controlfile_regn.txt
+++ b/config/controlfile_regn.txt
@@ -33,7 +33,7 @@
     "daily_output": 0,
     "monthly_output": 0,
     "yearly_output": 1,
-    "summarized_output": 0,
+    "summarized_output": 1,
     "soil_climate_output": 0
   }
 }

--- a/src/assembler/Runner.cpp
+++ b/src/assembler/Runner.cpp
@@ -144,13 +144,15 @@ void Runner::initOutput() {
       bgcfname = md.outputdir+"cmtbgc_yly"+stage+".nc";
       runcht.bgcylyouter.init(bgcfname); // set netcdf files for output
     }
-  } else if (md.runmode.compare("multi") && (!md.runeq)) {
+  } else if ( (md.runmode.compare("multi") == 0) && (!md.runeq) ) {
+    BOOST_LOG_SEV(glg, note) << "Outputting regional data! We are in multisite mode and NOT eq stage!";
     // output options (switches)
     md.outRegn      = true;
     md.outSiteYear  = false;
     md.outSiteDay   = false;
     md.outSiteMonth = false;
   } else {
+    BOOST_LOG_SEV(glg, err) << "What mode is this?? How did we get here??";
     md.outRegn=false;
     md.outSiteYear=false;
     md.outSiteDay=false;
@@ -158,6 +160,7 @@ void Runner::initOutput() {
   }
 
   // 2) summarized output by a list of variables
+  BOOST_LOG_SEV(glg, note) << "Output regional stuff (md.outRegn)?: " << md.outRegn;
   if (md.outRegn) {
     // varlist
     string outlistfile = "config/outvarlist.txt";


### PR DESCRIPTION
...tten.

Previously, this comparison would never pass, so despite setting
in the config file, there was no way to turn on the multi-site outputs

Now when using the regional control file and in sp or later mode, the
model will generate the DATA/test_06_cohorts/output/output-**.nc file,
which can be plotted with the 'plot_general_diagnostics.py' script from
here: https://github.com/tobeycarman/ddtv/blob/master/plot_general_diagnostics.py
