### PR TITLE
Address obvious omission in initialization routine.

### DIFF
--- a/src/lookup/CohortLookup.cpp
+++ b/src/lookup/CohortLookup.cpp
@@ -400,6 +400,7 @@ void CohortLookup::assignBgc4Ground(string &dircmt) {
   temutil::pfll2data(datalist, initshlwc);
   temutil::pfll2data(datalist, initdeepc);
   temutil::pfll2data(datalist, initminec);
+  temutil::pfll2data(datalist, initsoln);
   temutil::pfll2data(datalist, initavln);
 
 }


### PR DESCRIPTION
Issue discovered by looking at the calibration plots and
noticing that OrganicNitrogenSum was always zero, then
tracing with the debugger to see what happened to the initsoln
value from the parameter file (cmt_bgcsoil.txt).
