### PR TITLE
Enhance cal viewer

### DIFF
--- a/calibration/calibration-viewer.py
+++ b/calibration/calibration-viewer.py
@@ -709,6 +709,9 @@ class ExpandingWindow(object):
     logging.info("Updated the pft number to %i" % n)
     self.plot_target_lines()
 
+    logging.info("Reload all the data to the plot...")
+    self.load_data2plot(relim=True, autoscale=True)
+
   def key_press_event(self, event):
     logging.debug("You pressed: %s. Cursor at x: %s y: %s" % (event.key, event.xdata, event.ydata))
 

--- a/calibration/calibration-viewer.py
+++ b/calibration/calibration-viewer.py
@@ -508,6 +508,21 @@ class ExpandingWindow(object):
         if line.get_label() == '__mscm':
           ax.lines.remove(line)
 
+    # ----- STAGE CHANGE MARKERS -------
+    stage_changes = [len(inhelper.files()) for inhelper in self.extra_input_helpers]
+    stage_changes.insert(0, len(self.input_helper.files()))
+
+    for ax in self.axes:
+      # clean up anything existing...
+      for line in ax.lines:
+        if line.get_label() == '__scm':
+          ax.lines.remove(line)
+
+      # Assumes that all the data in the archives is complete and consistent.
+      for idx in np.cumsum(stage_changes)[0:-1]:
+        logging.info("Adding stage change line at year %s" % idx)
+        ax.axvline(idx, label='__scm', linestyle='--', color="red", alpha=1.0)
+
     # Then loop over the dictionary and plot a vertical line wherever necessary.
     # The module stage dictionary could looks something like this:
     # { 12: ('DslModule', true), 54: ('DvmModule', false)}

--- a/calibration/calibration-viewer.py
+++ b/calibration/calibration-viewer.py
@@ -973,16 +973,16 @@ if __name__ == '__main__':
       help="print out configured suites")
 
 
-  group = parser.add_mutually_exclusive_group()
+  targetgroup = parser.add_mutually_exclusive_group()
 
-  group.add_argument('--tar-cmtname', default=None,
+  targetgroup.add_argument('--tar-cmtname', default=None,
       choices=calibration_targets.cmtnames(),
       metavar='',
       help=textwrap.dedent('''\
           "The name of the community type that should be used to display 
           target values lines.''')
   )
-  group.add_argument('--tar-cmtnum', default=None, type=int,
+  targetgroup.add_argument('--tar-cmtnum', default=None, type=int,
       choices=calibration_targets.cmtnumbers(),
       metavar='',
       help=textwrap.dedent('''\

--- a/calibration/calibration-viewer.py
+++ b/calibration/calibration-viewer.py
@@ -897,7 +897,7 @@ class ExpandingWindow(object):
       plt.savefig(full_name) # pdf may be smaller than png?
 
     if not self.no_show:
-      plt.show()
+      plt.show(block=True)
 
 
   def report_view_and_data_lims(self):

--- a/calibration/calibration-viewer.py
+++ b/calibration/calibration-viewer.py
@@ -25,6 +25,77 @@ import matplotlib.gridspec as gridspec
 
 import matplotlib.widgets
 
+# Keep the detailed documentation here. Can be accessed via command
+# line --extended-help flag.
+def generate_extened_help():
+  help_text = textwrap.dedent('''\
+  By default, the program tries to read json files from your /tmp
+  directory and plot the resulting data. 
+
+  When plotting dynamically the plot will expand to fit data that
+  it finds in the directory or archive. Unless using the 
+  '--no-show' flag, the plot will be displayed in an "interactive" 
+  window provided by which-ever matplotlib backend you are using.
+
+  The different "suites" of plots refer to differnt
+  assembelages of variables that you would like plotted.
+  There is a seperate config file for "suites" of plots.
+
+  There are also command line options for showing target
+  value lines on the plots. If you specify that target
+  value lines should be shown (by name or number), the 
+  program will 1) search thru the calibration_targets.py file
+  that is provided in this directory for the appropriate
+  values, and 2) if the suite you specify contains variables
+  that have associated targets, then there will be dashed line
+  on the plot showing the target value.
+
+  I expereienced some problems with the interactive window
+  provided by matplotloib. Especially with the Home, Back,
+  and Forward buttons. They have been disabled in the code.
+  If you run the program with a high enough log level you 
+  should be able to find messages to this extent whenever
+  the buttons are clicked. Unfortunately the work around at
+  this time is to kill the plotting program (Ctrl-C in the 
+  controlling terminal window that started it) and start  the
+  program over. It can be helpful to pause DVMDOSTEM while
+  you are doing this.
+
+  When using the program, if you change the zoom, or pan, 
+  the plot will stop updating, even as more json data becomes
+  available. To resume the updating, use "Ctrl-r" (on the 
+  plot window, not the controlling terminal).
+
+      Keyboard Shortcuts
+      ------------------
+      ctrl + r    reset view, resume auto-expand
+
+      ctrl + q    quit
+
+      ctrl + p    purge json files - deletes first 100 json
+                  files if more than 100 json files exist in
+                  the /tmp directorty
+
+      ctrl + j    change to fixed window plot - prompts for
+                  desired window size in controlling terminal
+      ctrl + J    reset to expanding window plot
+
+      alt + p     change the pft being plotted - prompts for 
+                  desired window size in controlling terminal
+                  (buggy)
+
+
+  The link below lists more keyboard shortcuts (provided by 
+  matplotlib) that allow for handy things like turning the grid 
+  on and off and switching between log and linear axes:
+
+      http://matplotlib.org/1.3.1/users/navigation_toolbar.html
+
+  I am sure we forgot to mention something?
+  ''' % ())
+
+  print help_text
+
 #
 # Disable some buttons on the default toobar that freeze the program.
 # There might be a better way to do this. Inspired from here:
@@ -802,73 +873,11 @@ if __name__ == '__main__':
           (2) Static plots created as dvmdostem is running or from an
               archived calibration run.
         '''),
-        
-      epilog=textwrap.dedent('''\
-        By default, the program tries to read json files from your /tmp
-        directory and plot the resulting data.
-        
-        When plotting dynamically the plot will expand to fit data that
-        it finds in the directory or archive. Unless using the 
-        '--no-show' flag, the plot will be displayed in an "interactive" 
-        window provided by which-ever matplotlib backend you are using.
+      epilog="" # moved content to extended help
+    )
 
-        The different "suites" of plots refer to differnt
-        assembelages of variables that you would like plotted.
-        There is a seperate config file for "suites" of plots.
-
-        There are also command line options for showing target
-        value lines on the plots. If you specify that target
-        value lines should be shown (by name or number), the 
-        program will 1) search thru the calibration_targets.py file
-        that is provided in this directory for the appropriate
-        values, and 2) if the suite you specify contains variables
-        that have associated targets, then there will be dashed line
-        on the plot showing the target value.
-
-        I expereienced some problems with the interactive window
-        provided by matplotloib. Especially with the Home, Back,
-        and Forward buttons. They have been disabled in the code.
-        If you run the program with a high enough log level you 
-        should be able to find messages to this extent whenever
-        the buttons are clicked. Unfortunately the work around at
-        this time is to kill the plotting program (Ctrl-C in the 
-        controlling terminal window that started it) and start  the
-        program over. It can be helpful to pause DVMDOSTEM while
-        you are doing this.
-
-        When using the program, if you change the zoom, or pan, 
-        the plot will stop updating, even as more json data becomes
-        available. To resume the updating, use "Ctrl-r" (on the 
-        plot window, not the controlling terminal).
-        
-            Keyboard Shortcuts
-            ------------------
-            ctrl + r    reset view, resume auto-expand
-
-            ctrl + q    quit
-
-            ctrl + p    purge json files - deletes first 100 json
-                        files if more than 100 json files exist in
-                        the /tmp directorty
-
-            ctrl + j    change to fixed window plot - prompts for
-                        desired window size in controlling terminal
-            ctrl + J    reset to expanding window plot
-
-            alt + p     change the pft being plotted - prompts for 
-                        desired window size in controlling terminal
-                        (buggy)
-
-
-        The link below lists more keyboard shortcuts (provided by 
-        matplotlib) that allow for handy things like turning the grid 
-        on and off and switching between log and linear axes:
-    
-            http://matplotlib.org/1.3.1/users/navigation_toolbar.html
-
-        I am sure we forgot to mention something?
-        ''' % ())
-      )
+  parser.add_argument('--extended-help', action='store_true',
+      help="Show a detailed description of the program.")
 
   parser.add_argument('--pft', default=0, type=int,
       choices=[0,1,2,3,4,5,6,7,8,9],
@@ -937,6 +946,12 @@ if __name__ == '__main__':
   print "Parsing command line arguments..."
   args = parser.parse_args()
   #print args
+
+  if args.extended_help:
+    parser.print_help()
+    print ""
+    print generate_extened_help()
+    sys.exit(0)
 
   #
   # Start operating based on the command line arguments....

--- a/calibration/calibration-viewer.py
+++ b/calibration/calibration-viewer.py
@@ -201,7 +201,6 @@ class InputHelper(object):
 
   def files(self):
     '''Returns a list of files, either in a directory or .tar.gz archive'''
-    logging.debug("Returning a sorted list of files paths from %s that match a '*.json' pattern glob." % self._path)
     return sorted( glob.glob('%s/*.json' % self._path) )
 
   def path(self):

--- a/calibration/calibration-viewer.py
+++ b/calibration/calibration-viewer.py
@@ -373,6 +373,9 @@ class ExpandingWindow(object):
     # gets a sorted list of json files...
     files = self.input_helper.files()
 
+    for inhelper in self.extra_input_helpers:
+      log.info("Loading data from extra input helpers...")
+      files += inhelper.files()
 
     self.input_helper.report()
     for inhelper in self.extra_input_helpers:
@@ -396,11 +399,13 @@ class ExpandingWindow(object):
     self.input_helper.coverage_report(files)
 
     # create an x range big enough for every possible file...
+    log.info("Creating x range of appropriate size...(%s)" % len(files))
     if len(files) == 0:
       x = np.arange(0)
     else:
       end = int( os.path.splitext( os.path.basename(files[-1]) )[0] )
-      x = np.arange(0, end + 1 , 1) # <-- make range inclusive!
+      #x = np.arange(0, end + 1 , 1) # <-- make range inclusive!
+      x = np.arange(0, len(files))
     
 
     # ----- READ FIRST FILE FOR TITLE ------
@@ -445,7 +450,8 @@ class ExpandingWindow(object):
         with open(file) as f:
           fdata = json.load(f)
 
-        idx = int(os.path.splitext( os.path.basename(file) )[0])
+        #idx = int(os.path.splitext( os.path.basename(file) )[0])
+        idx = fnum
 
         for trace in self.traces:
           # set the trace's tmpy[idx] to file's data
@@ -535,7 +541,9 @@ class ExpandingWindow(object):
     '''
     logging.info("Animation Frame %7i" % frame)
     
+    # gets a sorted list of json files...
     files = self.input_helper.files()
+
     self.input_helper.coverage_report(files)
 
     self.report_view_and_data_lims()

--- a/calibration/calibration-viewer.py
+++ b/calibration/calibration-viewer.py
@@ -168,7 +168,7 @@ class InputHelper(object):
     elif os.path.isfile(path):
       # Assume path is a .tar.gz (or other compression) with .json files in it
 
-      DEFAULT_EXTRACTED_ARCHIVE_LOCATION = '/tmp/extracted-calibration-archive'
+      DEFAULT_EXTRACTED_ARCHIVE_LOCATION = os.path.join('/tmp/extracted-calibration-archive', os.path.basename(path))
 
       logging.info("Extracting archive to '%s'..." %
           DEFAULT_EXTRACTED_ARCHIVE_LOCATION)

--- a/src/TEM.cpp
+++ b/src/TEM.cpp
@@ -320,6 +320,9 @@ int main(int argc, char* argv[]){
               if (runner.calcontroller_ptr && modeldata.inter_stage_pause){
                 runner.calcontroller_ptr->pause();
               }
+              if (runner.calcontroller_ptr) {
+                runner.calcontroller_ptr->clear_and_create_json_storage();
+              }
             }
           }
           if (modeldata.runsp) {
@@ -373,6 +376,10 @@ int main(int argc, char* argv[]){
 
                 if(runner.calcontroller_ptr && modeldata.inter_stage_pause){
                   runner.calcontroller_ptr->pause();
+                }
+
+                if (runner.calcontroller_ptr) {
+                  runner.calcontroller_ptr->clear_and_create_json_storage();
                 }
 
               }
@@ -430,6 +437,11 @@ int main(int argc, char* argv[]){
                 if(runner.calcontroller_ptr && modeldata.inter_stage_pause){
                   runner.calcontroller_ptr->pause();
                 }
+
+                if (runner.calcontroller_ptr) {
+                  runner.calcontroller_ptr->clear_and_create_json_storage();
+                }
+
 
               }
               else{ // No SP restart file

--- a/src/TEM.cpp
+++ b/src/TEM.cpp
@@ -301,7 +301,7 @@ int main(int argc, char* argv[]){
               // prior to running.
               std::string restart_fname = modeldata.output_dir + "restart-eq.nc";
               if(! boost::filesystem::exists(restart_fname)){
-                BOOST_LOG_SEV(glg, fatal) << "Restart file "<<restart_fname\
+                BOOST_LOG_SEV(glg, fatal) << "Restart file " << restart_fname
                                           << " does not exist";
                 return 1;
               }
@@ -376,7 +376,7 @@ int main(int argc, char* argv[]){
                 }
 
               }
-              else{ //No EQ restart file
+              else{ // No EQ restart file
                 BOOST_LOG_SEV(glg, err) << "No restart file from EQ.";
               }
 
@@ -432,7 +432,7 @@ int main(int argc, char* argv[]){
                 }
 
               }
-              else{ //No SP restart file
+              else{ // No SP restart file
                 BOOST_LOG_SEV(glg, fatal) << "No restart file from SP.";
               }
             }
@@ -468,7 +468,7 @@ int main(int argc, char* argv[]){
                 // and cd.
                 runner.cohort.set_state_from_restartdata();
 
-                //Loading projected data instead of historic. FIX?
+                // Loading projected data instead of historic. FIX?
                 runner.cohort.load_proj_climate(modeldata.proj_climate_file);
 
                 // Run model
@@ -487,7 +487,7 @@ int main(int argc, char* argv[]){
                 runner.cohort.restartdata.append_to_ncfile(restart_fname, rowidx, colidx);
 
               }
-              else{ //No TR restart file
+              else{ // No TR restart file
                 BOOST_LOG_SEV(glg, fatal) << "No restart file from TR.";
               }
 


### PR DESCRIPTION
adds ability too plot from a series of archives of json data so that you can see several stages on one plot.

Assume you changed the model's config file to specify `"run_stage":"eqsptrsc"`, and `"inter_stage_pause":true`, ran the model with this command:

    $ ./dvmdostem -l note -p 10 -m 20 -s 30 -t 25 -n 20 -c

And then at each inter-stage pause you ran these commands in succession:

    $ tar -cjf pr-data.tar.gz /tmp/dvmdostem
    $ tar -cjf eq-data.tar.gz /tmp/dvmdostem
    $ tar -cjf sp-data.tar.gz /tmp/dvmdostem
    $ tar -cjf tr-data.tar.gz /tmp/dvmdostem
    $ tar -cjf sc-data.tar.gz /tmp/dvmdostem

Then you could use the viewer to see these files like so:

    $ ./calibration/calibration-viewer.py --from-archive pr-data.tar.gz --archive-series 

<img width="750" alt="screen shot 2016-08-18 at 2 56 49 pm" src="https://cloud.githubusercontent.com/assets/838735/17793477/06a632d4-6554-11e6-8d0b-801f54a1d884.png">


