### PR TITLE
General fixes

### DIFF
--- a/config/config.js
+++ b/config/config.js
@@ -50,9 +50,14 @@
   "stage_settings": {
     "restart_mode": "restart",   // other options??
     "inter_stage_pause": false,
-    "tr_yrs": 109,
-    "sc_yrs": 100
+
+    // maybe less confusing if these settings are only available from cmd line?
+    //"tr_yrs": 109,
+    //"sc_yrs": 100
+
+    // ??
     //"restartfile_dir": "DATA/Toolik_10x10_30yrs/" // location for restart-XX.nc file
+
   }
 
 //  "model_settings": {

--- a/config/config.js
+++ b/config/config.js
@@ -49,7 +49,7 @@
   },
   "stage_settings": {
     "restart_mode": "restart",   // other options??
-    "inter_stage_pause": false,
+    "inter_stage_pause": false
 
     // maybe less confusing if these settings are only available from cmd line?
     //"tr_yrs": 109,

--- a/config/config.js
+++ b/config/config.js
@@ -49,7 +49,6 @@
   },
   "stage_settings": {
     "restart_mode": "restart",   // other options??
-    "run_stage": "eq",
     "inter_stage_pause": false,
     "tr_yrs": 109,
     "sc_yrs": 100

--- a/include/ArgHandler.h
+++ b/include/ArgHandler.h
@@ -17,8 +17,8 @@ class ArgHandler {
 	boost::program_options::options_description desc;
 	boost::program_options::variables_map varmap;
 
-  int pre_run_yrs;
-  int max_eq;
+  int pr_yrs;
+  int eq_yrs;
   int sp_yrs;
   int tr_yrs;
   int sc_yrs;
@@ -31,6 +31,7 @@ class ArgHandler {
   bool floating_point_exp;
 
   std::string loop_order;
+
 	std::string ctrl_file;
 
   std::string log_level;
@@ -45,8 +46,8 @@ public:
 	void verify();
 	void show_help();
 
-  inline int get_pre_run_yrs() const {return pre_run_yrs;};
-  inline int get_max_eq() const {return max_eq;};
+  inline int get_pr_yrs() const {return pr_yrs;};
+  inline int get_eq_yrs() const {return eq_yrs;};
   inline int get_sp_yrs() const {return sp_yrs;};
   inline int get_tr_yrs() const {return tr_yrs;};
   inline int get_sc_yrs() const {return sc_yrs;};

--- a/include/ArgHandler.h
+++ b/include/ArgHandler.h
@@ -24,6 +24,8 @@ class ArgHandler {
   int sc_yrs;
 
   bool cal_mode;
+  int last_n_json_files;
+
   std::string pid_tag;
 
   bool floating_point_exp;
@@ -51,6 +53,8 @@ public:
   inline const bool get_fpe(){return floating_point_exp;};
 	
   inline const bool get_cal_mode(){return cal_mode;};
+  inline const int get_last_n_json_files() const {return last_n_json_files;};
+
   inline const std::string get_pid_tag() const {return pid_tag;};
   inline const std::string get_loop_order(){return loop_order;};
 	inline const std::string get_ctrl_file(){return ctrl_file;};

--- a/include/Runner.h
+++ b/include/Runner.h
@@ -76,5 +76,8 @@ private:
 
   deque<RestartData> mlyres;
 
+  void monthly_output(const int year, const int month, const std::string& runstage);
+  void yearly_output(const int year, const std::string& stage, const int startyr, const int endyr);
+
 };
 #endif /*RUNNER_H_*/

--- a/src/ArgHandler.cpp
+++ b/src/ArgHandler.cpp
@@ -36,25 +36,25 @@ void ArgHandler::parse(int argc, char** argv) {
       "PID tag so that the calibration-viewer.py knows where to find the json "
       "files.)")
 
-    ("pre-run-yrs,p", boost::program_options::value<int>(&pre_run_yrs)
+    ("pr-yrs,p", boost::program_options::value<int>(&pr_yrs)
        ->default_value(10),
-     "The number of 'pre-run' years.")
+     "Number or PRE RUN years to run.")
 
-    ("max-eq,m", boost::program_options::value<int>(&max_eq)
+    ("eq-yrs,e", boost::program_options::value<int>(&eq_yrs)
        ->default_value(1000),
-     "The maximum number of years to run in equlibrium stage.")
+     "Number of EQUILIBRIUM years to run.")
 
     ("sp-yrs,s", boost::program_options::value<int>(&sp_yrs)
        ->default_value(100),
-     "The number of spinup years.")
+     "Number of SPINUP years to run.")
 
     ("tr-yrs,t", boost::program_options::value<int>(&tr_yrs)
        ->default_value(0),
-     "The number of years to run transient. Overrides config for testing.")
+     "Number of TRANSIENT years to run.")
 
     ("sc-yrs,n", boost::program_options::value<int>(&sc_yrs)
        ->default_value(0),
-     "The number of years to run scenario. Overrides config for testing.")
+     "Number of SCENARIO years to run.")
 
     ("loop-order,o",
      boost::program_options::value<std::string>(&loop_order)

--- a/src/ArgHandler.cpp
+++ b/src/ArgHandler.cpp
@@ -19,6 +19,15 @@ void ArgHandler::parse(int argc, char** argv) {
      "program will generate yearly and monthly '.json' files in your /tmp "
      " directory that are intended to be read by other programs or scripts.")
 
+    ("last-n-json", boost::program_options::value<int>(&last_n_json_files)
+     ->default_value(-1),
+     "Only output the json files for the last N years. -1 indicates to output "
+     "all years. This is useful for running with PEST, where we do need the "
+     "json files (and calibration mode), but PEST only looks at the last year, "
+     "so we can save a lot of effort and only write out the last file. Made "
+     "this option configurable so that we can write out a number of files, in "
+     "case we need to do some averaging over the last few years for PEST.")
+
     ("pid-tag,u", boost::program_options::value<std::string>(&pid_tag)
       ->default_value(""),
       "Use the process ID (passed as an argmument) to tag the output cal json "

--- a/src/Runner.cpp
+++ b/src/Runner.cpp
@@ -96,24 +96,49 @@ void Runner::run_years(int start_year, int end_year, const std::string& stage) {
 
         this->cohort.updateMonthly(iy, im, DINM[im]);
 
-      if(this->calcontroller_ptr && md.output_monthly) {
-        BOOST_LOG_SEV(glg, debug) << "Write monthly calibration data to json files...";
-        this->output_caljson_monthly(iy, im, stage, this->calcontroller_ptr->monthly_json);
-      }
+        this->monthly_output(iy, im, stage);
 
       } // end month loop
     } // end named scope
 
-    if(this->calcontroller_ptr) { // check args->get_cal_mode() or calcontroller_ptr? ??
-      BOOST_LOG_SEV(glg, debug) << "Send yearly calibration data to json files...";
-      this->output_caljson_yearly(iy, stage, this->calcontroller_ptr->yearly_json);
-    }
+    this->yearly_output(iy, stage, start_year, end_year);
 
     BOOST_LOG_SEV(glg, note) << "(END OF YEAR) " << cohort.ground.layer_report_string("depth thermal CN ptr");
 
     BOOST_LOG_SEV(glg, note) << "Completed year " << iy << " for cohort/cell (row,col): (" << this->y << "," << this->x << ")";
 
   }} // end year loop (and named scope
+}
+
+void Runner::monthly_output(const int year, const int month, const std::string& runstage) {
+
+  if (md.output_monthly) {
+
+    // Calibration json files....
+    if(this->calcontroller_ptr) {
+      BOOST_LOG_SEV(glg, debug) << "Write monthly data to json files...";
+      this->output_caljson_monthly(year, month, runstage, this->calcontroller_ptr->monthly_json);
+    }
+
+    // NetCDF ???
+    BOOST_LOG_SEV(glg, debug) << "Stub locaiton for monthly NetCDF output?";
+
+  } else {
+    BOOST_LOG_SEV(glg, debug) << "Monthly output turned off in config settings.";
+  }
+
+
+}
+
+void Runner::yearly_output(const int year, const std::string& stage,
+    const int startyr, const int endyr) {
+
+  if(this->calcontroller_ptr) {
+      this->output_caljson_yearly(year, stage, this->calcontroller_ptr->yearly_json);
+  }
+
+  BOOST_LOG_SEV(glg, debug) << "Stub locaiton for yearly NetCDF output?";
+
 }
 
 void Runner::log_not_equal(const std::string& a_desc,

--- a/src/Runner.cpp
+++ b/src/Runner.cpp
@@ -91,26 +91,25 @@ void Runner::run_years(int start_year, int end_year, const std::string& stage) {
 
     /** MONTH TIMESTEP LOOP */
     BOOST_LOG_NAMED_SCOPE("M") {
-    for (int im = 0; im < 12; ++im) {
-      BOOST_LOG_SEV(glg, note) << "(Beginning of month loop, iy:"<<iy<<", im:"<<im<<") " << cohort.ground.layer_report_string("depth thermal CN desc");
+      for (int im = 0; im < 12; ++im) {
+        BOOST_LOG_SEV(glg, note) << "(Beginning of month loop, iy:"<<iy<<", im:"<<im<<") " << cohort.ground.layer_report_string("depth thermal CN desc");
 
-      this->cohort.updateMonthly(iy, im, DINM[im]);
+        this->cohort.updateMonthly(iy, im, DINM[im]);
 
-      // Monthly output control needs to be determined by a parameter
-      // or from the control file. It should default to false given
-      // the number of files it produces.
       if(this->calcontroller_ptr && md.output_monthly) {
         BOOST_LOG_SEV(glg, debug) << "Write monthly calibration data to json files...";
         this->output_caljson_monthly(iy, im, stage, this->calcontroller_ptr->monthly_json);
       }
-    }} // end month loop (and named scope)
 
-    BOOST_LOG_SEV(glg, note) << "(END OF YEAR) " << cohort.ground.layer_report_string("depth thermal CN ptr");
+      } // end month loop
+    } // end named scope
 
     if(this->calcontroller_ptr) { // check args->get_cal_mode() or calcontroller_ptr? ??
       BOOST_LOG_SEV(glg, debug) << "Send yearly calibration data to json files...";
       this->output_caljson_yearly(iy, stage, this->calcontroller_ptr->yearly_json);
     }
+
+    BOOST_LOG_SEV(glg, note) << "(END OF YEAR) " << cohort.ground.layer_report_string("depth thermal CN ptr");
 
     BOOST_LOG_SEV(glg, note) << "Completed year " << iy << " for cohort/cell (row,col): (" << this->y << "," << this->x << ")";
 

--- a/src/Runner.cpp
+++ b/src/Runner.cpp
@@ -121,7 +121,7 @@ void Runner::monthly_output(const int year, const int month, const std::string& 
     }
 
     // NetCDF ???
-    BOOST_LOG_SEV(glg, debug) << "Stub locaiton for monthly NetCDF output?";
+    BOOST_LOG_SEV(glg, debug) << "Stub location for monthly NetCDF output?";
 
   } else {
     BOOST_LOG_SEV(glg, debug) << "Monthly output turned off in config settings.";
@@ -134,10 +134,16 @@ void Runner::yearly_output(const int year, const std::string& stage,
     const int startyr, const int endyr) {
 
   if(this->calcontroller_ptr) {
+    if ( -1 == md.last_n_json_files ) {
       this->output_caljson_yearly(year, stage, this->calcontroller_ptr->yearly_json);
+    }
+
+    if ( year >= (endyr - md.last_n_json_files) ) {
+      this->output_caljson_yearly(year, stage, this->calcontroller_ptr->yearly_json);
+    }
   }
 
-  BOOST_LOG_SEV(glg, debug) << "Stub locaiton for yearly NetCDF output?";
+  BOOST_LOG_SEV(glg, debug) << "Stub loction for yearly NetCDF output?";
 
 }
 

--- a/src/TEM.cpp
+++ b/src/TEM.cpp
@@ -149,18 +149,17 @@ int main(int argc, char* argv[]){
 
   modeldata.update(args);
 
-  BOOST_LOG_SEV(glg, note) << "Running EQ stage: " << modeldata.runeq;
-  BOOST_LOG_SEV(glg, note) << "Running SP stage: " << modeldata.runsp;
-  BOOST_LOG_SEV(glg, note) << "Running TR stage: " << modeldata.runtr;
-  BOOST_LOG_SEV(glg, note) << "Running SC stage: " << modeldata.runsc;
-
-
   /*  
       Someday it may be worth the time/effort to make better use of
       boots::program_options here to manage the arguments from config file
       and the command line.
   */
   
+  BOOST_LOG_SEV(glg, note) << "Running PR stage: " << modeldata.pre_run_yrs << "yrs";
+  BOOST_LOG_SEV(glg, note) << "Running EQ stage: " << modeldata.max_eq_yrs << "yrs";
+  BOOST_LOG_SEV(glg, note) << "Running SP stage: " << modeldata.sp_yrs << "yrs";
+  BOOST_LOG_SEV(glg, note) << "Running TR stage: " << modeldata.tr_yrs << "yrs";
+  BOOST_LOG_SEV(glg, note) << "Running SC stage: " << modeldata.sc_yrs << "yrs";
 
   // Turn off buffering...
   setvbuf(stdout, NULL, _IONBF, 0);

--- a/src/TEM.cpp
+++ b/src/TEM.cpp
@@ -239,284 +239,284 @@ int main(int argc, char* argv[]){
           runner.cohort.initialize_state_parameters();  // sets data based on values in cohortlookup
           BOOST_LOG_SEV(glg, debug) << "right after initialize_internal_pointers() and initialize_state_parameters()"
                                     << runner.cohort.ground.layer_report_string("depth ptr");
+          // PRE RUN STAGE (PR)
+          if (modeldata.pre_run_yrs > 0) {
+            BOOST_LOG_NAMED_SCOPE("PRE-RUN");
+            /** Env-only "pre-run" stage.
+                 - should use only the env module
+                 - number of years to run can be controlled on cmd line
+                 - use fixed climate that is averaged over first X years
+                 - use static (fixed) co2 value (first element of co2 file)
+                 - FIX: need to set yrs since dsb ?
+                 - FIX: should ignore calibration directives?
+            */
 
-          if (modeldata.runeq) {
-            {
-              BOOST_LOG_NAMED_SCOPE("PRE-RUN");
-              /** Env-only "pre-run" stage.
-                   - should use only the env module
-                   - number of years to run can be controlled on cmd line
-                   - use fixed climate that is averaged over first X years
-                   - use static (fixed) co2 value (first element of co2 file)
-                   - FIX: need to set yrs since dsb ?
-                   - FIX: should ignore calibration directives?
-              */
+            // turn off everything but env
+            runner.cohort.md->set_envmodule(true);
+            runner.cohort.md->set_bgcmodule(false);
+            runner.cohort.md->set_nfeed(false);
+            runner.cohort.md->set_avlnflg(false);
+            runner.cohort.md->set_baseline(false);
+            runner.cohort.md->set_dsbmodule(false);
+            runner.cohort.md->set_dslmodule(false);
+            runner.cohort.md->set_dvmmodule(false);
 
-              // turn off everything but env
-              runner.cohort.md->set_envmodule(true);
-              runner.cohort.md->set_bgcmodule(false);
-              runner.cohort.md->set_nfeed(false);
-              runner.cohort.md->set_avlnflg(false);
-              runner.cohort.md->set_baseline(false);
-              runner.cohort.md->set_dsbmodule(false);
-              runner.cohort.md->set_dslmodule(false);
-              runner.cohort.md->set_dvmmodule(false);
+            BOOST_LOG_SEV(glg, debug) << "Ground, right before 'pre-run'. "
+                                      << runner.cohort.ground.layer_report_string("depth thermal");
 
-              BOOST_LOG_SEV(glg, debug) << "Ground, right before 'pre-run'. "
-                                        << runner.cohort.ground.layer_report_string("depth thermal");
+            runner.run_years(0, modeldata.pre_run_yrs, "pre-run"); // climate is prepared w/in here.
 
-              runner.run_years(0, modeldata.pre_run_yrs, "pre-run"); // climate is prepared w/in here.
+            BOOST_LOG_SEV(glg, debug) << "Ground, right after 'pre-run'"
+                                      << runner.cohort.ground.layer_report_string("depth thermal");
 
-              BOOST_LOG_SEV(glg, debug) << "Ground, right after 'pre-run'"
-                                        << runner.cohort.ground.layer_report_string("depth thermal");
+            if (runner.calcontroller_ptr) {
 
-              if (runner.calcontroller_ptr) {
-
-                if ( runner.calcontroller_ptr->post_warmup_pause() ){
-                  BOOST_LOG_SEV(glg, info) << "Pausing. Please check that the 'pre-run' "
-                                           << "data looks good.";
-                  runner.calcontroller_ptr->pause();
-                }
-              }
-            }
-            {
-              BOOST_LOG_NAMED_SCOPE("EQ");
-
-              if (runner.calcontroller_ptr) {
-                runner.calcontroller_ptr->clear_and_create_json_storage();
-              }
-
-              runner.cohort.md->set_envmodule(true);
-              runner.cohort.md->set_dvmmodule(true);
-              runner.cohort.md->set_bgcmodule(true);
-              runner.cohort.md->set_dslmodule(true);
-
-              runner.cohort.md->set_nfeed(true);
-              runner.cohort.md->set_avlnflg(true);
-              runner.cohort.md->set_baseline(true);
-
-              runner.cohort.md->set_dsbmodule(false);
-
-
-              // Check for the existence of a restart file to output to
-              // prior to running.
-              std::string restart_fname = modeldata.output_dir + "restart-eq.nc";
-              if(! boost::filesystem::exists(restart_fname)){
-                BOOST_LOG_SEV(glg, fatal) << "Restart file " << restart_fname
-                                          << " does not exist";
-                return 1;
-              }
-
-              runner.run_years(0, modeldata.max_eq_yrs, "eq-run");
-
-              runner.cohort.set_restartdata_from_state();
-
-              runner.cohort.restartdata.verify_logical_values();
-              BOOST_LOG_SEV(glg, debug) << "RestartData post EQ";
-              runner.cohort.restartdata.restartdata_to_log();
-
-              // Write out EQ restart file
-              runner.cohort.restartdata.append_to_ncfile(restart_fname, rowidx, colidx); /* cohort id/key ???*/
-
-              if(runner.calcontroller_ptr){
-                runner.calcontroller_ptr->archive_stage_JSON("eq");
-              }
-
-              if (runner.calcontroller_ptr && modeldata.inter_stage_pause){
+              if ( runner.calcontroller_ptr->post_warmup_pause() ){
+                BOOST_LOG_SEV(glg, info) << "Pausing. Please check that the 'pre-run' "
+                                         << "data looks good.";
                 runner.calcontroller_ptr->pause();
               }
             }
+
           }
-          if (modeldata.runsp) {
-            {
-              BOOST_LOG_NAMED_SCOPE("SP");
-              BOOST_LOG_SEV(glg, fatal) << "Running Spinup, " << modeldata.sp_yrs << " years.";
 
-              if (runner.calcontroller_ptr) {
-                runner.calcontroller_ptr->clear_and_create_json_storage();
+          // EQULIBRIUM STAGE (EQ)
+          if (modeldata.max_eq_yrs > 0) {
+
+            BOOST_LOG_NAMED_SCOPE("EQ");
+
+            if (runner.calcontroller_ptr) {
+              runner.calcontroller_ptr->clear_and_create_json_storage();
+            }
+
+            runner.cohort.md->set_envmodule(true);
+            runner.cohort.md->set_dvmmodule(true);
+            runner.cohort.md->set_bgcmodule(true);
+            runner.cohort.md->set_dslmodule(true);
+
+            runner.cohort.md->set_nfeed(true);
+            runner.cohort.md->set_avlnflg(true);
+            runner.cohort.md->set_baseline(true);
+
+            runner.cohort.md->set_dsbmodule(false);
+
+
+            // Check for the existence of a restart file to output to
+            // prior to running.
+            std::string restart_fname = modeldata.output_dir + "restart-eq.nc";
+            if(! boost::filesystem::exists(restart_fname)){
+              BOOST_LOG_SEV(glg, fatal) << "Restart file " << restart_fname
+                                        << " does not exist";
+              return 1;
+            }
+
+            runner.run_years(0, modeldata.max_eq_yrs, "eq-run");
+
+            runner.cohort.set_restartdata_from_state();
+
+            runner.cohort.restartdata.verify_logical_values();
+            BOOST_LOG_SEV(glg, debug) << "RestartData post EQ";
+            runner.cohort.restartdata.restartdata_to_log();
+
+            // Write out EQ restart file
+            runner.cohort.restartdata.append_to_ncfile(restart_fname, rowidx, colidx); /* cohort id/key ???*/
+
+            if(runner.calcontroller_ptr){
+              runner.calcontroller_ptr->archive_stage_JSON("eq");
+            }
+
+            if (runner.calcontroller_ptr && modeldata.inter_stage_pause){
+              runner.calcontroller_ptr->pause();
+            }
+          }
+
+          // SPINTUP STAGE (SP)
+          if (modeldata.sp_yrs > 0) {
+            BOOST_LOG_NAMED_SCOPE("SP");
+            BOOST_LOG_SEV(glg, fatal) << "Running Spinup, " << modeldata.sp_yrs << " years.";
+
+            if (runner.calcontroller_ptr) {
+              runner.calcontroller_ptr->clear_and_create_json_storage();
+            }
+
+            // Check for the existence of a restart file to output to
+            // prior to running.
+            std::string restart_fname = modeldata.output_dir + "restart-sp.nc";
+            if(!boost::filesystem::exists(restart_fname)){
+              BOOST_LOG_SEV(glg, fatal) << "Restart file " << restart_fname
+                                        << " does not exist";
+              return 1;
+            }
+
+            runner.cohort.climate.monthlycontainers2log();
+            // FIX: if restart file has -9999, then soil temps can end up impossibly low
+            // look for and read in restart-eq.nc (if it exists)
+            // should check for valid values prior to actual use
+            std::string eq_restart_fname = modeldata.output_dir + "restart-eq.nc";
+            if (boost::filesystem::exists(eq_restart_fname)) {
+              BOOST_LOG_SEV(glg, debug) << "Loading data from the restart file for spinup";
+              // update the cohort's restart data object
+              runner.cohort.restartdata.update_from_ncfile(eq_restart_fname, rowidx, colidx);
+              runner.cohort.restartdata.verify_logical_values();
+              // The above may be a bad idea. Separating reading
+              // and validation will confuse things when variables
+              // are added in the future - possibility for a disconnect.
+              BOOST_LOG_SEV(glg, debug) << "RestartData pre SP";
+              runner.cohort.restartdata.restartdata_to_log();
+
+              // copy values from the (updated) restart data to cohort
+              // and cd. this should overwrite some things that were
+              // previously just set in initialize_state_parameters(...)
+              runner.cohort.set_state_from_restartdata();
+
+              // run model
+              runner.run_years(0, modeldata.sp_yrs, "sp-run");
+
+              // Update restartdata structure from the running state
+              runner.cohort.set_restartdata_from_state();
+
+              BOOST_LOG_SEV(glg, debug) << "RestartData post SP";
+              runner.cohort.restartdata.restartdata_to_log();
+
+              // Save status to spinup restart file 
+              runner.cohort.restartdata.append_to_ncfile(restart_fname, rowidx, colidx);
+
+              if(runner.calcontroller_ptr){
+                runner.calcontroller_ptr->archive_stage_JSON("sp");
               }
 
-              // Check for the existence of a restart file to output to
-              // prior to running.
-              std::string restart_fname = modeldata.output_dir + "restart-sp.nc";
-              if(!boost::filesystem::exists(restart_fname)){
-                BOOST_LOG_SEV(glg, fatal) << "Restart file " << restart_fname
-                                          << " does not exist";
-                return 1;
+              if(runner.calcontroller_ptr && modeldata.inter_stage_pause){
+                runner.calcontroller_ptr->pause();
+              }
+            }
+            else{ // No EQ restart file
+              BOOST_LOG_SEV(glg, err) << "No restart file from EQ.";
+            }
+          }
+
+          // TRANSIENT STAGE (SP)
+          if (modeldata.tr_yrs > 0) {
+            BOOST_LOG_NAMED_SCOPE("TR");
+            BOOST_LOG_SEV(glg, fatal) << "Running Transient, "<<modeldata.tr_yrs<<" years\n";
+
+            if (runner.calcontroller_ptr) {
+              runner.calcontroller_ptr->clear_and_create_json_storage();
+            }
+
+            // Check for the existence of a restart file to output to
+            // prior to running.
+            std::string restart_fname = modeldata.output_dir \
+                                          + "restart-tr.nc";
+            if(!boost::filesystem::exists(restart_fname)){
+              BOOST_LOG_SEV(glg, fatal) << "Restart file "<<restart_fname\
+                                        << " does not exist.";
+              return 1;
+            }
+
+            std::string sp_restart_fname = modeldata.output_dir \
+                                             + "restart-sp.nc";
+
+            if(boost::filesystem::exists(sp_restart_fname)){
+              BOOST_LOG_SEV(glg, debug) << "Loading data from the restart file for transient";
+
+              // Update the cohort's restart data object
+              runner.cohort.restartdata.update_from_ncfile(sp_restart_fname, rowidx, colidx);
+
+              runner.cohort.restartdata.verify_logical_values();
+
+              BOOST_LOG_SEV(glg, debug) << "RestartData pre TR";
+              runner.cohort.restartdata.restartdata_to_log();
+
+              // Copy values from the updated restart data to cohort
+              // and cd.
+              runner.cohort.set_state_from_restartdata();
+
+              // Run model
+              runner.run_years(0, modeldata.tr_yrs, "tr-run");
+
+              // Update restartdata structure from the running state
+              runner.cohort.set_restartdata_from_state();
+
+              BOOST_LOG_SEV(glg, debug) << "RestartData post TR";
+              runner.cohort.restartdata.restartdata_to_log();
+
+              // Save status to transient restart file
+              runner.cohort.restartdata.append_to_ncfile(restart_fname, rowidx, colidx);
+
+              if(runner.calcontroller_ptr){
+                runner.calcontroller_ptr->archive_stage_JSON("tr");
               }
 
-              runner.cohort.climate.monthlycontainers2log();
-              // FIX: if restart file has -9999, then soil temps can end up impossibly low
-              // look for and read in restart-eq.nc (if it exists)
-              // should check for valid values prior to actual use
-              std::string eq_restart_fname = modeldata.output_dir + "restart-eq.nc";
-              if (boost::filesystem::exists(eq_restart_fname)) {
-                BOOST_LOG_SEV(glg, debug) << "Loading data from the restart file for spinup";
-                // update the cohort's restart data object
-                runner.cohort.restartdata.update_from_ncfile(eq_restart_fname, rowidx, colidx);
-                runner.cohort.restartdata.verify_logical_values();
-                // The above may be a bad idea. Separating reading
-                // and validation will confuse things when variables
-                // are added in the future - possibility for a disconnect.
-                BOOST_LOG_SEV(glg, debug) << "RestartData pre SP";
-                runner.cohort.restartdata.restartdata_to_log();
-
-                // copy values from the (updated) restart data to cohort
-                // and cd. this should overwrite some things that were
-                // previously just set in initialize_state_parameters(...)
-                runner.cohort.set_state_from_restartdata();
-
-                // run model
-                runner.run_years(0, modeldata.sp_yrs, "sp-run");
-
-                // Update restartdata structure from the running state
-                runner.cohort.set_restartdata_from_state();
-
-                BOOST_LOG_SEV(glg, debug) << "RestartData post SP";
-                runner.cohort.restartdata.restartdata_to_log();
-
-                // Save status to spinup restart file 
-                runner.cohort.restartdata.append_to_ncfile(restart_fname, rowidx, colidx);
-
-                if(runner.calcontroller_ptr){
-                  runner.calcontroller_ptr->archive_stage_JSON("sp");
-                }
-
-                if(runner.calcontroller_ptr && modeldata.inter_stage_pause){
-                  runner.calcontroller_ptr->pause();
-                }
-              }
-              else{ // No EQ restart file
-                BOOST_LOG_SEV(glg, err) << "No restart file from EQ.";
+              if(runner.calcontroller_ptr && modeldata.inter_stage_pause){
+                runner.calcontroller_ptr->pause();
               }
 
             }
-          }
-          if(modeldata.runtr){
-            {
-              BOOST_LOG_NAMED_SCOPE("TR");
-              BOOST_LOG_SEV(glg, fatal) << "Running Transient, "<<modeldata.tr_yrs<<" years\n";
-
-              if (runner.calcontroller_ptr) {
-                runner.calcontroller_ptr->clear_and_create_json_storage();
-              }
-
-              // Check for the existence of a restart file to output to
-              // prior to running.
-              std::string restart_fname = modeldata.output_dir \
-                                            + "restart-tr.nc";
-              if(!boost::filesystem::exists(restart_fname)){
-                BOOST_LOG_SEV(glg, fatal) << "Restart file "<<restart_fname\
-                                          << " does not exist.";
-                return 1;
-              }
-
-              std::string sp_restart_fname = modeldata.output_dir \
-                                               + "restart-sp.nc";
-
-              if(boost::filesystem::exists(sp_restart_fname)){
-                BOOST_LOG_SEV(glg, debug) << "Loading data from the restart file for transient";
-
-                // Update the cohort's restart data object
-                runner.cohort.restartdata.update_from_ncfile(sp_restart_fname, rowidx, colidx);
-
-                runner.cohort.restartdata.verify_logical_values();
-
-                BOOST_LOG_SEV(glg, debug) << "RestartData pre TR";
-                runner.cohort.restartdata.restartdata_to_log();
-
-                // Copy values from the updated restart data to cohort
-                // and cd.
-                runner.cohort.set_state_from_restartdata();
-
-                // Run model
-                runner.run_years(0, modeldata.tr_yrs, "tr-run");
-
-                // Update restartdata structure from the running state
-                runner.cohort.set_restartdata_from_state();
-
-                BOOST_LOG_SEV(glg, debug) << "RestartData post TR";
-                runner.cohort.restartdata.restartdata_to_log();
-
-                // Save status to transient restart file
-                runner.cohort.restartdata.append_to_ncfile(restart_fname, rowidx, colidx);
-
-                if(runner.calcontroller_ptr){
-                  runner.calcontroller_ptr->archive_stage_JSON("tr");
-                }
-
-                if(runner.calcontroller_ptr && modeldata.inter_stage_pause){
-                  runner.calcontroller_ptr->pause();
-                }
-
-              }
-              else{ // No SP restart file
-                BOOST_LOG_SEV(glg, fatal) << "No restart file from SP.";
-              }
+            else{ // No SP restart file
+              BOOST_LOG_SEV(glg, fatal) << "No restart file from SP.";
             }
           }
-          if(modeldata.runsc){
-            {
-              BOOST_LOG_NAMED_SCOPE("SC");
-              BOOST_LOG_SEV(glg, fatal) << "Running Scenario, "<<modeldata.sc_yrs<<" years\n";
 
-              if (runner.calcontroller_ptr) {
-                runner.calcontroller_ptr->clear_and_create_json_storage();
+          // SCENARIO STAGE (SC)
+          if (modeldata.sc_yrs > 0) {
+            BOOST_LOG_NAMED_SCOPE("SC");
+            BOOST_LOG_SEV(glg, fatal) << "Running Scenario, "<<modeldata.sc_yrs<<" years\n";
+
+            if (runner.calcontroller_ptr) {
+              runner.calcontroller_ptr->clear_and_create_json_storage();
+            }
+
+            // Check for the existence of a restart file to output to
+            // prior to running.
+            std::string restart_fname = modeldata.output_dir \
+                                          + "restart-sc.nc";
+            if(!boost::filesystem::exists(restart_fname)){
+              BOOST_LOG_SEV(glg, fatal) << "Restart file "<<restart_fname\
+                                        << " does not exist.";
+              return 1;
+            }
+
+            std::string tr_restart_fname = modeldata.output_dir \
+                                             + "restart-tr.nc";
+
+            if(boost::filesystem::exists(tr_restart_fname)){
+              BOOST_LOG_SEV(glg, debug) << "Loading data from the transient restart file for a scenario run";
+
+              // Update the cohort's restart data object
+              runner.cohort.restartdata.update_from_ncfile(tr_restart_fname, rowidx, colidx);
+
+              BOOST_LOG_SEV(glg, debug) << "RestartData pre SC";
+              runner.cohort.restartdata.restartdata_to_log();
+
+              // Copy values from the updated restart data to cohort
+              // and cd.
+              runner.cohort.set_state_from_restartdata();
+
+              // Loading projected data instead of historic. FIX?
+              runner.cohort.load_proj_climate(modeldata.proj_climate_file);
+
+              // Run model
+              runner.run_years(0, modeldata.sc_yrs, "sc-run");
+
+              // Update restartdata structure from the running state
+              runner.cohort.set_restartdata_from_state();
+
+              BOOST_LOG_SEV(glg, debug) << "RestartData post SC";
+              runner.cohort.restartdata.restartdata_to_log();
+
+              // Save status to scenario restart file
+              // This may be unnecessary, but will provide a possibly
+              // interesting snapshot of the data structure
+              // following a scenario run.
+              runner.cohort.restartdata.append_to_ncfile(restart_fname, rowidx, colidx);
+
+              if(runner.calcontroller_ptr){
+                runner.calcontroller_ptr->archive_stage_JSON("sc");
               }
 
-              // Check for the existence of a restart file to output to
-              // prior to running.
-              std::string restart_fname = modeldata.output_dir \
-                                            + "restart-sc.nc";
-              if(!boost::filesystem::exists(restart_fname)){
-                BOOST_LOG_SEV(glg, fatal) << "Restart file "<<restart_fname\
-                                          << " does not exist.";
-                return 1;
-              }
-
-              std::string tr_restart_fname = modeldata.output_dir \
-                                               + "restart-tr.nc";
-
-              if(boost::filesystem::exists(tr_restart_fname)){
-                BOOST_LOG_SEV(glg, debug) << "Loading data from the transient restart file for a scenario run";
-
-                // Update the cohort's restart data object
-                runner.cohort.restartdata.update_from_ncfile(tr_restart_fname, rowidx, colidx);
-
-                BOOST_LOG_SEV(glg, debug) << "RestartData pre SC";
-                runner.cohort.restartdata.restartdata_to_log();
-
-                // Copy values from the updated restart data to cohort
-                // and cd.
-                runner.cohort.set_state_from_restartdata();
-
-                // Loading projected data instead of historic. FIX?
-                runner.cohort.load_proj_climate(modeldata.proj_climate_file);
-
-                // Run model
-                runner.run_years(0, modeldata.sc_yrs, "sc-run");
-
-                // Update restartdata structure from the running state
-                runner.cohort.set_restartdata_from_state();
-
-                BOOST_LOG_SEV(glg, debug) << "RestartData post SC";
-                runner.cohort.restartdata.restartdata_to_log();
-
-                // Save status to scenario restart file
-                // This may be unnecessary, but will provide a possibly
-                // interesting snapshot of the data structure
-                // following a scenario run.
-                runner.cohort.restartdata.append_to_ncfile(restart_fname, rowidx, colidx);
-
-                if(runner.calcontroller_ptr){
-                  runner.calcontroller_ptr->archive_stage_JSON("sc");
-                }
-
-              }
-              else{ // No TR restart file
-                BOOST_LOG_SEV(glg, fatal) << "No restart file from TR.";
-              }
-
+            }
+            else{ // No TR restart file
+              BOOST_LOG_SEV(glg, fatal) << "No restart file from TR.";
             }
           }
 

--- a/src/TEM.cpp
+++ b/src/TEM.cpp
@@ -155,8 +155,8 @@ int main(int argc, char* argv[]){
       and the command line.
   */
   
-  BOOST_LOG_SEV(glg, note) << "Running PR stage: " << modeldata.pre_run_yrs << "yrs";
-  BOOST_LOG_SEV(glg, note) << "Running EQ stage: " << modeldata.max_eq_yrs << "yrs";
+  BOOST_LOG_SEV(glg, note) << "Running PR stage: " << modeldata.pr_yrs << "yrs";
+  BOOST_LOG_SEV(glg, note) << "Running EQ stage: " << modeldata.eq_yrs << "yrs";
   BOOST_LOG_SEV(glg, note) << "Running SP stage: " << modeldata.sp_yrs << "yrs";
   BOOST_LOG_SEV(glg, note) << "Running TR stage: " << modeldata.tr_yrs << "yrs";
   BOOST_LOG_SEV(glg, note) << "Running SC stage: " << modeldata.sc_yrs << "yrs";
@@ -239,7 +239,7 @@ int main(int argc, char* argv[]){
           BOOST_LOG_SEV(glg, debug) << "right after initialize_internal_pointers() and initialize_state_parameters()"
                                     << runner.cohort.ground.layer_report_string("depth ptr");
           // PRE RUN STAGE (PR)
-          if (modeldata.pre_run_yrs > 0) {
+          if (modeldata.pr_yrs > 0) {
             BOOST_LOG_NAMED_SCOPE("PRE-RUN");
             /** Env-only "pre-run" stage.
                  - should use only the env module
@@ -263,7 +263,7 @@ int main(int argc, char* argv[]){
             BOOST_LOG_SEV(glg, debug) << "Ground, right before 'pre-run'. "
                                       << runner.cohort.ground.layer_report_string("depth thermal");
 
-            runner.run_years(0, modeldata.pre_run_yrs, "pre-run"); // climate is prepared w/in here.
+            runner.run_years(0, modeldata.pr_yrs, "pre-run"); // climate is prepared w/in here.
 
             BOOST_LOG_SEV(glg, debug) << "Ground, right after 'pre-run'"
                                       << runner.cohort.ground.layer_report_string("depth thermal");
@@ -280,7 +280,7 @@ int main(int argc, char* argv[]){
           }
 
           // EQULIBRIUM STAGE (EQ)
-          if (modeldata.max_eq_yrs > 0) {
+          if (modeldata.eq_yrs > 0) {
 
             BOOST_LOG_NAMED_SCOPE("EQ");
 
@@ -309,7 +309,7 @@ int main(int argc, char* argv[]){
               return 1;
             }
 
-            runner.run_years(0, modeldata.max_eq_yrs, "eq-run");
+            runner.run_years(0, modeldata.eq_yrs, "eq-run");
 
             runner.cohort.set_restartdata_from_state();
 

--- a/src/runmodule/ModelData.cpp
+++ b/src/runmodule/ModelData.cpp
@@ -67,8 +67,8 @@ void ModelData::update(ArgHandler const * arghandler) {
 
   BOOST_LOG_SEV(glg, debug) << "Updating ModelData from an ArgHandler...";
 
-  this->pre_run_yrs = arghandler->get_pre_run_yrs();
-  this->max_eq_yrs = arghandler->get_max_eq();
+  this->pr_yrs = arghandler->get_pr_yrs();
+  this->eq_yrs = arghandler->get_eq_yrs();
   this->sp_yrs = arghandler->get_sp_yrs();
   this->tr_yrs = arghandler->get_tr_yrs();
   this->sc_yrs = arghandler->get_sc_yrs();

--- a/src/runmodule/ModelData.cpp
+++ b/src/runmodule/ModelData.cpp
@@ -31,10 +31,7 @@ ModelData::ModelData(Json::Value controldata){
   BOOST_LOG_SEV(glg, debug) << "Creating a ModelData. New style constructor with injected controldata...";
   
   std::string stgstr(controldata["stage_settings"]["run_stage"].asString());
-  runeq = (stgstr.find("eq") != std::string::npos) ? true : false;
-  runsp = (stgstr.find("sp") != std::string::npos) ? true : false;
-  runtr = (stgstr.find("tr") != std::string::npos) ? true : false;
-  runsc = (stgstr.find("sc") != std::string::npos) ? true : false;
+
   inter_stage_pause = controldata["stage_settings"]["inter_stage_pause"].asBool();
   initmode = controldata["stage_settings"]["restart"].asInt();  // may become obsolete
   tr_yrs        = controldata["stage_settings"]["tr_yrs"].asInt();
@@ -74,25 +71,12 @@ void ModelData::update(ArgHandler const * arghandler) {
   this->sp_yrs = arghandler->get_sp_yrs();
   this->tr_yrs = arghandler->get_tr_yrs();
   this->sc_yrs = arghandler->get_sc_yrs();
-
-  // maybe we don't even need the runeq, runsp, etc variables?
-  // might be some antiquated pattern from pre IO-refactor...
-  if (this->pre_run_yrs > 0) { /* ?? nothing... */}
-  if (this->max_eq_yrs > 0) {runeq = true;}
-  if (this->sp_yrs > 0) {runsp = true;}
-  if (this->tr_yrs > 0) {runtr = true;}
-  if (this->sc_yrs > 0) {runsc = true;}
-
   this->pid_tag = arghandler->get_pid_tag();
 
 }
 
 
 ModelData::ModelData() {
-  runeq = false;
-  runsp = false;
-  runtr = false;
-  runsc = false;
   set_envmodule(false);
   set_bgcmodule(false);
   set_dvmmodule(false);

--- a/src/runmodule/ModelData.cpp
+++ b/src/runmodule/ModelData.cpp
@@ -64,6 +64,7 @@ ModelData::ModelData(Json::Value controldata){
     Pass const * so that access to ArgHandler is read-only.
 */
 void ModelData::update(ArgHandler const * arghandler) {
+
   BOOST_LOG_SEV(glg, debug) << "Updating ModelData from an ArgHandler...";
 
   this->pre_run_yrs = arghandler->get_pre_run_yrs();
@@ -72,6 +73,7 @@ void ModelData::update(ArgHandler const * arghandler) {
   this->tr_yrs = arghandler->get_tr_yrs();
   this->sc_yrs = arghandler->get_sc_yrs();
   this->pid_tag = arghandler->get_pid_tag();
+  this->last_n_json_files = arghandler->get_last_n_json_files();
 
 }
 

--- a/src/runmodule/ModelData.h
+++ b/src/runmodule/ModelData.h
@@ -24,10 +24,6 @@ public:
 
   string loop_order; // time-major or space-major
 
-  bool runeq;
-  bool runsp;
-  bool runtr;
-  bool runsc;
   int initmode;
   bool inter_stage_pause; //Controls pauses between EQ, SP, TR, SC
 

--- a/src/runmodule/ModelData.h
+++ b/src/runmodule/ModelData.h
@@ -47,6 +47,7 @@ public:
 
   std::string pid_tag;
   std::string caldata_tree_loc;
+  int last_n_json_files;
 
   int changeclimate; // 0: default (up to run stage); 1: dynamical; -1: static
   int changeco2; // 0: default (up to run stage); 1: dynamical; -1: static

--- a/src/runmodule/ModelData.h
+++ b/src/runmodule/ModelData.h
@@ -27,8 +27,8 @@ public:
   int initmode;  // NOT USED?
   bool inter_stage_pause; //Controls pauses between EQ, SP, TR, SC
 
-  int max_eq_yrs;
-  int pre_run_yrs;
+  int eq_yrs;
+  int pr_yrs;
   int sp_yrs;
   int tr_yrs;
   int sc_yrs;

--- a/src/runmodule/ModelData.h
+++ b/src/runmodule/ModelData.h
@@ -24,7 +24,7 @@ public:
 
   string loop_order; // time-major or space-major
 
-  int initmode;
+  int initmode;  // NOT USED?
   bool inter_stage_pause; //Controls pauses between EQ, SP, TR, SC
 
   int max_eq_yrs;


### PR DESCRIPTION
Addresses several issues:
 
 * fixes #207 (standardize command line arguments)
 * cleans up the stage selection code
 * general comments, whitespace
 * adds option to only write out the last N json files. This is useful when running PEST, which only looks at the last file, so there is no need to write out 1000 years of json files; can save a lot of IO

This compiles and runs. I tested it in an integration branch for the last PEST run on Atlas.