### PR TITLE
Switches call from deprecated function to renamed function.

### DIFF
--- a/src/TEMUtilityFunctions.cpp
+++ b/src/TEMUtilityFunctions.cpp
@@ -215,7 +215,7 @@ namespace temutil {
 
     if ( !parsingSuccessful ) {
         BOOST_LOG_SEV(glg, fatal) << "Failed to parse configuration file: " << filepath;
-        BOOST_LOG_SEV(glg, fatal) << reader.getFormatedErrorMessages();
+        BOOST_LOG_SEV(glg, fatal) << reader.getFormattedErrorMessages();
         exit(-1);
     }
 


### PR DESCRIPTION
On a clean Fedora 25 install, Dec 2016, with the packages listed
in bootstrap-system.sh, attempting to compile results in an
error that 'Json::Reader::getFormatedErrorMessages() const' is
deprecated, and that 'Json::Reader::getFormattedErrorMessages()'
should be used instead. This commit switches the function call,
and successfully builds.