### PR TITLE
Fix out of range error when trying to print zero length vector to csv.

### DIFF
--- a/src/TEMUtilityFunctions.h
+++ b/src/TEMUtilityFunctions.h
@@ -213,7 +213,9 @@ namespace temutil {
       s += boost::lexical_cast<std::string>(*it);
       s += ", ";
     }
-    s.erase(s.size()-2);
+    if (s.size() >= 2) {   // clear the trailing comma, space
+      s.erase(s.size()-2);
+    }
     return s;
   }
 


### PR DESCRIPTION
This is an isolated bugfix from Tobey's original branch for working on fire disturbance.