### PR TITLE
Adds initial LICENSE and CONTRIBUTORS files.

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -1,0 +1,23 @@
+This file contains a list of people who have contributed to the
+development of dvmdostem or the preceding versions, such as 
+dostem and dvmtem. Some dates are approximate, especially
+for the older timeframes.
+
+Currently active
+  Tobey Carman, dvmtem/dvmdostem, <tcarman2@alaska.edu>, 2011-2016
+  Helene Genet, dostem/dvmdostem, <hgenet@alaska.edu>, 2012-2016
+  Mark Lara, dostem/waterdostem, <mjlara@alaska.edu>, 2013-2016
+  Ruth Rutter, dvmdostem, <rarutter@alaska.edu>, 2014-2016
+
+
+Historical contributors
+  Jana Canary, dvmdostem, <jdcanary@alaska.edu>, 2015-2016
+  Eugenie Euskirchen, dvmtem, <>
+  Dave Kicklighter, tem, <>
+  Yanjiao Mi, peatland-dostem, <>, 2015
+  Dave McGuire, tem/dostem,  <>
+  Vijay Patil, dvmdostem, <>, ??-2015
+  Colin Tucker, dostem/dvmdostem, <>, ??-2015
+  Shuhua Yi, dvmdostem, <> 
+  Fengming Yuan, dvmdostem, <>
+

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,22 @@
+The MIT Expat License (MIT)
+
+Copyright (c) 2016 Spatial Ecology Lab, Tobey Carman, Ruth Rutter, Helene Genet (University of Alaska Fairbanks)
+Copyright (c) 2016 Marine Biological Lab (Woods Hole Oceanographic Institution)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to 
+deal in the Software without restriction, including without limitation the 
+right to use, copy, modify, merge, publish, distribute, sublicense, and/or 
+sell copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in 
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING 
+FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+IN THE SOFTWARE.


### PR DESCRIPTION
Note that the copyright year for Woods Hole is not quite correct,
as we don't know precisely which years they provided substantial
changes so applied the current year instead.

The CONTRIBUTORS file is only partially complete. Further information
will require contacting people to collect more names and approximate
years.
