### PR TITLE
Removes dead moss.

### DIFF
--- a/calibration/configured_suites.py
+++ b/calibration/configured_suites.py
@@ -68,14 +68,12 @@ configured_suites = {
 
       { 'jsontag': 'CarbonShallow', 'axesnum': 1, 'units': 'gC/m^2', },
       { 'jsontag': 'CarbonDeep', 'axesnum': 1, 'units': 'gC/m^2', },
-      { 'jsontag': 'DeadMossCarbon', 'axesnum': 1, 'units': 'gC/m^2', },
 
       { 'jsontag': 'CarbonMineralSum', 'axesnum': 2, 'units': 'gC/m^2', },
 
       { 'jsontag': 'OrganicNitrogenSum', 'axesnum':3, 'units': 'gN/m^2', },
 
       { 'jsontag': 'AvailableNitrogenSum', 'axesnum':4, 'units': 'gN/m^2', },
-      { 'jsontag': 'DeadMossNitrogen', 'axesnum': 4, 'units': 'gN/m^2', },
       { 'jsontag': 'StNitrogenUptakeAll', 'axesnum': 4, 'units': 'gN/m^2', },
       { 'jsontag': 'InNitrogenUptakeAll', 'axesnum': 4, 'units': 'gN/m^2', },
 
@@ -135,7 +133,6 @@ configured_suites = {
 
       { 'jsontag': 'CarbonShallow', 'axesnum': 4, 'units': 'gC/m^2', },
       { 'jsontag': 'CarbonDeep', 'axesnum': 4, 'units': 'gC/m^2', },
-      { 'jsontag': 'DeadMossCarbon', 'axesnum': 4, 'units': 'gC/m^2', },
 
       { 'jsontag': 'CarbonMineralSum', 'axesnum': 5, 'units': 'gC/m^2', },
 
@@ -178,7 +175,6 @@ configured_suites = {
       { 'jsontag': 'StNitrogenUptakeAll', 'axesnum': 5, 'units': 'gN/m^2', },
       { 'jsontag': 'InNitrogenUptakeAll', 'axesnum': 5, 'units': 'gN/m^2', },
 
-      { 'jsontag': 'DeadMossNitrogen', 'axesnum': 6, 'units': 'gN/m^2', },
       { 'jsontag': 'AvlNInput', 'axesnum': 6, 'units': 'gN/m^2', },
       { 'jsontag': 'AvlNLost', 'axesnum': 6, 'units': 'gN/m^2', },
 

--- a/parameters/cmt_bgcsoil.txt
+++ b/parameters/cmt_bgcsoil.txt
@@ -13,7 +13,6 @@
 29.73             // nmincnsoil:
 0.2               // propftos:
 0.0               // fnloss:  fraction N leaching (0 - 1) when drainage occurs
-17                // initdmossc:
 1783              // initshlwc:
 5021              // initdeepc:
 9000              // initminec:
@@ -34,7 +33,6 @@
 29.73             // nmincnsoil:
 0.2               // propftos:
 0.0               // fnloss:  fraction N leaching (0 - 1) when drainage occurs
-178               // initdmossc:
 1783              // initshlwc:
 5021              // initdeepc:
 9000              // initminec:
@@ -55,7 +53,6 @@
 29.73             // nmincnsoil:
 0.2               // propftos:
 0.0               // fnloss:  fraction N leaching (0 - 1) when drainage occurs
-0.0               // initdmossc:
 1783              // initshlwc:
 5021              // initdeepc:
 9000              // initminec:
@@ -76,7 +73,6 @@
 29.73             // nmincnsoil:
 0.2               // propftos:
 0.0               // fnloss:  fraction N leaching (0 - 1) when drainage occurs
-0.0               // initdmossc:
 1783              // initshlwc:
 5021              // initdeepc:
 9000              // initminec:
@@ -97,7 +93,6 @@
 29.73             // nmincnsoil:
 0.2               // propftos:
 0.0               // fnloss:  fraction N leaching (0 - 1) when drainage occurs
-0.0               // initdmossc:
 1783              // initshlwc:
 5021              // initdeepc:
 9000              // initminec:
@@ -118,7 +113,6 @@
 24.6             // nmincnsoil:
 0.2               // propftos:
 0.0               // fnloss:  fraction N leaching (0 - 1) when drainage occurs
-1549.5               // initdmossc: MUST MATCH initdmossthick in cmt_dimground.txt!!!
 3000              // initshlwc:
 7700              // initdeepc:
 43000              // initminec:
@@ -139,7 +133,6 @@
 29.73             // nmincnsoil:
 0.2               // propftos:
 0.0               // fnloss:  fraction N leaching (0 - 1) when drainage occurs
-0.0               // initdmossc:
 1783              // initshlwc:
 5021              // initdeepc:
 9000              // initminec:

--- a/parameters/cmt_calparbgc.txt
+++ b/parameters/cmt_calparbgc.txt
@@ -16,7 +16,6 @@
 0.20         0.20         0.20         0.20         0.20         0.20         0.20         0.20         0.20         0.0          // frg: fraction of available NPP (GPP after rm) for growth resp. 
 // soil calibrated parameters
 2.65253         // micbnup: parameter for soil microbial immobialization of N
-0.0057042       // kdcmoss: dead moss C decompositin rates at reference condition
 0.0507042       // kdcrawc: raw-material (litter) C decompositin rates at reference condition
 0.0108046       // kdcsoma:
 0.0020805       // kdcsompr:
@@ -39,7 +38,6 @@
 0.20         0.20         0.20         0.20         0.20         0.20         0.20         0.20         0.20         0.0          // frg: NPP fraction for growth resp. 
 // soil calibrated parameters
 2.65253         // micbnup: parameter for soil microbial immobialization of N
-0.0057042       // kdcmoss: dead moss C decompositin rates at reference condition
 0.0507042       // kdcrawc: raw-material (litter) C decompositin rates at reference condition
 0.0108046       // kdcsoma:
 0.0020805       // kdcsompr:
@@ -62,7 +60,6 @@
 0.20         0.20         0.20         0.20         0.20         0.20         0.20         0.20         0.20         0.0          // frg: fraction of available NPP (GPP after rm) for growth resp. 
 // soil calibrated parameters
 2.65253         // micbnup: parameter for soil microbial immobialization of N
-0.0057042       // kdcmoss: dead moss C decompositin rates at reference condition
 0.0507042       // kdcrawc: raw-material (litter) C decompositin rates at reference condition
 0.0108046       // kdcsoma:
 0.0020805       // kdcsompr:
@@ -85,7 +82,6 @@
 0.20         0.20         0.20         0.20         0.20         0.20         0.20         0.20         0.20         0.0          // frg: fraction of available NPP (GPP after rm) for growth resp. 
 // soil calibrated parameters
 2.65253         // micbnup: parameter for soil microbial immobialization of N
-0.0057042       // kdcmoss: dead moss C decompositin rates at reference condition
 0.0507042       // kdcrawc: raw-material (litter) C decompositin rates at reference condition
 0.0108046       // kdcsoma:
 0.0020805       // kdcsompr:
@@ -108,7 +104,6 @@
 0.20         0.20         0.20         0.20         0.20         0.20         0.20         0.20         0.20         0.0          // frg: fraction of available NPP (GPP after rm) for growth resp. 
 // soil calibrated parameters
 2.65253         // micbnup: parameter for soil microbial immobialization of N
-0.0057042       // kdcmoss: dead moss C decompositin rates at reference condition
 0.0907042       // kdcrawc: raw-material (litter) C decompositin rates at reference condition
 0.0158046       // kdcsoma:
 0.0020805       // kdcsompr:
@@ -131,7 +126,6 @@
 0.20         0.20        0.20        0.30         0.20         0.10         0.20         0.20         0.0          0.0        // frg: fraction of available NPP (GPP after rm) for growth resp. 
 // soil calibrated parameters
 8.65         // micbnup: parameter for soil microbial immobialization of N
-0.009        // kdcmoss:
 0.07       // kdcrawc: raw-material (litter) C decompositin rates at reference condition
 0.0097       // kdcsoma:
 0.001      // kdcsompr:
@@ -154,7 +148,6 @@
 0.20         0.20         0.20         0.20         0.20         0.20         0.20         0.0        0.0          0.0          // frg: fraction of available NPP (GPP after rm) for growth resp. 
 // soil calibrated parameters
 2.65253         // micbnup: parameter for soil microbial immobialization of N
-0.0057042       // kdcmoss: dead moss C decompositin rates at reference condition
 0.0507042       // kdcrawc: raw-material (litter) C decompositin rates at reference condition
 0.0108046       // kdcsoma:
 0.0020805       // kdcsompr:
@@ -177,7 +170,6 @@
 0.20         0.20         0.20         0.20         0.20         0.0        0.0         0.0        0.0          0.0          // frg: fraction of available NPP (GPP after rm) for growth resp. 
 // soil calibrated parameters
 2.65253         // micbnup: parameter for soil microbial immobialization of N
-0.0057042       // kdcmoss: dead moss C decompositin rates at reference condition
 0.0507042       // kdcrawc: raw-material (litter) C decompositin rates at reference condition
 0.0108046       // kdcsoma:
 0.0020805       // kdcsompr:

--- a/parameters/cmt_dimground.txt
+++ b/parameters/cmt_dimground.txt
@@ -9,8 +9,6 @@
 0.035              // maxmossthick: max. dead moss thickness (m)
 0.005              // initdmossthick: initial dead moss thickness (m)
 1                  // mosstype: moss type (1: sphagnum; 2: furthermoss; 3: other)
-0.049              // coefmossa:
-0.50               // coefmossb:
 // soil characteristics
 0.1                // initfibthick: meters
 0.1                // inithumthick:
@@ -31,8 +29,6 @@
 0.035              // maxmossthick: max. moss thickness (m)
 0.005              // initdmossthick: initial dead moss thickness (m)
 1                  // mosstype: moss type (1: sphagnum; 2: furthermoss; 3: other)
-0.049              // coefmossa:
-0.50               // coefmossb:
 // soil characteristics
 0.1                // initfibthick: meters
 0.1                // inithumthick:
@@ -53,8 +49,6 @@
 0.035              // maxmossthick: max. moss thickness (m)
 0.005              // initdmossthick: initial dead moss thickness (m)
 1                  // mosstype: moss type (1: sphagnum; 2: furthermoss; 3: other)
-0.049              // coefmossa:
-0.50               // coefmossb:
 // soil characteristics
 0.1                // initfibthick: meters
 0.1                // inithumthick:
@@ -75,8 +69,6 @@
 0.035              // maxmossthick: max. moss thickness (m)
 0.005              // initdmossthick: initial dead moss thickness (m)
 1                  // mosstype: moss type (1: sphagnum; 2: furthermoss; 3: other)
-0.049              // coefmossa:
-1.50               // coefmossb:
 // soil characteristics
 0.1                // initfibthick: meters
 0.1                // inithumthick:
@@ -97,8 +89,6 @@
 0.035              // maxmossthick: max. moss thickness (m)
 0.005              // initdmossthick: initial dead moss thickness (m)
 1                  // mosstype: moss type (1: sphagnum; 2: furthermoss; 3: other)
-0.049              // coefmossa:
-0.50               // coefmossb:
 // soil characteristics
 0.1                // initfibthick: meters
 0.1                // inithumthick:
@@ -119,8 +109,6 @@
 0.30               // maxmossthick: max. moss thickness (m)
 0.10               // initdmossthick: initial dead moss thickness (m) MUST MATCH initdmossc in cmt_bgcsoil.txt!!!
 1                  // mosstype: moss type (1: sphagnum; 2: furthermoss; 3: other)
-0.049              // coefmossa:
-0.50               // coefmossb:
 // soil characteristics
 0.0667             // initfibthick: meters
 0.145              // inithumthick:
@@ -141,8 +129,6 @@
 0.035              // maxmossthick: max. moss thickness (m)
 0.005              // initdmossthick: initial dead moss thickness (m)
 1                  // mosstype: moss type (1: sphagnum; 2: furthermoss; 3: other)
-0.049              // coefmossa:
-0.50               // coefmossb:
 // soil characteristics
 0.1                // initfibthick: meters
 0.1                // inithumthick:
@@ -163,8 +149,6 @@
 0.035              // maxmossthick: max. moss thickness (m)
 0.005              // initdmossthick: initial dead moss thickness (m)
 1                  // mosstype: moss type (1: sphagnum; 2: furthermoss; 3: other)
-0.049              // coefmossa:
-0.50               // coefmossb:
 // soil characteristics
 0.1                // initfibthick: meters
 0.1                // inithumthick:

--- a/scripts/diagnostics.py
+++ b/scripts/diagnostics.py
@@ -400,7 +400,6 @@ def ecosystem_sum_soilC(jdata):
 #    total += jdata["CarbonMineralSum"]
 #    total += jdata["CarbonDeep"]
 #    total += jdata["CarbonShallow"]
-    total += jdata["DeadMossCarbon"]
     total += jdata["WoodyDebrisC"]
   return total
 
@@ -643,7 +642,6 @@ def Report_Soil_C(idx, header=False, jd=None, pjd=None):
                 jd['SomaSum'],
                 jd['SomprSum'],
                 jd['SomcrSum'],
-                jd['DeadMossCarbon'],
 
             )
 

--- a/src/Runner.cpp
+++ b/src/Runner.cpp
@@ -413,8 +413,6 @@ void Runner::output_caljson_monthly(int year, int month, std::string stage, boos
                              + cohort.bdall->m_soid.minebc
                              + cohort.bdall->m_soid.minecc;
   // pools
-  data["DeadMossCarbon"] = cohort.bdall->m_sois.dmossc;
-  data["DeadMossNitrogen"] = cohort.bdall->m_sois.dmossn;
   data["StandingDeadC"] = cohort.bdall->m_vegs.deadc;
   data["StandingDeadN"] = cohort.bdall->m_vegs.deadn;
   data["WoodyDebrisC"] = cohort.bdall->m_sois.wdebrisc;
@@ -435,7 +433,6 @@ void Runner::output_caljson_monthly(int year, int month, std::string stage, boos
   data["RHsompr"] = cohort.bdall->m_soi2a.rhsomprsum;
   data["RHsomcr"] = cohort.bdall->m_soi2a.rhsomcrsum;
   data["RHwdeb"] = cohort.bdall->m_soi2a.rhwdeb;
-  data["RHmossc"] = cohort.bdall->m_soi2a.rhmossc;
   data["RH"] = cohort.bdall->m_soi2a.rhtot;
 
   data["YearsSinceDisturb"] = cohort.cd.yrsdist;
@@ -497,7 +494,6 @@ void Runner::output_caljson_monthly(int year, int month, std::string stage, boos
     data["PFT" + pft_str]["LabNitrogenUptake"] = cohort.bd[pft].m_soi2v.lnuptake;
     data["PFT" + pft_str]["TotNitrogenUptake"] = cohort.bd[pft].m_soi2v.snuptakeall + cohort.bd[pft].m_soi2v.lnuptake;
     data["PFT" + pft_str]["MossDeathC"] = cohort.bd[pft].m_v2soi.mossdeathc;
-    data["PFT" + pft_str]["DeadMossC"] = cohort.bd[pft].m_sois.dmossc;
 
     data["PFT" + pft_str]["PARDown"] = cohort.ed[pft].m_a2v.pardown;
     data["PFT" + pft_str]["PARAbsorb"] = cohort.ed[pft].m_a2v.parabsorb;
@@ -596,8 +592,6 @@ void Runner::output_caljson_yearly(int year, std::string stage, boost::filesyste
                              + cohort.bdall->y_soid.minebc
                              + cohort.bdall->y_soid.minecc;
   // pools
-  data["DeadMossCarbon"] = cohort.bdall->y_sois.dmossc;
-  data["DeadMossNitrogen"] = cohort.bdall->y_sois.dmossn;
   data["StandingDeadC"] = cohort.bdall->y_vegs.deadc;
   data["StandingDeadN"] = cohort.bdall->y_vegs.deadn;
   data["WoodyDebrisC"] = cohort.bdall->y_sois.wdebrisc;

--- a/src/TEM.cpp
+++ b/src/TEM.cpp
@@ -291,10 +291,10 @@ int main(int argc, char* argv[]){
 
           }
 
-          // EQULIBRIUM STAGE (EQ)
+          // EQUILIBRIUM STAGE (EQ)
           if (modeldata.eq_yrs > 0) {
             BOOST_LOG_NAMED_SCOPE("EQ");
-            BOOST_LOG_SEV(glg, fatal) << "Running Equlibrium, " << modeldata.sp_yrs << " years.";
+            BOOST_LOG_SEV(glg, fatal) << "Running Equilibrium, " << modeldata.eq_yrs << " years.";
 
             if (runner.calcontroller_ptr) {
               runner.calcontroller_ptr->handle_stage_start();

--- a/src/data/BgcData.cpp
+++ b/src/data/BgcData.cpp
@@ -222,8 +222,6 @@ void BgcData::soil_beginOfMonth() {
 void BgcData::soil_beginOfYear() {
   y_sois.wdebrisc= 0.;
   y_sois.wdebrisn= 0.;
-  y_sois.dmossc  = 0.;
-  y_sois.dmossn  = 0.;
   y_soid.shlwc   = 0.;
   y_soid.deepc   = 0.;
   y_soid.mineac  = 0.;  // top mineral SOMC
@@ -358,8 +356,6 @@ void BgcData::soil_endOfMonth(const int currmind) {
       y_sois.avln[il]   = m_sois.avln[il]    ;
     }
 
-    y_sois.dmossc   = m_sois.dmossc     ;
-    y_sois.dmossn   = m_sois.dmossn     ;
     y_sois.wdebrisc = m_sois.wdebrisc   ;
     y_sois.wdebrisn = m_sois.wdebrisn   ;
     y_soid.shlwc    = m_soid.shlwc      ;
@@ -396,8 +392,7 @@ void BgcData::soil_endOfMonth(const int currmind) {
                   m_soi2a.rhsomasum +
                   m_soi2a.rhsomprsum +
                   m_soi2a.rhsomcrsum +
-                  m_soi2a.rhwdeb +
-                  m_soi2a.rhmossc;
+                  m_soi2a.rhwdeb;
 
   //cumulative annually
   y_soi2a.rhwdeb    += m_soi2a.rhwdeb;

--- a/src/data/RestartData.cpp
+++ b/src/data/RestartData.cpp
@@ -111,7 +111,6 @@ MPI_Datatype RestartData::register_mpi_datatype() {
     MAX_NUM_FNT, // int frontFT[MAX_NUM_FNT];
     
     1, // double wdebrisc;
-    1, // double dmossc;
     
     MAX_SOI_LAY, // double rawc[MAX_SOI_LAY];
     MAX_SOI_LAY, // double soma[MAX_SOI_LAY];
@@ -119,7 +118,6 @@ MPI_Datatype RestartData::register_mpi_datatype() {
     MAX_SOI_LAY, // double somcr[MAX_SOI_LAY];
     
     1, // double wdebrisn;
-    1, // double dmossn;
     1, // double orgn[MAX_SOI_LAY];
     
     MAX_SOI_LAY, // double avln[MAX_SOI_LAY];
@@ -182,13 +180,11 @@ MPI_Datatype RestartData::register_mpi_datatype() {
     MPI_DOUBLE, // double frontZ[MAX_NUM_FNT];
     MPI_INT, // int frontFT[MAX_NUM_FNT];
     MPI_DOUBLE, // double wdebrisc;
-    MPI_DOUBLE, // double dmossc;
     MPI_DOUBLE, // double rawc[MAX_SOI_LAY];
     MPI_DOUBLE, // double soma[MAX_SOI_LAY];
     MPI_DOUBLE, // double sompr[MAX_SOI_LAY];
     MPI_DOUBLE, // double somcr[MAX_SOI_LAY];
     MPI_DOUBLE, // double wdebrisn;
-    MPI_DOUBLE, // double dmossn;
     MPI_DOUBLE, // double orgn[MAX_SOI_LAY];
     MPI_DOUBLE, // double avln[MAX_SOI_LAY];
     MPI_DOUBLE // double prvltrfcnA[12][MAX_SOI_LAY];
@@ -249,13 +245,11 @@ MPI_Datatype RestartData::register_mpi_datatype() {
     offsetof(RestartData, frontZ),
     offsetof(RestartData, frontFT),
     offsetof(RestartData, wdebrisc),
-    offsetof(RestartData, dmossc),
     offsetof(RestartData, rawc),
     offsetof(RestartData, soma),
     offsetof(RestartData, sompr),
     offsetof(RestartData, somcr),
     offsetof(RestartData, wdebrisn),
-    offsetof(RestartData, dmossn),
     offsetof(RestartData, orgn),
     offsetof(RestartData, avln),
     offsetof(RestartData, prvltrfcnA)
@@ -518,8 +512,6 @@ void RestartData::verify_logical_values(){
   check_bounds("watertab", watertab);
   check_bounds("wdebrisc", wdebrisc);
   check_bounds("wdebrisn", wdebrisn);
-  check_bounds("dmossc", dmossc);
-  check_bounds("dmossn", dmossn);
   for(int ii=0; ii<MAX_SOI_LAY; ii++){
     check_bounds("DZsoil", DZsoil[ii]);
     check_bounds("TYPEsoil", TYPEsoil[ii]);
@@ -602,10 +594,6 @@ void RestartData::read_px_vars(const std::string& fname, const int rowidx, const
   temutil::nc( nc_get_var1_double(ncid, cv, start, &wdebrisc) );
   temutil::nc( nc_inq_varid(ncid, "wdebrisn", &cv) );
   temutil::nc( nc_get_var1_double(ncid, cv, start, &wdebrisn) );
-  temutil::nc( nc_inq_varid(ncid, "dmossc", &cv) );
-  temutil::nc( nc_get_var1_double(ncid, cv, start, &dmossc) );
-  temutil::nc( nc_inq_varid(ncid, "dmossn", &cv) );
-  temutil::nc( nc_get_var1_double(ncid, cv, start, &dmossn) );
 
   temutil::nc( nc_close(ncid) );
 
@@ -990,16 +978,12 @@ void RestartData::create_empty_file(const std::string& fname,
   int watertabV;
   int wdebriscV;
   int wdebrisnV;
-  int dmosscV;
-  int dmossnV;
   temutil::nc( nc_def_var(ncid, "firea2sorgn", NC_DOUBLE, 2, vartype2D_dimids, &firea2sorgnV) );
   temutil::nc( nc_def_var(ncid, "snwextramass", NC_DOUBLE, 2, vartype2D_dimids, &snwextramasV) );
   temutil::nc( nc_def_var(ncid, "monthsfrozen", NC_DOUBLE, 2, vartype2D_dimids, &monthsfrozenV) );
   temutil::nc( nc_def_var(ncid, "watertab", NC_DOUBLE, 2, vartype2D_dimids, &watertabV) );
   temutil::nc( nc_def_var(ncid, "wdebrisc", NC_DOUBLE, 2, vartype2D_dimids, &wdebriscV) );
   temutil::nc( nc_def_var(ncid, "wdebrisn", NC_DOUBLE, 2, vartype2D_dimids, &wdebrisnV) );
-  temutil::nc( nc_def_var(ncid, "dmossc", NC_DOUBLE, 2, vartype2D_dimids, &dmosscV) );
-  temutil::nc( nc_def_var(ncid, "dmossn", NC_DOUBLE, 2, vartype2D_dimids, &dmossnV) );
 
   // Setup 3D vars, integer
   int ifwoodyV;
@@ -1222,10 +1206,6 @@ void RestartData::write_px_vars(const std::string& fname, const int rowidx, cons
   temutil::nc( nc_put_var1_double(ncid, cv, start, &wdebrisc) );
   temutil::nc( nc_inq_varid(ncid, "wdebrisn", &cv) );
   temutil::nc( nc_put_var1_double(ncid, cv, start, &wdebrisn) );
-  temutil::nc( nc_inq_varid(ncid, "dmossc", &cv) );
-  temutil::nc( nc_put_var1_double(ncid, cv, start, &dmossc) );
-  temutil::nc( nc_inq_varid(ncid, "dmossn", &cv) );
-  temutil::nc( nc_put_var1_double(ncid, cv, start, &dmossn) );
 
   temutil::nc( nc_close(ncid) );
 
@@ -1604,9 +1584,7 @@ void RestartData::restartdata_to_log(){
   BOOST_LOG_SEV(glg, debug) << "rtunfrozendays: " << rtunfrozendays;
   BOOST_LOG_SEV(glg, debug) << "watertab: " << watertab;
   BOOST_LOG_SEV(glg, debug) << "wdebrisc: " << wdebrisc;
-  BOOST_LOG_SEV(glg, debug) << "dmossc: " << dmossc;
   BOOST_LOG_SEV(glg, debug) << "wdebrisn: " << wdebrisn;
-  BOOST_LOG_SEV(glg, debug) << "dmossn: " << dmossn;
 
   for(int ii=0; ii<MAX_SOI_LAY; ii++){
     BOOST_LOG_SEV(glg, debug) << "DZsoil[" << ii << "]: " << DZsoil[ii];

--- a/src/data/RestartData.h
+++ b/src/data/RestartData.h
@@ -128,14 +128,12 @@ public :
   int frontFT[MAX_NUM_FNT];
 
   double wdebrisc;
-  double dmossc;
   double rawc[MAX_SOI_LAY];
   double soma[MAX_SOI_LAY];
   double sompr[MAX_SOI_LAY];
   double somcr[MAX_SOI_LAY];
 
   double wdebrisn;
-  double dmossn;
   double orgn[MAX_SOI_LAY];
   double avln[MAX_SOI_LAY];
 

--- a/src/disturb/WildFire.cpp
+++ b/src/disturb/WildFire.cpp
@@ -226,17 +226,6 @@ void WildFire::burn(int year) {
                            //  and calculated below
   }
 
-  // NOTE: Here we operates on soil portion of 'bdall', later will copy that
-  // to other PFTs if any
-
-  if (bdall->m_sois.dmossc > 0.0) {
-    BOOST_LOG_SEV(glg, debug) << "Burning all dead moss biomass. (Move C and N from bdall soil pool to 'burned' pool)";
-    burnedsolc += bdall->m_sois.dmossc;
-    burnedsoln += bdall->m_sois.dmossn;
-    bdall->m_sois.dmossc = 0.0;
-    bdall->m_sois.dmossn = 0.0;
-  }
-
   BOOST_LOG_SEV(glg, debug) << "Handle burning the soil (loop over all soil layers)...";
   for (int il = 0; il < cd->m_soil.numsl; il++) {
 
@@ -247,8 +236,6 @@ void WildFire::burn(int year) {
                               << "   bottom:"<< cd->m_soil.z[il] + cd->m_soil.dz[il];
 
     if(cd->m_soil.type[il] <= 2) {
-
-
 
       totbotdepth += cd->m_soil.dz[il];
 

--- a/src/ecodomain/Ground.h
+++ b/src/ecodomain/Ground.h
@@ -176,9 +176,6 @@ private :
   double thicknessFromCarbon(const double carbon, const double coefA, const double coefB);
   double carbonFromThickness(const double thickness, const double coefA, const double coefB);
 
-  void get_dead_moss_C_content_from_thickness(SoilLayer* sl, const double &dmossdz);
-  void get_dead_moss_thickness_from_C_content(SoilLayer* sl, const double &dmossc);
-
   void getOslCarbon5Thickness(SoilLayer* sl, const double &plctop,
                               const double &plcbot);
   void getOslThickness5Carbon(SoilLayer* sl, const double &plztop,

--- a/src/ecodomain/horizon/Moss.h
+++ b/src/ecodomain/horizon/Moss.h
@@ -13,10 +13,6 @@ public:
                  //             2: feathermoss;
                  //             3: other (including lichen)
 
-  double dmossc; // dead moss C (kg/m2), which not included in SOM, is always
-                 // in the last moss layer; AND, used as a tracker to determine
-                 // if a moss horizon exists.
-
   double thick;  // in meters
   double dz[MAX_MOS_LAY];
 

--- a/src/inc/fluxes.h
+++ b/src/inc/fluxes.h
@@ -226,8 +226,6 @@ struct soi2atm_env {
 struct soi2atm_bgc {
   double rhwdeb; //rh from wood debris
 
-  double rhmossc;
-
   double rhrawc[MAX_SOI_LAY];
   double rhsoma[MAX_SOI_LAY];
   double rhsompr[MAX_SOI_LAY];
@@ -240,7 +238,7 @@ struct soi2atm_bgc {
 
   double rhtot;  //total rhs
   
-  soi2atm_bgc(): rhwdeb(UIN_D), rhmossc(UIN_D), rhrawcsum(UIN_D),
+  soi2atm_bgc(): rhwdeb(UIN_D), rhrawcsum(UIN_D),
                  rhsomasum(UIN_D), rhsomprsum(UIN_D), rhsomcrsum(UIN_D) {
 
     for (int i = 0; i < MAX_SOI_LAY; ++i) {

--- a/src/inc/layerconst.h
+++ b/src/inc/layerconst.h
@@ -3,7 +3,7 @@
 
 const int MAX_SNW_LAY = 6;  // Maximum number of Snow Layer
 
-const int MAX_MOS_LAY = 2;  // Maximum number of moss Layer involved in soil
+const int MAX_MOS_LAY = 1;  // Maximum number of moss Layer involved in soil
                             //   thermal/hydrological/bgc processes
 const int MAX_SLW_LAY = 3;  // Maximum number of shallow organic Layer
 const int MAX_DEP_LAY = 3;  // Maximum number of deep organic Layer

--- a/src/inc/parameters.h
+++ b/src/inc/parameters.h
@@ -139,8 +139,6 @@ struct vegpar_bgc {
 struct soipar_cal {
   double micbnup;  // parameter related to N immoblization by soil microbial
 
-  double kdcmoss; // calibrated dead moss C material respiration rate
-                  // (at 0oC, favoriable soil moisture)
   double kdcrawc; // calibrated soil raw C material respiration rate
                   // (at 0oC, favoriable soil moisture, and not
                   // litter C/N adjusted)
@@ -149,7 +147,7 @@ struct soipar_cal {
                    //respiration rate (at 0oC)
   double kdcsomcr; // calibrated soil chemically-resistant SOM
                    // respiration rate (at 0oC)
-  soipar_cal(): micbnup(UIN_D), kdcmoss(UIN_D), kdcrawc(UIN_D), kdcsoma(UIN_D),
+  soipar_cal(): micbnup(UIN_D), kdcrawc(UIN_D), kdcsoma(UIN_D),
       kdcsompr(UIN_D), kdcsomcr(UIN_D) {}
 };
 
@@ -158,8 +156,6 @@ struct soipar_dim {
   // moss
   double maxmossthick;
   double minmossthick;
-  double coefmossa;//carbon vs thick
-  double coefmossb;//carbon vs thick
 
   // soils
   double minshlwthick;
@@ -173,8 +169,8 @@ struct soipar_dim {
   double coefminea;//carbon density vs ham
   double coefmineb;//carbon density vs ham
   
-  soipar_dim(): maxmossthick(UIN_D), minmossthick(UIN_D), coefmossa(UIN_D),
-      coefmossb(UIN_D), minshlwthick(UIN_D), coefshlwa(UIN_D), coefshlwb(UIN_D),
+  soipar_dim(): maxmossthick(UIN_D), minmossthick(UIN_D), 
+      minshlwthick(UIN_D), coefshlwa(UIN_D), coefshlwb(UIN_D),
       mindeepthick(UIN_D), coefdeepa(UIN_D), coefdeepb(UIN_D), coefminea(UIN_D),
       coefmineb(UIN_D) {}
 
@@ -222,9 +218,6 @@ struct soipar_bgc {
   double eqsompr;   // physically-resistant SOM
   double eqsomcr;   // chemically-resistant SOM
 
-  // dead moss material decomposition rate
-  double kdmoss;
-
   // litter C/N ratio adjusted C decomposition rate
   double lcclnc; // the litterfalling C/N ratio base for adjusting 'kdc' to 'kd'
   double kdrawc[MAX_SOI_LAY];
@@ -236,7 +229,7 @@ struct soipar_bgc {
                 rhq10(UIN_D), propftos(UIN_D), nmincnsoil(UIN_D), fnloss(UIN_D),
                 fsoma(UIN_D), fsompr(UIN_D), fsomcr(UIN_D), som2co2(UIN_D),
                 eqrawc(UIN_D), eqsoma(UIN_D), eqsompr(UIN_D), eqsomcr(UIN_D),
-                kdmoss(UIN_D), lcclnc(UIN_D) {
+                lcclnc(UIN_D) {
                 
     for (int i = 0; i < MAX_SOI_LAY; ++i) {
       kdrawc[i] = UIN_D;

--- a/src/inc/states.h
+++ b/src/inc/states.h
@@ -236,9 +236,6 @@ struct soistate_bgc {
   double wdebrisc;    // wood debris C
   double wdebrisn;    // wood debris N
 
-  double dmossc;  // dead moss material C
-  double dmossn;  // dead moss material N
-
   double rawc[MAX_SOI_LAY];   //soil raw plant material C
   double soma[MAX_SOI_LAY];   //active som c
   double sompr[MAX_SOI_LAY];  //physically-resistant som c
@@ -247,7 +244,7 @@ struct soistate_bgc {
   double orgn[MAX_SOI_LAY];   // soil total N content kg/m2
   double avln[MAX_SOI_LAY];   // soil available N content kg/m2
   
-  soistate_bgc(): wdebrisc(UIN_D),wdebrisn(UIN_D),dmossc(UIN_D),dmossn(UIN_D) {
+  soistate_bgc(): wdebrisc(UIN_D),wdebrisn(UIN_D) {
     for (int i=0; i < MAX_SOI_LAY; ++i) {
       rawc[i] = UIN_D;
       soma[i] = UIN_D;

--- a/src/inc/temconst.h
+++ b/src/inc/temconst.h
@@ -12,11 +12,11 @@
 // number of vegetation BGC state variables
 const int NUM_VEG_STATE = 2*NUM_PFT_PART // C & structural N content in
                                          // defined-no. of tissues
-                          + 3;     // labible N, C & N in dead veg
+                          + 3;     // labile N, C & N in dead veg
                                    // number of layered soil BGC state variables
 
 const int NUM_SOI_STATE = 6*MAX_SOI_LAY     // 4 soil C pools, orgn, and avln
-                          + 4;              // wderis C and N, dmoss C and N
+                          + 2;              // wdebris C and N 
 
 // number of state variables
 const int MAXSTATE = NUM_VEG_STATE + NUM_SOI_STATE;

--- a/src/lookup/CohortLookup.cpp
+++ b/src/lookup/CohortLookup.cpp
@@ -145,7 +145,6 @@ std::string CohortLookup::calparbgc2str() {
   s << "    kra[2] (fraction of available NPP (GPP after rm))\n";
   s << "// soil calibrated parameters\n";
   s << this->micbnup << " // micbnup: parameter for soil microbial immobialization of N\n";
-  s << this->kdcmoss << " // kdcmoss: dead moss C decompositin rates at reference condition\n";
   s << this->kdcrawc << " // kdcrawc: raw-material (litter) C decompositin rates at reference condition\n";
   s << this->kdcsoma << " // kdcsoma:\n";
   s << this->kdcsompr << " // kdcsompr:\n";
@@ -159,7 +158,7 @@ void CohortLookup::assignBgcCalpar(std::string & dircmt) {
 
   // get a list of data for the cmt number
   std::list<std::string> l = temutil::parse_parameter_file(
-      dircmt + "cmt_calparbgc.txt", temutil::cmtcode2num(this->cmtcode), 19
+      dircmt + "cmt_calparbgc.txt", temutil::cmtcode2num(this->cmtcode), 18
   );
 
   // pop each line off the front of the list
@@ -179,7 +178,6 @@ void CohortLookup::assignBgcCalpar(std::string & dircmt) {
   temutil::pfll2data_pft(l, frg);
 
   temutil::pfll2data(l, micbnup);
-  temutil::pfll2data(l, kdcmoss);
   temutil::pfll2data(l, kdcrawc);
   temutil::pfll2data(l, kdcsoma);
   temutil::pfll2data(l, kdcsompr);
@@ -232,7 +230,7 @@ void CohortLookup::assignGroundDimension(string &dircmt) {
 
   // get a list of data for the cmt number
   std::list<std::string> l = temutil::parse_parameter_file(
-      dircmt + "cmt_dimground.txt", temutil::cmtcode2num(this->cmtcode), 17
+      dircmt + "cmt_dimground.txt", temutil::cmtcode2num(this->cmtcode), 15
   );
 
   // pop each line off the front of the list
@@ -245,8 +243,6 @@ void CohortLookup::assignGroundDimension(string &dircmt) {
   temutil::pfll2data(l, maxdmossthick);
   temutil::pfll2data(l, initdmossthick);
   temutil::pfll2data(l, mosstype);
-  temutil::pfll2data(l, coefmossa);
-  temutil::pfll2data(l, coefmossb);
 
   temutil::pfll2data(l, initfibthick);
   temutil::pfll2data(l, inithumthick);
@@ -378,7 +374,7 @@ void CohortLookup::assignBgc4Ground(string &dircmt) {
   
   // get a list of data for the cmt number
   std::list<std::string> datalist = temutil::parse_parameter_file(
-      dircmt + "cmt_bgcsoil.txt", temutil::cmtcode2num(this->cmtcode), 19
+      dircmt + "cmt_bgcsoil.txt", temutil::cmtcode2num(this->cmtcode), 18
   );
 
   // pop each line off the front of the list
@@ -396,7 +392,6 @@ void CohortLookup::assignBgc4Ground(string &dircmt) {
   temutil::pfll2data(datalist, nmincnsoil);
   temutil::pfll2data(datalist, propftos);
   temutil::pfll2data(datalist, fnloss);
-  temutil::pfll2data(datalist, initdmossc);
   temutil::pfll2data(datalist, initshlwc);
   temutil::pfll2data(datalist, initdeepc);
   temutil::pfll2data(datalist, initminec);

--- a/src/lookup/CohortLookup.h
+++ b/src/lookup/CohortLookup.h
@@ -43,7 +43,6 @@ public:
   // soil
   double micbnup; //parameter related to N immoblization by soil microbial
 
-  double kdcmoss; //calibrated dead moss C material respiration rate (at 0oC)
   double kdcrawc; //calibrated soil raw C material respiration rate (at 0oC)
   double kdcsoma; //calibrated soil active SOM respiration rate (at 0oC)
   double kdcsompr; //calibrated soil physically-resistant
@@ -84,8 +83,6 @@ public:
   double maxdmossthick;
   double initdmossthick;
   int mosstype;
-  double coefmossa;//carbon vs thick
-  double coefmossb;//carbon vs thick
 
   // soils
   double initfibthick;

--- a/src/output/RestartOutputer.cpp
+++ b/src/output/RestartOutputer.cpp
@@ -97,8 +97,6 @@ void RestartOutputer::init(string& outputdir,string& stage) {
   frontFTV=restartFile->add_var("frontFT", ncInt, chtD, frontD); //freezing/thawing front
   wdebriscV =restartFile->add_var("WDEBRISC", ncDouble, chtD);
   wdebrisnV =restartFile->add_var("WDEBRISN", ncDouble, chtD);
-  dmosscV =restartFile->add_var("DMOSSC", ncDouble, chtD);
-  dmossnV =restartFile->add_var("DMOSSN", ncDouble, chtD);
   rawcV  =restartFile->add_var("RAWC", ncDouble, chtD, soillayerD);
   somaV  =restartFile->add_var("SOMA", ncDouble, chtD, soillayerD);
   somprV =restartFile->add_var("SOMPR", ncDouble, chtD, soillayerD);
@@ -175,8 +173,6 @@ void RestartOutputer::outputVariables(const int & chtcount) {
   frontFTV->put_rec(&resod->frontFT[0], chtcount);
   wdebriscV->put_rec(&resod->wdebrisc, chtcount);
   wdebrisnV->put_rec(&resod->wdebrisn, chtcount);
-  dmosscV->put_rec(&resod->dmossc, chtcount);
-  dmossnV->put_rec(&resod->dmossn, chtcount);
   rawcV->put_rec(&resod->rawc[0], chtcount);
   somaV->put_rec(&resod->soma[0], chtcount);
   somprV->put_rec(&resod->sompr[0], chtcount);

--- a/src/output/RestartOutputer.h
+++ b/src/output/RestartOutputer.h
@@ -125,14 +125,12 @@ private:
   NcVar* frontFTV;
 
   NcVar* wdebriscV;
-  NcVar* dmosscV;
   NcVar* rawcV;
   NcVar* somaV;
   NcVar* somprV;
   NcVar* somcrV;
 
   NcVar* wdebrisnV;
-  NcVar* dmossnV;
   NcVar* solnV;
   NcVar* avlnV;
 

--- a/src/parallel-code/Master.cpp
+++ b/src/parallel-code/Master.cpp
@@ -329,8 +329,6 @@ void Master::write_cohort_record_to_restartnc_file(const NcFile & rfile, const R
   NcVar * frontFTV        = rfile.get_var("frontFT");    //freezing/thawing front
   NcVar * wdebriscV       = rfile.get_var("WDEBRISC");
   NcVar * wdebrisnV       = rfile.get_var("WDEBRISN");
-  NcVar * dmosscV         = rfile.get_var("DMOSSC");
-  NcVar * dmossnV         = rfile.get_var("DMOSSN");
   NcVar * rawcV           = rfile.get_var("RAWC");
   NcVar * somaV           = rfile.get_var("SOMA");
   NcVar * somprV          = rfile.get_var("SOMPR");
@@ -399,8 +397,6 @@ void Master::write_cohort_record_to_restartnc_file(const NcFile & rfile, const R
   frontFTV->put_rec(rd.frontFT , record);
   wdebriscV->put_rec(&rd.wdebrisc , record);
   wdebrisnV->put_rec(&rd.wdebrisn , record);
-  dmosscV->put_rec(&rd.dmossc , record);
-  dmossnV->put_rec(&rd.dmossn , record);
   rawcV->put_rec(rd.rawc , record);
   somaV->put_rec(rd.soma , record);
   somprV->put_rec(rd.sompr , record);
@@ -520,9 +516,6 @@ NcFile Master::setup_restartnc_file(int num_records){
   
   restartFile.add_var("WDEBRISC", ncDouble, chtD);
   restartFile.add_var("WDEBRISN", ncDouble, chtD);
-  
-  restartFile.add_var("DMOSSC", ncDouble, chtD);
-  restartFile.add_var("DMOSSN", ncDouble, chtD);
   
   restartFile.add_var("RAWC", ncDouble, chtD, soillayerD);
   restartFile.add_var("SOMA", ncDouble, chtD, soillayerD);

--- a/src/runmodule/Cohort.cpp
+++ b/src/runmodule/Cohort.cpp
@@ -1435,8 +1435,6 @@ void Cohort::set_restartdata_from_state() {
   //
   restartdata.wdebrisc = bdall->m_sois.wdebrisc;
   restartdata.wdebrisn = bdall->m_sois.wdebrisn;
-  restartdata.dmossc = bdall->m_sois.dmossc;
-  restartdata.dmossn = bdall->m_sois.dmossn;
 
   for(int il =0; il<cd.m_soil.numsl; il++) {
     restartdata.rawc[il]  = bdall->m_sois.rawc[il];

--- a/src/runmodule/Integrator.cpp
+++ b/src/runmodule/Integrator.cpp
@@ -124,8 +124,6 @@ Integrator::Integrator() {
 
   strcpy(predstr_soi[I_WDEBRISC],"WDEBRISC"); // wood debris C
   strcpy(predstr_soi[I_WDEBRISN],"WDEBRISN"); // wood debris N
-  strcpy(predstr_soi[I_DMOSSC],"DMOSSC"); // dead moss C
-  strcpy(predstr_soi[I_DMOSSN],"DMOSSN"); // dead moss N
 
   // soil C&N flux variables
   for(int il =0; il<MAX_SOI_LAY; il++) { //Yuan: here is the reason that the "temconst.h" is needed
@@ -147,7 +145,6 @@ Integrator::Integrator() {
   }
 
   strcpy(predstr_soi[I_RH_WD],"RHWD" ); //woody debris respiration
-  strcpy(predstr_soi[I_RH_DMOSS],"RHDMOSS" ); //dead moss respiration
   // Total Ecosystem N loss
   strcpy(predstr_soi[I_AVLNLOSS],"AVLNLOSS" ); //total inorganic nitrogen loss
   strcpy(predstr_soi[I_ORGNLOSS],"ORGNLOSS" ); //total organic nitrogen loss
@@ -171,7 +168,6 @@ void Integrator::setVegetation_Bgc(Vegetation_Bgc * vegp) {
 void Integrator::report_array(float array[]){
   BOOST_LOG_SEV(glg, debug)<<"Integrator report_array (incomplete):";
 
-  BOOST_LOG_SEV(glg, debug)<<"I_DMOSSC: "<<array[I_DMOSSC]<<" I_DMOSSN: "<<array[I_DMOSSN];
 
   for(int ii=0; ii<NUMEQ; ii++){
 
@@ -194,7 +190,6 @@ void Integrator::report_array(float array[]){
       ii++;
     }
   }
-  BOOST_LOG_SEV(glg, debug)<<"I_RH_DMOSS: "<<array[I_RH_DMOSS];
 }
 
 void Integrator::updateMonthlyVbgc() {
@@ -261,8 +256,6 @@ void Integrator::c2ystate_soi(float y[]) {
 
   y[I_WDEBRISC] = bd->m_sois.wdebrisc;
   y[I_WDEBRISN] = bd->m_sois.wdebrisn;
-  y[I_DMOSSC] = bd->m_sois.dmossc;
-  y[I_DMOSSN] = bd->m_sois.dmossn;
 };
 
 
@@ -478,8 +471,6 @@ void Integrator::y2cstate_soi(float y[]) {
 
   bd->m_sois.wdebrisc = y[I_WDEBRISC];
   bd->m_sois.wdebrisn = y[I_WDEBRISN];
-  bd->m_sois.dmossc   = y[I_DMOSSC];
-  bd->m_sois.dmossn   = y[I_DMOSSN];
 };
 
 void Integrator::y2cflux_veg(float y[]) {
@@ -513,8 +504,6 @@ void Integrator::y2cflux_soi(float y[]) {
   }
 
   bd->m_soi2a.rhwdeb   = y[I_RH_WD];
-  bd->m_soi2a.rhmossc  = y[I_RH_DMOSS];
-  //
   bd->m_soi2l.avlnlost = y[I_AVLNLOSS];
   bd->m_soi2l.orgnlost = y[I_ORGNLOSS];
 };
@@ -581,8 +570,6 @@ void Integrator::y2tcstate_soi(float pstate[]) {
 
   ssl->tmp_sois.wdebrisc= pstate[I_WDEBRISC];
   ssl->tmp_sois.wdebrisn= pstate[I_WDEBRISN];
-  ssl->tmp_sois.dmossc  = pstate[I_DMOSSC];
-  ssl->tmp_sois.dmossn  = pstate[I_DMOSSN];
 };
 
 // assign fluxes and state back to pdstate
@@ -609,8 +596,6 @@ void Integrator::dc2ystate_soi(float pdstate[]) {
 
   pdstate[I_WDEBRISC] = ssl->del_sois.wdebrisc;
   pdstate[I_WDEBRISN] = ssl->del_sois.wdebrisn;
-  pdstate[I_DMOSSC]   = ssl->del_sois.dmossc;
-  pdstate[I_DMOSSN]   = ssl->del_sois.dmossn;
 };
 
 void Integrator::dc2yflux_veg(float pdstate[]) {
@@ -643,7 +628,6 @@ void Integrator::dc2yflux_soi(float pdstate[]) {
   }
 
   pdstate[I_RH_WD]    = ssl->del_soi2a.rhwdeb;
-  pdstate[I_RH_DMOSS] = ssl->del_soi2a.rhmossc;
   pdstate[I_ORGNLOSS] = ssl->del_soi2l.orgnlost;
   pdstate[I_AVLNLOSS] = ssl->del_soi2l.avlnlost;
 
@@ -728,13 +712,6 @@ int Integrator::checkPools() {
       return I_WDEBRISN;
     }
 
-    if(ydum[I_DMOSSC]<0.) {
-      return I_DMOSSC;
-    }
-
-    if(ydum[I_DMOSSN]<0.) {
-      return I_DMOSSN;
-    }
   }
 
   return negativepool;
@@ -934,28 +911,10 @@ int Integrator::boundcon( float ptstate[], float err[], float& ptol ) {
       return test = soivarkey(I_WDEBRISN)+1;
     }
 
-    same = err[I_DMOSSC] - fabs( ptol * ptstate[I_DMOSSC]);
-
-    if (same>zero) {
-      return test = soivarkey(I_DMOSSN)+1;
-    }
-
-    same = err[I_DMOSSN] - fabs( ptol * ptstate[I_DMOSSN]);
-
-    if (same>zero) {
-      return test = soivarkey(I_DMOSSN)+1;
-    }
-
     same = err[I_RH_WD] - fabs( ptol * ptstate[I_RH_WD]);
 
     if (same>zero) {
       return test = soivarkey(I_RH_WD)+1;
-    }
-
-    same = err[I_RH_DMOSS] - fabs( ptol * ptstate[I_RH_DMOSS]);
-
-    if (same>zero) {
-      return test = soivarkey(I_RH_DMOSS)+1;
     }
 
     // soil N

--- a/src/runmodule/Integrator.h
+++ b/src/runmodule/Integrator.h
@@ -78,7 +78,6 @@ public :
     I_WDEBRISC= 6 * MAX_SOI_LAY, // because indexed from zero, so here
                                  // is the sum of all above
     I_WDEBRISN,
-    I_DMOSSC, I_DMOSSN,
 
     I_L_RH_RAW  = NUM_SOI_STATE,
     I_L_RH_SOMA = NUM_SOI_STATE + MAX_SOI_LAY,
@@ -90,7 +89,6 @@ public :
 
     I_RH_WD = NUM_SOI_STATE + 6 * MAX_SOI_LAY, // Because indexed from zero,
                                              // so here is the sum of all above
-    I_RH_DMOSS,
 
     I_ORGNLOSS, I_AVLNLOSS
 

--- a/src/runmodule/OutRetrive.cpp
+++ b/src/runmodule/OutRetrive.cpp
@@ -710,8 +710,6 @@ void OutRetrive::updateRestartOutputBuffer() {
   //
   resod->wdebrisc = bdall->m_sois.wdebrisc;
   resod->wdebrisn = bdall->m_sois.wdebrisn;
-  resod->dmossc = bdall->m_sois.dmossc;
-  resod->dmossn = bdall->m_sois.dmossn;
 
   for(int il =0; il<cd->m_soil.numsl; il++) {
     resod->rawc[il]  = bdall->m_sois.rawc[il];

--- a/src/snowsoil/Richards.cpp
+++ b/src/snowsoil/Richards.cpp
@@ -68,9 +68,9 @@ void Richards::update(Layer *fstsoill, Layer* bdrainl,
   // in a soil profile, there may be a few or none
   Layer* currl=fstsoill;
 
-  // excluding dead moss layer(s) for hydrological process due to
-  // hydraulic parameters not validated, which causes oscilation
-  // if no exclusion of dead moss layer, comment out this 'while' loop
+  // excluding moss layer(s) for hydrological process due to
+  // hydraulic parameters not validated, which causes oscillation
+  // if no exclusion of moss layer, comment out this 'while' loop
   while (currl != NULL && currl->isMoss) {
     currl = currl->nextl;
   }
@@ -157,7 +157,7 @@ void Richards::update(Layer *fstsoill, Layer* bdrainl,
     }
   } // end of whole soil layers loop for unfrozen column sections
 
-  // for layers above 'topsoill', e.g., 'dead moss',
+  // for layers above 'topsoill', e.g., 'moss',
   // if excluded from hydrological process
   currl = topsoill->prevl;
 

--- a/src/snowsoil/Soil_Env.cpp
+++ b/src/snowsoil/Soil_Env.cpp
@@ -444,10 +444,10 @@ void Soil_Env::retrieveDailyFronts() {
     ed->d_sois.frontstype[il]= ground->frontstype[il];
   }
 
-  // determine the deepth of daily active layer depth (seasonal or permafrost)
+  // determine the depth of daily active layer depth (seasonal or permafrost)
   ed->d_soid.ald = MISSING_D;
 
-  for (int il =0; il<MAX_NUM_FNT; il++) {
+  for (int il=0; il<MAX_NUM_FNT; il++) {
     if (il==0 && ed->d_soid.unfrzcolumn<=0.) {
       ed->d_soid.ald = 0.;
       break;
@@ -462,7 +462,7 @@ void Soil_Env::retrieveDailyFronts() {
     }
   }
 
-  // determine the top deepth of daily active layer (seasonal)
+  // determine the daily thaw depth 
   ed->d_soid.alc = 0.;
 
   for (int il =0; il<MAX_NUM_FNT; il++) {


### PR DESCRIPTION
Dead moss is not scientifically differentiable from the fibric
layer. This commit removes the implementation of the dead moss
layer and forces moss mortality to be transferred to the fibric
layer.

The plotting scripts (calibration-viewer.py and diagnostics.py) are
also updated to remove dead moss references.