### PR TITLE
Adds a placeholder file to multi-site output directory.

### DIFF
--- a/DATA/test_06_cohorts/output/placeholder.txt
+++ b/DATA/test_06_cohorts/output/placeholder.txt
@@ -1,0 +1,2 @@
+Nothing. Simply here so git will keep the DATA/output/ directory around. 
+Without this directory, the program crashes with a cryptic seg fault.


### PR DESCRIPTION
Without this, a fresh clone of the model will seg falut
when run in multi-site because the output/ directory does
not exist. The placeholder makes sure that git will
keep the empty directory around, even though it is told
to ignore stuff in the output directory.

In the future we should just make the program smarter about
creating the directory if it doesn't exist.
