### PR TITLE
Fix makefile defaults to work on fresh Fedora install

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 CC=g++
 CFLAGS=-c -Werror -ansi -g -fPIC -DBOOST_ALL_DYN_LINK
 LIBS=-lnetcdf_c++ -lnetcdf -lboost_system -lboost_filesystem \
--lboost_program_options -lboost_thread -lboost_log -ljson -lreadline
+-lboost_program_options -lboost_thread -lboost_log -ljsoncpp -lpthread -lreadline
 USEMPI = false
 
 ifeq ($(USEMPI),true)


### PR DESCRIPTION
Seems like the default library name for jsoncpp is "jsoncpp" instead of "json" which is nice. Also for some reason we have to link against pthread on Linux machines. These defaults are setup for a fresh Fedora install (as you might get using Vagrant).
