### PR TITLE
Revert "Switches call from deprecated function to renamed function."

### DIFF
--- a/src/TEMUtilityFunctions.cpp
+++ b/src/TEMUtilityFunctions.cpp
@@ -215,7 +215,7 @@ namespace temutil {
 
     if ( !parsingSuccessful ) {
         BOOST_LOG_SEV(glg, fatal) << "Failed to parse configuration file: " << filepath;
-        BOOST_LOG_SEV(glg, fatal) << reader.getFormattedErrorMessages();
+        BOOST_LOG_SEV(glg, fatal) << reader.getFormatedErrorMessages();
         exit(-1);
     }
 


### PR DESCRIPTION
Reverts ua-snap/dvm-dos-tem#247

Atlas's version of JSON::Reader does not have the renamed function.