### PR TITLE
Shorten the defaults for MIN and MAX_EQ_YR, MAX_SP_YR.

### DIFF
--- a/src/inc/timeconst.h
+++ b/src/inc/timeconst.h
@@ -24,9 +24,9 @@ const int MAX_ATM_NOM_YR = 30;
 const int MAX_VEG_SET = 15; // maximum number of vegetation datasets
 
 //YUAN: moving the constants in Timer here
-const int MIN_EQ_YR = 2000; // minimum number of years for equilibrium run
-const int MAX_EQ_YR = 20000; // maximum number of years for equilibrium run
-const int MAX_SP_YR = 900; // maximum number of years of spinup run;
+const int MIN_EQ_YR = 200; // minimum number of years for equilibrium run
+const int MAX_EQ_YR = 2000; // maximum number of years for equilibrium run
+const int MAX_SP_YR = 300; // maximum number of years of spinup run;
 
 const int BEG_TR_YR = 1901;
 const int END_TR_YR = 2006;


### PR DESCRIPTION
This would make the default testing runs happen faster,
However the MAX_EQ_YR would need to be increased and the
program re-compiled for longer calibration sessions.
