### PR TITLE
Fix json clear and create

### DIFF
--- a/src/TEM.cpp
+++ b/src/TEM.cpp
@@ -328,14 +328,13 @@ int main(int argc, char* argv[]){
           if (modeldata.runsp) {
             {
               BOOST_LOG_NAMED_SCOPE("SP");
-              BOOST_LOG_SEV(glg, fatal) << "Running Spinup, "<<modeldata.sp_yrs<<" years\n";
+              BOOST_LOG_SEV(glg, fatal) << "Running Spinup, " << modeldata.sp_yrs << " years.";
 
               // Check for the existence of a restart file to output to
               // prior to running.
-              std::string restart_fname = modeldata.output_dir \
-                                            + "restart-sp.nc";
+              std::string restart_fname = modeldata.output_dir + "restart-sp.nc";
               if(!boost::filesystem::exists(restart_fname)){
-                BOOST_LOG_SEV(glg, fatal) << "Restart file "<<restart_fname\
+                BOOST_LOG_SEV(glg, fatal) << "Restart file " << restart_fname
                                           << " does not exist";
                 return 1;
               }
@@ -344,8 +343,7 @@ int main(int argc, char* argv[]){
               // FIX: if restart file has -9999, then soil temps can end up impossibly low
               // look for and read in restart-eq.nc (if it exists)
               // should check for valid values prior to actual use
-              std::string eq_restart_fname = modeldata.output_dir \
-                                               + "restart-eq.nc";
+              std::string eq_restart_fname = modeldata.output_dir + "restart-eq.nc";
               if (boost::filesystem::exists(eq_restart_fname)) {
                 BOOST_LOG_SEV(glg, debug) << "Loading data from the restart file for spinup";
                 // update the cohort's restart data object

--- a/src/TEM.cpp
+++ b/src/TEM.cpp
@@ -277,13 +277,14 @@ int main(int argc, char* argv[]){
                                            << "data looks good.";
                   runner.calcontroller_ptr->pause();
                 }
-
-                runner.calcontroller_ptr->clear_and_create_json_storage();
               }
             }
-
             {
               BOOST_LOG_NAMED_SCOPE("EQ");
+
+              if (runner.calcontroller_ptr) {
+                runner.calcontroller_ptr->clear_and_create_json_storage();
+              }
 
               runner.cohort.md->set_envmodule(true);
               runner.cohort.md->set_dvmmodule(true);
@@ -320,15 +321,16 @@ int main(int argc, char* argv[]){
               if (runner.calcontroller_ptr && modeldata.inter_stage_pause){
                 runner.calcontroller_ptr->pause();
               }
-              if (runner.calcontroller_ptr) {
-                runner.calcontroller_ptr->clear_and_create_json_storage();
-              }
             }
           }
           if (modeldata.runsp) {
             {
               BOOST_LOG_NAMED_SCOPE("SP");
               BOOST_LOG_SEV(glg, fatal) << "Running Spinup, " << modeldata.sp_yrs << " years.";
+
+              if (runner.calcontroller_ptr) {
+                runner.calcontroller_ptr->clear_and_create_json_storage();
+              }
 
               // Check for the existence of a restart file to output to
               // prior to running.
@@ -375,11 +377,6 @@ int main(int argc, char* argv[]){
                 if(runner.calcontroller_ptr && modeldata.inter_stage_pause){
                   runner.calcontroller_ptr->pause();
                 }
-
-                if (runner.calcontroller_ptr) {
-                  runner.calcontroller_ptr->clear_and_create_json_storage();
-                }
-
               }
               else{ // No EQ restart file
                 BOOST_LOG_SEV(glg, err) << "No restart file from EQ.";
@@ -391,6 +388,10 @@ int main(int argc, char* argv[]){
             {
               BOOST_LOG_NAMED_SCOPE("TR");
               BOOST_LOG_SEV(glg, fatal) << "Running Transient, "<<modeldata.tr_yrs<<" years\n";
+
+              if (runner.calcontroller_ptr) {
+                runner.calcontroller_ptr->clear_and_create_json_storage();
+              }
 
               // Check for the existence of a restart file to output to
               // prior to running.
@@ -436,11 +437,6 @@ int main(int argc, char* argv[]){
                   runner.calcontroller_ptr->pause();
                 }
 
-                if (runner.calcontroller_ptr) {
-                  runner.calcontroller_ptr->clear_and_create_json_storage();
-                }
-
-
               }
               else{ // No SP restart file
                 BOOST_LOG_SEV(glg, fatal) << "No restart file from SP.";
@@ -451,6 +447,10 @@ int main(int argc, char* argv[]){
             {
               BOOST_LOG_NAMED_SCOPE("SC");
               BOOST_LOG_SEV(glg, fatal) << "Running Scenario, "<<modeldata.sc_yrs<<" years\n";
+
+              if (runner.calcontroller_ptr) {
+                runner.calcontroller_ptr->clear_and_create_json_storage();
+              }
 
               // Check for the existence of a restart file to output to
               // prior to running.


### PR DESCRIPTION
Moved json "clear and create" step from the end of each stage to the beginning of the stage. Tested this quickly by running all stages, with `inter_stage_pause=true` and making archives of the data at each stage, then plotting with the calibration-viewer.py. Seems to work.