### PR TITLE
add snippet to create output directory if it doesn;t exist.

### DIFF
--- a/src/TEM.cpp
+++ b/src/TEM.cpp
@@ -196,6 +196,11 @@ int main(int argc, char* argv[]){
   int num_cols = run_mask[0].size();
 
   // Create empty restart files for all stages based on size of run mask
+  if (!boost::filesystem::exists(modeldata.output_dir)) {
+    BOOST_LOG_SEV(glg, info) << "Creating output directory as specified in "
+                             << "config file: ", modeldata.output_dir;
+    boost::filesystem::create_directory(modeldata.output_dir);
+  }
   RestartData::create_empty_file(eq_restart_fname, num_rows, num_cols);
   RestartData::create_empty_file(sp_restart_fname, num_rows, num_cols);
   RestartData::create_empty_file(tr_restart_fname, num_rows, num_cols);


### PR DESCRIPTION
This has been a nagging problem: user pull updates from dvmdostem, tries
new dataset and the model won;t run, complaining about missing files.
Turns out that when creating new NetCDF files for the restart files, the
operation will succeed if the directory exists, but if the directory doesn't
exist, then it will fail to create the files. We always forget about it
because usually once you create the directory once, the problem goes away.