### PR TITLE
Improve stage transitions

### DIFF
--- a/scripts/create_region_input.py
+++ b/scripts/create_region_input.py
@@ -111,6 +111,14 @@ def create_template_restart_nc_file(filename, sizex=10, sizey=10):
   print "Creating an empty restart file: ", filename
   ncfile = netCDF4.Dataset(filename, mode='w', format='NETCDF4')
 
+  print textwrap.dedent('''\
+  %%%%%   NOTE   %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+  Please note, this functionality may no longer be necessary, as functions have
+  been added to the dvmdostem model that will allow it to create its own empty 
+  restart files.
+  %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+  ''')
+
   # Dimensions for the file.
   Y = ncfile.createDimension('Y', sizey)
   X = ncfile.createDimension('X', sizex)
@@ -164,7 +172,6 @@ def create_template_restart_nc_file(filename, sizex=10, sizey=10):
 
   for v in ['prvltrfcnA']:
     ncfile.createVariable(v, np.double, ('Y','X','prevtwelve','pft'))
-
 
   ncfile.close()
 
@@ -656,7 +663,7 @@ if __name__ == '__main__':
   )
   
   parser.add_argument('--crtf-only', action="store_true",
-                      help="Only create the restart template file.")
+                      help="Only create the restart template file. Deprecated in favor of the built in capability in dvmdostem.")
 
   parser.add_argument('--tifs', default="../../snap-data",
                       help="Directory containing input TIF directories.")

--- a/src/TEM.cpp
+++ b/src/TEM.cpp
@@ -185,17 +185,21 @@ int main(int argc, char* argv[]){
   // Open the run mask (spatial mask)
   std::vector< std::vector<int> > run_mask = read_run_mask(modeldata.runmask_file);
 
-  // Create empty restart files for all stages based on size of run mask
-  RestartData::create_empty_file(modeldata.output_dir + "restart-eq.nc", 10, 10);
-  RestartData::create_empty_file(modeldata.output_dir + "restart-sp.nc", 10, 10);
-  RestartData::create_empty_file(modeldata.output_dir + "restart-tr.nc", 10, 10);
-  RestartData::create_empty_file(modeldata.output_dir + "restart-sc.nc", 10, 10);
-
   // Make some convenient handles for later...
   std::string eq_restart_fname = modeldata.output_dir + "restart-eq.nc";
   std::string sp_restart_fname = modeldata.output_dir + "restart-sp.nc";
   std::string tr_restart_fname = modeldata.output_dir + "restart-tr.nc";
   std::string sc_restart_fname = modeldata.output_dir + "restart-sc.nc";
+
+  // Figure out how big the run_mask is
+  int num_rows = run_mask.size();
+  int num_cols = run_mask[0].size();
+
+  // Create empty restart files for all stages based on size of run mask
+  RestartData::create_empty_file(eq_restart_fname, num_rows, num_cols);
+  RestartData::create_empty_file(sp_restart_fname, num_rows, num_cols);
+  RestartData::create_empty_file(tr_restart_fname, num_rows, num_cols);
+  RestartData::create_empty_file(sc_restart_fname, num_rows, num_cols);
 
   if (args->get_loop_order() == "space-major") {
 

--- a/src/TEM.cpp
+++ b/src/TEM.cpp
@@ -334,7 +334,7 @@ int main(int argc, char* argv[]){
             runner.cohort.restartdata.restartdata_to_log();
 
             BOOST_LOG_SEV(glg, note) << "Writing RestartData to: " << eq_restart_fname;
-            runner.cohort.restartdata.append_to_ncfile(eq_restart_fname, rowidx, colidx);
+            runner.cohort.restartdata.write_pixel_to_ncfile(eq_restart_fname, rowidx, colidx);
 
             if (runner.calcontroller_ptr) {
               runner.calcontroller_ptr->handle_stage_end("eq");
@@ -379,7 +379,7 @@ int main(int argc, char* argv[]){
             runner.cohort.restartdata.restartdata_to_log();
 
             BOOST_LOG_SEV(glg, note) << "Writing RestartData out to: " << sp_restart_fname;
-            runner.cohort.restartdata.append_to_ncfile(sp_restart_fname, rowidx, colidx);
+            runner.cohort.restartdata.write_pixel_to_ncfile(sp_restart_fname, rowidx, colidx);
 
             if (runner.calcontroller_ptr) {
               runner.calcontroller_ptr->handle_stage_end("sp");
@@ -418,7 +418,7 @@ int main(int argc, char* argv[]){
             runner.cohort.restartdata.restartdata_to_log();
 
             BOOST_LOG_SEV(glg, note) << "Writing RestartData out to: " << tr_restart_fname;
-            runner.cohort.restartdata.append_to_ncfile(tr_restart_fname, rowidx, colidx);
+            runner.cohort.restartdata.write_pixel_to_ncfile(tr_restart_fname, rowidx, colidx);
 
             if (runner.calcontroller_ptr) {
               runner.calcontroller_ptr->handle_stage_end("tr");
@@ -458,7 +458,7 @@ int main(int argc, char* argv[]){
             runner.cohort.restartdata.restartdata_to_log();
 
             BOOST_LOG_SEV(glg, note) << "Writing RestartData out to: " << sc_restart_fname;
-            runner.cohort.restartdata.append_to_ncfile(sc_restart_fname, rowidx, colidx);
+            runner.cohort.restartdata.write_pixel_to_ncfile(sc_restart_fname, rowidx, colidx);
 
             if (runner.calcontroller_ptr) {
               runner.calcontroller_ptr->handle_stage_end("sc");

--- a/src/TEM.cpp
+++ b/src/TEM.cpp
@@ -67,6 +67,7 @@
 #include "TEMLogger.h"
 #include "TEMUtilityFunctions.h"
 #include "../include/Runner.h"
+#include "data/RestartData.h"
 
 #include <netcdf.h>
 
@@ -183,6 +184,18 @@ int main(int argc, char* argv[]){
 
   // Open the run mask (spatial mask)
   std::vector< std::vector<int> > run_mask = read_run_mask(modeldata.runmask_file);
+
+  // Create empty restart files for all stages based on size of run mask
+  RestartData::create_empty_file(modeldata.output_dir + "restart-eq.nc", 10, 10);
+  RestartData::create_empty_file(modeldata.output_dir + "restart-sp.nc", 10, 10);
+  RestartData::create_empty_file(modeldata.output_dir + "restart-tr.nc", 10, 10);
+  RestartData::create_empty_file(modeldata.output_dir + "restart-sc.nc", 10, 10);
+
+  // Make some convenient handles for later...
+  std::string eq_restart_fname = modeldata.output_dir + "restart-eq.nc";
+  std::string sp_restart_fname = modeldata.output_dir + "restart-sp.nc";
+  std::string tr_restart_fname = modeldata.output_dir + "restart-tr.nc";
+  std::string sc_restart_fname = modeldata.output_dir + "restart-sc.nc";
 
   if (args->get_loop_order() == "space-major") {
 
@@ -309,15 +322,6 @@ int main(int argc, char* argv[]){
             }
 
             // Run model
-            // Check for the existence of a restart file to output to
-            // prior to running.
-            std::string restart_fname = modeldata.output_dir + "restart-eq.nc";
-            if( !boost::filesystem::exists(restart_fname) ) {
-              BOOST_LOG_SEV(glg, fatal) << "Restart file " << restart_fname
-                                        << " does not exist";
-              return 1;
-            }
-
             runner.run_years(0, modeldata.eq_yrs, "eq-run");
 
             // Update restartdata structure from the running state
@@ -327,8 +331,8 @@ int main(int argc, char* argv[]){
             BOOST_LOG_SEV(glg, debug) << "RestartData post EQ";
             runner.cohort.restartdata.restartdata_to_log();
 
-            // Write out EQ restart file
-            runner.cohort.restartdata.append_to_ncfile(restart_fname, rowidx, colidx); /* cohort id/key ???*/
+            BOOST_LOG_SEV(glg, note) << "Writing RestartData to: " << eq_restart_fname;
+            runner.cohort.restartdata.append_to_ncfile(eq_restart_fname, rowidx, colidx);
 
             if (runner.calcontroller_ptr) {
               runner.calcontroller_ptr->handle_stage_end("eq");
@@ -345,55 +349,40 @@ int main(int argc, char* argv[]){
               runner.calcontroller_ptr->handle_stage_start();
             }
 
-            // Check for the existence of a restart file to output to
-            // prior to running.
-            std::string restart_fname = modeldata.output_dir + "restart-sp.nc";
-            if(!boost::filesystem::exists(restart_fname)){
-              BOOST_LOG_SEV(glg, fatal) << "Restart file " << restart_fname
-                                        << " does not exist";
-              return 1;
-            }
-
             runner.cohort.climate.monthlycontainers2log();
-            // FIX: if restart file has -9999, then soil temps can end up impossibly low
-            // look for and read in restart-eq.nc (if it exists)
-            // should check for valid values prior to actual use
-            std::string eq_restart_fname = modeldata.output_dir + "restart-eq.nc";
-            if (boost::filesystem::exists(eq_restart_fname)) {
-              BOOST_LOG_SEV(glg, debug) << "Loading data from the restart file for spinup";
-              // update the cohort's restart data object
-              runner.cohort.restartdata.update_from_ncfile(eq_restart_fname, rowidx, colidx);
-              runner.cohort.restartdata.verify_logical_values();
-              // The above may be a bad idea. Separating reading
-              // and validation will confuse things when variables
-              // are added in the future - possibility for a disconnect.
-              BOOST_LOG_SEV(glg, debug) << "RestartData pre SP";
-              runner.cohort.restartdata.restartdata_to_log();
 
-              // copy values from the (updated) restart data to cohort
-              // and cd. this should overwrite some things that were
-              // previously just set in initialize_state_parameters(...)
-              runner.cohort.set_state_from_restartdata();
+            BOOST_LOG_SEV(glg, debug) << "Loading RestartData from: " << eq_restart_fname;
+            runner.cohort.restartdata.update_from_ncfile(eq_restart_fname, rowidx, colidx);
 
-              // run model
-              runner.run_years(0, modeldata.sp_yrs, "sp-run");
+            // FIX: if restart file has -9999, then soil temps can end up
+            // impossibly low should check for valid values prior to actual use
 
-              // Update restartdata structure from the running state
-              runner.cohort.set_restartdata_from_state();
+            // Maybe a diffcult to maintain in the future
+            // when/if more variables are added?
+            runner.cohort.restartdata.verify_logical_values();
 
-              BOOST_LOG_SEV(glg, debug) << "RestartData post SP";
-              runner.cohort.restartdata.restartdata_to_log();
+            BOOST_LOG_SEV(glg, debug) << "RestartData pre SP";
+            runner.cohort.restartdata.restartdata_to_log();
 
-              // Save status to spinup restart file 
-              runner.cohort.restartdata.append_to_ncfile(restart_fname, rowidx, colidx);
+            // Copy values from the updated restart data to cohort and cd
+            runner.cohort.set_state_from_restartdata();
 
-              if(runner.calcontroller_ptr) {
-                runner.calcontroller_ptr->handle_stage_end("sp");
-              }
+            // Run model
+            runner.run_years(0, modeldata.sp_yrs, "sp-run");
 
-            } else {
-              BOOST_LOG_SEV(glg, err) << "No restart file from EQ.";
+            // Update restartdata structure from the running state
+            runner.cohort.set_restartdata_from_state();
+
+            BOOST_LOG_SEV(glg, debug) << "RestartData post SP";
+            runner.cohort.restartdata.restartdata_to_log();
+
+            BOOST_LOG_SEV(glg, note) << "Writing RestartData out to: " << sp_restart_fname;
+            runner.cohort.restartdata.append_to_ncfile(sp_restart_fname, rowidx, colidx);
+
+            if (runner.calcontroller_ptr) {
+              runner.calcontroller_ptr->handle_stage_end("sp");
             }
+
           }
 
           // TRANSIENT STAGE (TR)
@@ -405,51 +394,34 @@ int main(int argc, char* argv[]){
               runner.calcontroller_ptr->handle_stage_start();
             }
 
-            // Check for the existence of a restart file to output to
-            // prior to running.
-            std::string restart_fname = modeldata.output_dir + "restart-tr.nc";
-            if(!boost::filesystem::exists(restart_fname)){
-              BOOST_LOG_SEV(glg, fatal) << "Restart file " << restart_fname
-                                        << " does not exist.";
-              return 1;
+            // update the cohort's restart data object
+            BOOST_LOG_SEV(glg, debug) << "Loading RestartData from: " << sp_restart_fname;
+            runner.cohort.restartdata.update_from_ncfile(sp_restart_fname, rowidx, colidx);
+
+            runner.cohort.restartdata.verify_logical_values();
+
+            BOOST_LOG_SEV(glg, debug) << "RestartData pre TR";
+            runner.cohort.restartdata.restartdata_to_log();
+
+            // Copy values from the updated restart data to cohort and cd
+            runner.cohort.set_state_from_restartdata();
+
+            // Run model
+            runner.run_years(0, modeldata.tr_yrs, "tr-run");
+
+            // Update restartdata structure from the running state
+            runner.cohort.set_restartdata_from_state();
+
+            BOOST_LOG_SEV(glg, debug) << "RestartData post TR";
+            runner.cohort.restartdata.restartdata_to_log();
+
+            BOOST_LOG_SEV(glg, note) << "Writing RestartData out to: " << tr_restart_fname;
+            runner.cohort.restartdata.append_to_ncfile(tr_restart_fname, rowidx, colidx);
+
+            if (runner.calcontroller_ptr) {
+              runner.calcontroller_ptr->handle_stage_end("tr");
             }
 
-            std::string sp_restart_fname = modeldata.output_dir  + "restart-sp.nc";
-
-            if (boost::filesystem::exists(sp_restart_fname)) {
-              BOOST_LOG_SEV(glg, debug) << "Loading data from the restart file for transient";
-
-              // Update the cohort's restart data object
-              runner.cohort.restartdata.update_from_ncfile(sp_restart_fname, rowidx, colidx);
-
-              runner.cohort.restartdata.verify_logical_values();
-
-              BOOST_LOG_SEV(glg, debug) << "RestartData pre TR";
-              runner.cohort.restartdata.restartdata_to_log();
-
-              // Copy values from the updated restart data to cohort
-              // and cd.
-              runner.cohort.set_state_from_restartdata();
-
-              // Run model
-              runner.run_years(0, modeldata.tr_yrs, "tr-run");
-
-              // Update restartdata structure from the running state
-              runner.cohort.set_restartdata_from_state();
-
-              BOOST_LOG_SEV(glg, debug) << "RestartData post TR";
-              runner.cohort.restartdata.restartdata_to_log();
-
-              // Save status to transient restart file
-              runner.cohort.restartdata.append_to_ncfile(restart_fname, rowidx, colidx);
-
-              if (runner.calcontroller_ptr) {
-                runner.calcontroller_ptr->handle_stage_end("tr");
-              }
-
-            } else {
-              BOOST_LOG_SEV(glg, fatal) << "No restart file from SP.";
-            }
           }
 
           // SCENARIO STAGE (SC)
@@ -461,56 +433,35 @@ int main(int argc, char* argv[]){
               runner.calcontroller_ptr->handle_stage_start();
             }
 
-            // Check for the existence of a restart file to output to
-            // prior to running.
-            std::string restart_fname = modeldata.output_dir + "restart-sc.nc";
-            if (!boost::filesystem::exists(restart_fname)) {
-              BOOST_LOG_SEV(glg, fatal) << "Restart file " << restart_fname
-                                        << " does not exist.";
-              return 1;
+            // update the cohort's restart data object
+            BOOST_LOG_SEV(glg, debug) << "Loading RestartData from: " << tr_restart_fname;
+            runner.cohort.restartdata.update_from_ncfile(tr_restart_fname, rowidx, colidx);
+
+            BOOST_LOG_SEV(glg, debug) << "RestartData pre SC";
+            runner.cohort.restartdata.restartdata_to_log();
+
+            // Copy values from the updated restart data to cohort and cd
+            runner.cohort.set_state_from_restartdata();
+
+            // Loading projected data instead of historic. FIX?
+            runner.cohort.load_proj_climate(modeldata.proj_climate_file);
+
+            // Run model
+            runner.run_years(0, modeldata.sc_yrs, "sc-run");
+
+            // Update restartdata structure from the running state
+            runner.cohort.set_restartdata_from_state();
+
+            BOOST_LOG_SEV(glg, debug) << "RestartData post SC";
+            runner.cohort.restartdata.restartdata_to_log();
+
+            BOOST_LOG_SEV(glg, note) << "Writing RestartData out to: " << sc_restart_fname;
+            runner.cohort.restartdata.append_to_ncfile(sc_restart_fname, rowidx, colidx);
+
+            if (runner.calcontroller_ptr) {
+              runner.calcontroller_ptr->handle_stage_end("sc");
             }
 
-            std::string tr_restart_fname = modeldata.output_dir
-                                             + "restart-tr.nc";
-
-            if (boost::filesystem::exists(tr_restart_fname)) {
-              BOOST_LOG_SEV(glg, debug) << "Loading data from the transient restart file for a scenario run";
-
-              // Update the cohort's restart data object
-              runner.cohort.restartdata.update_from_ncfile(tr_restart_fname, rowidx, colidx);
-
-              BOOST_LOG_SEV(glg, debug) << "RestartData pre SC";
-              runner.cohort.restartdata.restartdata_to_log();
-
-              // Copy values from the updated restart data to cohort
-              // and cd.
-              runner.cohort.set_state_from_restartdata();
-
-              // Loading projected data instead of historic. FIX?
-              runner.cohort.load_proj_climate(modeldata.proj_climate_file);
-
-              // Run model
-              runner.run_years(0, modeldata.sc_yrs, "sc-run");
-
-              // Update restartdata structure from the running state
-              runner.cohort.set_restartdata_from_state();
-
-              BOOST_LOG_SEV(glg, debug) << "RestartData post SC";
-              runner.cohort.restartdata.restartdata_to_log();
-
-              // Save status to scenario restart file
-              // This may be unnecessary, but will provide a possibly
-              // interesting snapshot of the data structure
-              // following a scenario run.
-              runner.cohort.restartdata.append_to_ncfile(restart_fname, rowidx, colidx);
-
-              if (runner.calcontroller_ptr) {
-                runner.calcontroller_ptr->handle_stage_end("sc");
-              }
-
-            } else { // No TR restart file
-              BOOST_LOG_SEV(glg, fatal) << "No restart file from TR.";
-            }
           }
 
           // NOTE: Could have an option to set some time constants based on

--- a/src/TEM.cpp
+++ b/src/TEM.cpp
@@ -202,17 +202,15 @@ int main(int argc, char* argv[]){
     // y <==> row <==> lat
     // x <==> col <==> lon
 
-    /* 
-       Loop over a 2D grid of 'cells' (cohorts?),
-       run each cell for some number of years. 
-       
-       Processing starts in the lower left corner (0,0).
-       Should really look into replacing this loop with 
-       something like python's map(...) function...
-        --> Could this allow us to use a map reduce strategy??
-     
-       Look into std::transform. 
-    */
+    // Loop over a 2D grid of 'cells' (cohorts?),
+    // run each cell for some number of years. 
+    //
+    // Processing starts in the lower left corner (0,0).
+    // Should really look into replacing this loop with 
+    // something like python's map(...) function...
+    // --> Could this allow us to use a map reduce strategy??
+    //
+    // Look into std::transform.
 
     // Use a few type definitions to save some typing.
     typedef std::vector<int> vec;
@@ -502,7 +500,7 @@ int main(int argc, char* argv[]){
     }
   
     
-  } else if(args->get_loop_order() == "time-major") {
+  } else if (args->get_loop_order() == "time-major") {
     BOOST_LOG_SEV(glg, warn) << "DO NOTHING. NOT IMPLEMENTED YET.";
     // for each year
 

--- a/src/data/RestartData.cpp
+++ b/src/data/RestartData.cpp
@@ -415,7 +415,7 @@ void RestartData::update_from_ncfile(const std::string& fname, const int rowidx,
 }
 
 /** Copies values from this RestartData object to a NetCDF file. */
-void RestartData::append_to_ncfile(const std::string& fname, const int rowidx, const int colidx) {
+void RestartData::write_pixel_to_ncfile(const std::string& fname, const int rowidx, const int colidx) {
 
   BOOST_LOG_SEV(glg, debug) << "Opening dataset: " << fname
                             << " to WRITE RestartData for pixel (y, x): ("

--- a/src/data/RestartData.cpp
+++ b/src/data/RestartData.cpp
@@ -913,6 +913,268 @@ void RestartData::read_px_prev_pft_vars(const std::string& fname, const int rowi
 
 }
 
+/** Creates (overwrites) an empty restart file. */
+void RestartData::create_empty_file(const std::string& fname,
+    const int ysize, const int xsize) {
+
+  BOOST_LOG_SEV(glg, debug) << "Opening new file with 'NC_CLOBBER'";
+  int ncid;
+  temutil::nc( nc_create(fname.c_str(), NC_CLOBBER, &ncid) );
+
+  //int old_fill_mode;
+  //temutil::nc( nc_set_fill(ncid, NC_NOFILL, &old_fill_mode) );
+  //BOOST_LOG_SEV(glg, debug) << "The old fill mode was: " << old_fill_mode;
+
+  // Define handles for dimensions
+  int yD;
+  int xD;
+  int pftD;
+  int pftpartD;
+  int snowlayerD;
+  int rootlayerD;
+  int soillayerD;
+  int rocklayerD;
+  int frontsD;
+  int prevtenD;
+  int prevtwelveD;
+
+  BOOST_LOG_SEV(glg, debug) << "Creating dimensions...";
+  temutil::nc( nc_def_dim(ncid, "Y", ysize, &yD) );
+  temutil::nc( nc_def_dim(ncid, "X", xsize, &xD) );
+  temutil::nc( nc_def_dim(ncid, "pft", 10, &pftD) );
+  temutil::nc( nc_def_dim(ncid, "pftpart", 3, &pftpartD) );
+  temutil::nc( nc_def_dim(ncid, "snowlayer", 6, &snowlayerD) );
+  temutil::nc( nc_def_dim(ncid, "rootlayer", 10, &rootlayerD) );
+  temutil::nc( nc_def_dim(ncid, "soillayer", 23, &soillayerD) );
+  temutil::nc( nc_def_dim(ncid, "rocklayer", 5, &rocklayerD) );
+  temutil::nc( nc_def_dim(ncid, "fronts", 10, &frontsD) );
+  temutil::nc( nc_def_dim(ncid, "prevten", 10, &prevtenD) );
+  temutil::nc( nc_def_dim(ncid, "prevtwelve", 12, &prevtwelveD) );
+
+
+  // Setup arrays holding dimids for different "types" of variables
+  // --> will re-arrange these later to define variables with different dims
+  int vartype2D_dimids[2];
+  vartype2D_dimids[0] = yD;
+  vartype2D_dimids[1] = xD;
+
+  int vartype3D_dimids[3];
+  vartype3D_dimids[0] = yD;
+  vartype3D_dimids[1] = xD;
+  vartype3D_dimids[2] = pftD;
+
+  int vartype4D_dimids[4];
+  vartype4D_dimids[0] = yD;
+  vartype4D_dimids[1] = xD;
+  vartype4D_dimids[2] = pftpartD;
+  vartype4D_dimids[3] = pftD;
+
+  // Setup 2D vars, integer
+  int dsrV;
+  int numslV;
+  int numsnwlV;
+  int rtfrozendaysV;
+  int rtunfrozendaysV;
+  int yrsdistV;
+  temutil::nc( nc_def_var(ncid, "dsr", NC_INT, 2, vartype2D_dimids, &dsrV) );
+  temutil::nc( nc_def_var(ncid, "numsl", NC_INT, 2, vartype2D_dimids, &numslV) );
+  temutil::nc( nc_def_var(ncid, "numsnwl", NC_INT, 2, vartype2D_dimids, &numsnwlV) );
+  temutil::nc( nc_def_var(ncid, "rtfrozendays", NC_INT, 2, vartype2D_dimids, &rtfrozendaysV) );
+  temutil::nc( nc_def_var(ncid, "rtunfrozendays", NC_INT, 2, vartype2D_dimids, &rtunfrozendaysV) );
+  temutil::nc( nc_def_var(ncid, "yrsdist", NC_INT, 2, vartype2D_dimids, &yrsdistV) );
+
+  // Setup 2D vars, double
+  int firea2sorgnV;
+  int snwextramasV;
+  int monthsfrozenV;
+  int watertabV;
+  int wdebriscV;
+  int wdebrisnV;
+  int dmosscV;
+  int dmossnV;
+  temutil::nc( nc_def_var(ncid, "firea2sorgn", NC_DOUBLE, 2, vartype2D_dimids, &firea2sorgnV) );
+  temutil::nc( nc_def_var(ncid, "snwextramass", NC_DOUBLE, 2, vartype2D_dimids, &snwextramasV) );
+  temutil::nc( nc_def_var(ncid, "monthsfrozen", NC_DOUBLE, 2, vartype2D_dimids, &monthsfrozenV) );
+  temutil::nc( nc_def_var(ncid, "watertab", NC_DOUBLE, 2, vartype2D_dimids, &watertabV) );
+  temutil::nc( nc_def_var(ncid, "wdebrisc", NC_DOUBLE, 2, vartype2D_dimids, &wdebriscV) );
+  temutil::nc( nc_def_var(ncid, "wdebrisn", NC_DOUBLE, 2, vartype2D_dimids, &wdebrisnV) );
+  temutil::nc( nc_def_var(ncid, "dmossc", NC_DOUBLE, 2, vartype2D_dimids, &dmosscV) );
+  temutil::nc( nc_def_var(ncid, "dmossn", NC_DOUBLE, 2, vartype2D_dimids, &dmossnV) );
+
+  // Setup 3D vars, integer
+  int ifwoodyV;
+  int ifdeciwoodyV;
+  int ifperenialV;
+  int nonvascularV;
+  int vegageV;
+  temutil::nc( nc_def_var(ncid, "ifwoody", NC_INT, 3, vartype3D_dimids, &ifwoodyV) );
+  temutil::nc( nc_def_var(ncid, "ifdeciwoody", NC_INT, 3, vartype3D_dimids, &ifdeciwoodyV) );
+  temutil::nc( nc_def_var(ncid, "ifperenial", NC_INT, 3, vartype3D_dimids, &ifperenialV) );
+  temutil::nc( nc_def_var(ncid, "nonvascular", NC_INT, 3, vartype3D_dimids, &nonvascularV) );
+  temutil::nc( nc_def_var(ncid, "vegage", NC_INT, 3, vartype3D_dimids, &vegageV) );
+
+  // Setup 3D vars, double
+  int vegcovV;
+  int laiV;
+  int vegwaterV;
+  int vegsnowV;
+  int labnV;
+  int deadcV;
+  int deadnV;
+  int toptV;
+  int eetmxV;
+  int unnormleafmxV;
+  int growingttimeV;
+  int foliagemxV;
+  temutil::nc( nc_def_var(ncid, "vegcov", NC_DOUBLE, 3, vartype3D_dimids, &vegcovV) );
+  temutil::nc( nc_def_var(ncid, "lai", NC_DOUBLE, 3, vartype3D_dimids, &laiV) );
+  temutil::nc( nc_def_var(ncid, "vegwater", NC_DOUBLE, 3, vartype3D_dimids, &vegwaterV) );
+  temutil::nc( nc_def_var(ncid, "vegsnow", NC_DOUBLE, 3, vartype3D_dimids, &vegsnowV) );
+  temutil::nc( nc_def_var(ncid, "labn", NC_DOUBLE, 3, vartype3D_dimids, &labnV) );
+  temutil::nc( nc_def_var(ncid, "deadc", NC_DOUBLE, 3, vartype3D_dimids, &deadcV) );
+  temutil::nc( nc_def_var(ncid, "deadn", NC_DOUBLE, 3, vartype3D_dimids, &deadnV) );
+  temutil::nc( nc_def_var(ncid, "topt", NC_DOUBLE, 3, vartype3D_dimids, &toptV) );
+  temutil::nc( nc_def_var(ncid, "eetmx", NC_DOUBLE, 3, vartype3D_dimids, &eetmxV) );
+  temutil::nc( nc_def_var(ncid, "unnormleafmx", NC_DOUBLE, 3, vartype3D_dimids, &unnormleafmxV) );
+  temutil::nc( nc_def_var(ncid, "growingttime", NC_DOUBLE, 3, vartype3D_dimids, &growingttimeV) );
+  temutil::nc( nc_def_var(ncid, "foliagemx", NC_DOUBLE, 3, vartype3D_dimids, &foliagemxV) );
+
+  // Setup 4D vars, double
+  int vegcV;
+  int strnV;
+  temutil::nc( nc_def_var(ncid, "vegc", NC_DOUBLE, 4, vartype4D_dimids, &vegcV) );
+  temutil::nc( nc_def_var(ncid, "strn", NC_DOUBLE, 4, vartype4D_dimids, &strnV) );
+
+  // re-arrange dims in vartype
+  vartype3D_dimids[0] = yD;
+  vartype3D_dimids[1] = xD;
+  vartype3D_dimids[2] = soillayerD;
+
+  // Setup 3D vars, integer
+  int TEXTUREsoilV;
+  int FROZENsoilV;
+  int TYPEsoilV;
+  int AGEsoilV;
+  temutil::nc( nc_def_var(ncid, "TEXTUREsoil", NC_INT, 3, vartype3D_dimids, &TEXTUREsoilV) );
+  temutil::nc( nc_def_var(ncid, "FROZENsoil", NC_INT, 3, vartype3D_dimids, &FROZENsoilV) );
+  temutil::nc( nc_def_var(ncid, "TYPEsoil", NC_INT, 3, vartype3D_dimids, &TYPEsoilV) );
+  temutil::nc( nc_def_var(ncid, "AGEsoil", NC_INT, 3, vartype3D_dimids, &AGEsoilV) );
+
+  // Setup 3D vars, double
+  int TSsoilV;
+  int DZsoilV;
+  int LIQsoilV;
+  int ICEsoilV;
+  int FROZENFRACsoilV;
+  int rawcV;
+  int somaV;
+  int somprV;
+  int somcrV;
+  int orgnV;
+  int avlnV;
+  temutil::nc( nc_def_var(ncid, "TSsoil", NC_DOUBLE, 3, vartype3D_dimids, &TSsoilV) );
+  temutil::nc( nc_def_var(ncid, "DZsoil", NC_DOUBLE, 3, vartype3D_dimids, &DZsoilV) );
+  temutil::nc( nc_def_var(ncid, "LIQsoil", NC_DOUBLE, 3, vartype3D_dimids, &LIQsoilV) );
+  temutil::nc( nc_def_var(ncid, "ICEsoil", NC_DOUBLE, 3, vartype3D_dimids, &ICEsoilV) );
+  temutil::nc( nc_def_var(ncid, "FROZENFRACsoil", NC_DOUBLE, 3, vartype3D_dimids, &FROZENFRACsoilV) );
+  temutil::nc( nc_def_var(ncid, "rawc", NC_DOUBLE, 3, vartype3D_dimids, &rawcV) );
+  temutil::nc( nc_def_var(ncid, "soma", NC_DOUBLE, 3, vartype3D_dimids, &somaV) );
+  temutil::nc( nc_def_var(ncid, "sompr", NC_DOUBLE, 3, vartype3D_dimids, &somprV) );
+  temutil::nc( nc_def_var(ncid, "somcr", NC_DOUBLE, 3, vartype3D_dimids, &somcrV) );
+  temutil::nc( nc_def_var(ncid, "orgn", NC_DOUBLE, 3, vartype3D_dimids, &orgnV) );
+  temutil::nc( nc_def_var(ncid, "avln", NC_DOUBLE, 3, vartype3D_dimids, &avlnV) );
+
+  // %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+  // NOTE: Seems odd, that these variables are defined in terms of soillayer
+  // dimension and not the snowlayer dimension??? If this changes, will have
+  // to update the custom MPI Type! (And for consistency, update the
+  // create_region_inpuy.py script, although the --crtf-only feature will
+  // probably be deprecated after adding the ability to create these files in
+  // the C++ code.
+  // The old files that we've been using prior to 11/2016 seem to have been
+  // using number of soil layers, so I left it at that for now....
+  // %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+  int TSsnowV;
+  int DZsnowV;
+  int LIQsnowV;
+  int RHOsnowV;
+  int ICEsnowV;
+  int AGEsnowV;
+  temutil::nc( nc_def_var(ncid, "TSsnow", NC_DOUBLE, 3, vartype3D_dimids, &TSsnowV) );
+  temutil::nc( nc_def_var(ncid, "DZsnow", NC_DOUBLE, 3, vartype3D_dimids, &DZsnowV) );
+  temutil::nc( nc_def_var(ncid, "LIQsnow", NC_DOUBLE, 3, vartype3D_dimids, &LIQsnowV) );
+  temutil::nc( nc_def_var(ncid, "RHOsnow", NC_DOUBLE, 3, vartype3D_dimids, &RHOsnowV) );
+  temutil::nc( nc_def_var(ncid, "ICEsnow", NC_DOUBLE, 3, vartype3D_dimids, &ICEsnowV) );
+  temutil::nc( nc_def_var(ncid, "AGEsnow", NC_DOUBLE, 3, vartype3D_dimids, &AGEsnowV) );
+
+  // re-arrange dims in vartype
+  vartype3D_dimids[0] = yD;
+  vartype3D_dimids[1] = xD;
+  vartype3D_dimids[2] = rocklayerD;
+
+  int TSrockV;
+  int DZrockV;
+  temutil::nc( nc_def_var(ncid, "TSrock", NC_DOUBLE, 3, vartype3D_dimids, &TSrockV) );
+  temutil::nc( nc_def_var(ncid, "DZrock", NC_DOUBLE, 3, vartype3D_dimids, &DZrockV) );
+
+
+  // re-arrange dims in vartype
+  vartype3D_dimids[0] = yD;
+  vartype3D_dimids[1] = xD;
+  vartype3D_dimids[2] = frontsD;
+
+  int frontFTV;
+  int frontZV;
+  temutil::nc( nc_def_var(ncid, "frontFT", NC_INT, 3, vartype3D_dimids, &frontFTV) );
+  temutil::nc( nc_def_var(ncid, "frontZ", NC_DOUBLE, 3, vartype3D_dimids, &frontZV) );
+
+  // re-arrange dims in vartype
+  vartype4D_dimids[0] = yD;
+  vartype4D_dimids[1] = xD;
+  vartype4D_dimids[2] = rootlayerD;
+  vartype4D_dimids[3] = pftD;
+
+  int rootfracV;
+  temutil::nc( nc_def_var(ncid, "rootfrac", NC_DOUBLE, 4, vartype4D_dimids, &rootfracV) );
+
+
+  // re-arrange dims in vartype
+  vartype4D_dimids[0] = yD;
+  vartype4D_dimids[1] = xD;
+  vartype4D_dimids[2] = prevtenD;
+  vartype4D_dimids[3] = pftD;
+
+  int toptAV;
+  int eetmxAV;
+  int unnormleafmxAV;
+  int growingttimeAV;
+  temutil::nc( nc_def_var(ncid, "toptA", NC_DOUBLE, 4, vartype4D_dimids, &toptAV) );
+  temutil::nc( nc_def_var(ncid, "eetmxA", NC_DOUBLE, 4, vartype4D_dimids, &eetmxAV) );
+  temutil::nc( nc_def_var(ncid, "unnormleafmxA", NC_DOUBLE, 4, vartype4D_dimids, &unnormleafmxAV) );
+  temutil::nc( nc_def_var(ncid, "growingttimeA", NC_DOUBLE, 4, vartype4D_dimids, &growingttimeAV) );
+
+  // re-arrange dims in vartype
+  vartype4D_dimids[0] = yD;
+  vartype4D_dimids[1] = xD;
+  vartype4D_dimids[2] = prevtwelveD;
+  vartype4D_dimids[3] = pftD;
+
+  int prvltrfcnAV;
+  temutil::nc( nc_def_var(ncid, "prvltrfcnA", NC_DOUBLE, 4, vartype4D_dimids, &prvltrfcnAV) );
+
+  /* Create Attributes?? */
+
+  /* End Define Mode (not scrictly necessary for netcdf 4) */
+  BOOST_LOG_SEV(glg, debug) << "Leaving 'define mode'...";
+  temutil::nc( nc_enddef(ncid) );
+
+  /* Close file. */
+  BOOST_LOG_SEV(glg, debug) << "Closing new file...";
+  temutil::nc( nc_close(ncid) );
+
+}
+
+
 /** Writes single values for variables have dimensions (Y, X).*/
 void RestartData::write_px_vars(const std::string& fname, const int rowidx, const int colidx) {
   

--- a/src/data/RestartData.h
+++ b/src/data/RestartData.h
@@ -21,7 +21,7 @@ public :
   #endif
 
   void reinitValue();
-  void append_to_ncfile(const std::string& fname, const int rowidx, const int colidx);
+  void write_pixel_to_ncfile(const std::string& fname, const int rowidx, const int colidx);
   void update_from_ncfile(const std::string& fname, const int rowidx, const int colidx);
   //The following two functions should probably be replaced with
   //something that does not require manually adding new members.

--- a/src/data/RestartData.h
+++ b/src/data/RestartData.h
@@ -48,6 +48,8 @@ public :
   void write_px_front_vars(const std::string& fname, const int rowidx, const int colidx);
   void write_px_prev_pft_vars(const std::string& fname, const int rowidx, const int colidx);
 
+  static void create_empty_file(const std::string& fname, const int ysize, const int xsize);
+
   int chtid;
 
   // atm

--- a/src/data/RestartData.h
+++ b/src/data/RestartData.h
@@ -54,7 +54,7 @@ public :
   int dsr;
   double firea2sorgn;
 
-  //vegetation
+  // vegetation
   int yrsdist;
 
   int ifwoody[NUM_PFT]; // - 'veg_dim'
@@ -66,8 +66,8 @@ public :
   double lai[NUM_PFT];
   double rootfrac[MAX_ROT_LAY][NUM_PFT];
 
-  double vegwater[NUM_PFT]; //canopy water - 'vegs_env'
-  double vegsnow[NUM_PFT]; //canopy snow  - 'vegs_env'
+  double vegwater[NUM_PFT]; // canopy water - 'vegs_env'
+  double vegsnow[NUM_PFT];  // canopy snow  - 'vegs_env'
 
   double vegc[NUM_PFT_PART][NUM_PFT]; // - 'vegs_bgc'
   double labn[NUM_PFT];
@@ -79,18 +79,20 @@ public :
   double eetmx[NUM_PFT]; // yearly max. month 'eet'
   double unnormleafmx[NUM_PFT]; // yearly max. unnormalized 'fleaf'
   double growingttime[NUM_PFT]; // yearly growthing t-time
-  // this is for f(foliage) in GPP to be sure f(foliage) not going down
+
+  // This is for f(foliage) in GPP to be sure f(foliage) not going down
   double foliagemx[NUM_PFT];
 
-  // this is for f(temp) in GPP to calculate the mean of the 10 previous values
+  // This is for f(temp) in GPP to calculate the mean of the 10 previous values
   double toptA[10][NUM_PFT];
-  //this is for f(phenology) in GPP to calculate the mean of the 10
-  //  previous values
+
+  // This is for f(phenology) in GPP to calculate the mean of the 10
+  // previous values
   double eetmxA[10][NUM_PFT];
   double unnormleafmxA[10][NUM_PFT];
   double growingttimeA[10][NUM_PFT];
 
-  //snow
+  // snow
   int numsnwl;
   double snwextramass;
   double TSsnow[MAX_SNW_LAY];
@@ -100,7 +102,7 @@ public :
   double ICEsnow[MAX_SNW_LAY];
   double AGEsnow[MAX_SNW_LAY];
 
-  //ground-soil
+  // ground-soil
   int numsl;
   double monthsfrozen;
   int rtfrozendays;
@@ -135,8 +137,8 @@ public :
   double orgn[MAX_SOI_LAY];
   double avln[MAX_SOI_LAY];
 
-  //previous 12-month litterfall (root death) input C/N ratios in each
-  //  soil layer for adjusting 'kd'
+  // previous 12-month litterfall (root death) input C/N ratios in each
+  // soil layer for adjusting 'kd'
   double prvltrfcnA[12][MAX_SOI_LAY];
 
 


### PR DESCRIPTION
Refactor so that the model is now smart enough to create its own empty restart files. 

This will deprecate the functionality that we used to use with `create_region_input.py --crtf-only`. 

This should make it so that there is no need to remember to create the template restart files when doing a clean checkout from git; now the model is smart enough to make the files itself.