### PR TITLE
Improve output viewer

### DIFF
--- a/bootstrap-system.sh
+++ b/bootstrap-system.sh
@@ -26,7 +26,7 @@ yum install -y hdf5-openmpi-devel
 yum install -y xauth
 
 # packages used for plotting
-yum install -y python-matplotlib python-matplotlib-wx netcdf4-python python-ipython
+yum install -y python-matplotlib python-matplotlib-wx netcdf4-python python-ipython python-jinja2
 
 # For processing/preparing the "new style" inputs
 yum install -y gdal gdal-devel

--- a/scripts/generate-html-viewer.py
+++ b/scripts/generate-html-viewer.py
@@ -93,6 +93,8 @@ def NEW_template():
   dm : dict
     A dict mapping 'categories' to lists of image
     paths (one list for each column).
+  titles : dict
+    A dict mapping columns (L, C, R) to title text.
 
   Returns
   -------
@@ -133,6 +135,22 @@ def NEW_template():
         <script src="https://oss.maxcdn.com/html5shiv/3.7.3/html5shiv.min.js"></script>
         <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
       <![endif]-->
+
+      <style type="text/css">
+
+        .fixed-column-headerbox {
+          padding: 5px;
+          margin: 4px;
+          border: 1px solid gray;
+          background-color: yellow;
+
+        }
+
+        .main-data-area {
+          margin-top: 50px;
+        }
+
+      </style>
     </head>
     <body>
       <div class="container-fluid">
@@ -149,13 +167,19 @@ def NEW_template():
         <div class="row">
           <div class="panel-group">
             <div class="panel panel-default">
-              <div class="panel-heading">
-                <h4 class="panel-title">
-                  <a data-toggle="collapse" href="#collapse-{{ column }}-{{ category }}">{{ category }}</a>
-                </h4>
+
+              <div class="panel-heading clearfix">
+                  {% for column, paths in col2imglistmap.iteritems() %}
+                    <div class="col-sm-4">
+                      <h4 class="panel-title">
+                      <a data-toggle="collapse" href="#collapse-{{ category }}">{{ category }}</a>
+                      </h4>
+                    </div>
+                  {% endfor %}
               </div>
-              <div id="collapse-{{ column }}-{{ category }}" class="panel-collapse collapse">
-                {% for column, paths in imglists.iteritems() %}
+
+              <div id="collapse-{{ category }}" class="panel-collapse collapse">
+                {% for column, paths in col2imglistmap.iteritems() %}
                 <div class="col-sm-4">
                   <ul class="list-group">
                     {% for image in paths %}
@@ -167,6 +191,7 @@ def NEW_template():
                 </div>
                 {% endfor %}
               </div>
+
             </div>
           </div>
         </div>

--- a/scripts/generate-html-viewer.py
+++ b/scripts/generate-html-viewer.py
@@ -265,14 +265,16 @@ def build_new_page(left_path, center_path, right_path, autoshow=False):
       return tokens[-1]
 
   def build_full_image_list(path, depth=None):
-    path = os.path.normpath(path)
     images, pdfs, pngs = [], [], []
-    for root, dirs, files in walkdepth(path, depth=depth):
-      pdfs += [os.path.join(root, filename) for filename in fnmatch.filter(files, "*.pdf")]
-      pngs += [os.path.join(root, filename) for filename in fnmatch.filter(files, "*.png")]
+    if path == "" or path == None:
+      pass # Nothing to do with an empty path...
+    else:
+      path = os.path.normpath(path)
+      for root, dirs, files in walkdepth(path, depth=depth):
+        pdfs += [os.path.join(root, filename) for filename in fnmatch.filter(files, "*.pdf")]
+        pngs += [os.path.join(root, filename) for filename in fnmatch.filter(files, "*.png")]
 
     print "%s" % path
-    print "=" * len(path)
     print "  pdfs: %8i" % len(pdfs)
     print "  pngs: %8i" % len(pngs)
     print ""

--- a/scripts/generate-html-viewer.py
+++ b/scripts/generate-html-viewer.py
@@ -8,7 +8,7 @@
 import fnmatch
 import os
 import collections
-
+import webbrowser
 import argparse
 import textwrap
 import glob
@@ -205,7 +205,7 @@ def NEW_template():
   '''))
 
 
-def build_new_page(left_path, center_path, right_path):
+def build_new_page(left_path, center_path, right_path, autoshow=False):
   # Unused...
   # def build_list_imgs_in_category(category, image_list):
   #   list_of_imgs_in_category = []
@@ -265,9 +265,10 @@ def build_new_page(left_path, center_path, right_path):
       pngs += [os.path.join(root, filename) for filename in fnmatch.filter(files, "*.png")]
 
     print "%s" % path
-    print "_" * len(path)
-    print "pdfs: %8i" % len(pdfs)
-    print "pngs: %8i" % len(pngs)
+    print "=" * len(path)
+    print "  pdfs: %8i" % len(pdfs)
+    print "  pngs: %8i" % len(pngs)
+    print ""
     images = pdfs + pngs
 
     return images
@@ -280,6 +281,8 @@ def build_new_page(left_path, center_path, right_path):
   # Figure out what rows we need - one row for every category, that shows up in 
   # any of the three lists.
   categories = set(map(classify, left_img_list+center_img_list+right_img_list))
+  print "Found %i categories: %s" % (len(categories), ' '.join(categories))
+  print ""
 
   # Build up this dict mapping 'categories' of plots to lists of file paths
   # for each column that can be passed to the template...
@@ -295,12 +298,19 @@ def build_new_page(left_path, center_path, right_path):
     'R':right_path,
   }
 
+
   ns = NEW_template().render(dm=dm, titles=titles)
- 
-  with open("NEWthree-view.html", 'w') as f:
+
+  newFileName = "output-view.html"
+  with open(newFileName, 'w') as f:
     f.write( ns )
 
-  from IPython import embed; embed() 
+  print "Created file: %s" % (newFileName)
+  print "Open this file in a web-browser: file://%s" % (os.path.join(os.getcwd(), newFileName)) 
+  if autoshow:
+    print "Trying to auto-show in browser (doesn't work on all platforms)..."
+    webbrowser.open("file://{}".format(os.path.join(os.getcwd(), newFileName)), new=0, autoraise=True)
+  print ""
 
 
 
@@ -420,8 +430,13 @@ if __name__ == '__main__':
   parser.add_argument('-r', '--right', metavar='',
     help=textwrap.dedent('''A path to a directory of files for the right column'''))
 
+  parser.add_argument('--show', action='store_true',
+    help=textwrap.dedent('''Attempt to open the resulting page in a web-browser
+      tab. Might not work on all platforms. If the browser does not pop up with
+      the new page loaded, then copy/paste the provided URL into a browser.'''))
+
   parser.add_argument('--display-method', nargs=1, default=["img"], choices=['img', 'object/embed'],
-    help=textwrap.dedent('''Which method to use to display the pdfs.'''))
+    help=textwrap.dedent('''Deprecated. Which method to use to display the pdfs.'''))
 
   parser.add_argument('--create-bundle', default=None,
     help=textwrap.dedent('''Create a self-contained bundle with the generated
@@ -440,7 +455,7 @@ if __name__ == '__main__':
   if args.version_1_output:
     generate_version_1_html(args)
 
-  build_new_page(args.left, args.center, args.right)
+  build_new_page(args.left, args.center, args.right, autoshow=args.show)
 
   if args.create_bundle:
     print "NOT IMPLEMENTED YET..."

--- a/scripts/generate-html-viewer.py
+++ b/scripts/generate-html-viewer.py
@@ -145,16 +145,16 @@ def NEW_template():
       <div class="container-fluid">
         {% for category, imglists in dm.iteritems() %}
         <div class="row">
-          {% for column, paths in imglists.iteritems() %}
-          <div class="col-sm-4">
-            <div class="panel-group">
-              <div class="panel panel-default">
-                <div class="panel-heading">
-                  <h4 class="panel-title">
-                    <a data-toggle="collapse" href="#collapse-{{ column }}-{{ category }}">{{ category }}</a>
-                  </h4>
-                </div>
-                <div id="collapse-{{ column }}-{{ category }}" class="panel-collapse collapse">
+          <div class="panel-group">
+            <div class="panel panel-default">
+              <div class="panel-heading">
+                <h4 class="panel-title">
+                  <a data-toggle="collapse" href="#collapse-{{ column }}-{{ category }}">{{ category }}</a>
+                </h4>
+              </div>
+              <div id="collapse-{{ column }}-{{ category }}" class="panel-collapse collapse">
+                {% for column, paths in imglists.iteritems() %}
+                <div class="col-sm-4">
                   <ul class="list-group">
                     {% for image in paths %}
                     <li class="list-group-item">
@@ -163,10 +163,10 @@ def NEW_template():
                     {% endfor %}
                   </ul>
                 </div>
+                {% endfor %}
               </div>
             </div>
           </div>
-          {% endfor %}
         </div>
         {% endfor %}
       </div>

--- a/scripts/generate-html-viewer.py
+++ b/scripts/generate-html-viewer.py
@@ -135,15 +135,17 @@ def NEW_template():
       <![endif]-->
     </head>
     <body>
+      <div class="container-fluid">
       <div class="navbar-fixed-top">
         <div class="row">
-          <div class="col-sm-4">Left title</div>
-          <div class="col-sm-4">center title</div>
-          <div class="col-sm-4">right title</div>
+          <div class="col-sm-4"><div class="fixed-column-headerbox">{{ titles.L }}</div></div>
+          <div class="col-sm-4"><div class="fixed-column-headerbox">{{ titles.C }}</div></div>
+          <div class="col-sm-4"><div class="fixed-column-headerbox">{{ titles.R }}</div></div>
         </div>
       </div>
-      <div class="container-fluid">
-        {% for category, imglists in dm.iteritems() %}
+      </div>
+      <div class="container-fluid main-data-area">
+        {% for category, col2imglistmap in dm.iteritems() %}
         <div class="row">
           <div class="panel-group">
             <div class="panel panel-default">
@@ -203,8 +205,8 @@ def build_new_page(left_path, center_path, right_path):
 
   # Find all the images in the left, center and right paths/trees - recursive!!
   left_img_list = build_full_image_list(args.left)
-  right_img_list = build_full_image_list(args.right)
   center_img_list = build_full_image_list(args.center)
+  right_img_list = build_full_image_list(args.right)
 
   # Figure out what rows we need
   categories = set(map(classify, left_img_list+center_img_list+right_img_list))
@@ -217,7 +219,14 @@ def build_new_page(left_path, center_path, right_path):
     for col, il in zip(['L','C','R'], (left_img_list, center_img_list, right_img_list)):
       dm[cat][col] = [p for p in il if classify(p)==cat]
 
-  ns = NEW_template().render(dm=dm)
+  titles = {
+    'L':left_path,
+    'C':center_path,
+    'R':right_path,
+  }
+
+
+  ns = NEW_template().render(dm=dm, titles=titles)
  
   with open("NEWthree-view.html", 'w') as f:
     f.write( ns )

--- a/scripts/generate-html-viewer.py
+++ b/scripts/generate-html-viewer.py
@@ -423,6 +423,12 @@ if __name__ == '__main__':
   parser.add_argument('--display-method', nargs=1, default=["img"], choices=['img', 'object/embed'],
     help=textwrap.dedent('''Which method to use to display the pdfs.'''))
 
+  parser.add_argument('--create-bundle', default=None,
+    help=textwrap.dedent('''Create a self-contained bundle with the generated
+    HTML file all the data and found in the --left, --center, and --right 
+    locations. The HTML file will use relative paths, so assuming the bundle
+    is not modified, the viewer should work.'''))
+
   parser.add_argument('--version-1-output', action='store_true', 
     help=textwrap.dedent('''Generate the first version of html page. Writes
     a file static HTML page, 'three-view.html', that attempts to display all
@@ -435,6 +441,9 @@ if __name__ == '__main__':
     generate_version_1_html(args)
 
   build_new_page(args.left, args.center, args.right)
+
+  if args.create_bundle:
+    print "NOT IMPLEMENTED YET..."
 
 
 

--- a/scripts/generate-html-viewer.py
+++ b/scripts/generate-html-viewer.py
@@ -7,6 +7,7 @@
 
 import fnmatch
 import os
+import collections
 
 import argparse
 import textwrap
@@ -240,7 +241,7 @@ def build_new_page(left_path, center_path, right_path):
   # for each column that can be passed to the template...
   dm = {}
   for cat in categories:
-    dm[cat] = {}
+    dm[cat] = collections.OrderedDict()
     for col, il in zip(['L','C','R'], (left_img_list, center_img_list, right_img_list)):
       dm[cat][col] = [p for p in il if classify(p)==cat]
 

--- a/scripts/generate-html-viewer.py
+++ b/scripts/generate-html-viewer.py
@@ -359,6 +359,29 @@ def generate_page(left_img_list=[], center_img_list=[], right_img_list=[], title
       ))
   return page
 
+def generate_version_1_html(args):
+  LEFT = sorted(glob.glob("%s/*.pdf" % (args.left)))
+  CENTER = sorted(glob.glob("%s/*.pdf" % (args.center)))
+  RIGHT = sorted(glob.glob("%s/*.pdf" % (args.right)))
+  titlelist = (args.left, args.center, args.right)
+
+
+  # unused??
+  def build_list_imgs_in_category(category, image_list):
+    list_of_imgs_in_category = []
+    for image in image_list:
+      print classify(image)
+      if classify(image) == category:
+        list_of_imgs_in_category.append(image)
+
+    return list_of_imgs_in_category
+
+
+  with open("three-view.html", 'w') as f:
+    f.write( generate_page(LEFT, CENTER, RIGHT, titlelist, tag_type=args.display_method[0]) )
+
+
+
 if __name__ == '__main__':
 
   parser = argparse.ArgumentParser(
@@ -383,31 +406,18 @@ if __name__ == '__main__':
   parser.add_argument('--display-method', nargs=1, default=["img"], choices=['img', 'object/embed'],
     help=textwrap.dedent('''Which method to use to display the pdfs.'''))
 
+  parser.add_argument('--version-1-output', action='store_true', 
+    help=textwrap.dedent('''Generate the first version of html page. Writes
+    a file static HTML page, 'three-view.html', that attempts to display all
+    .pdf images in the --left, --right and --center directories.'''))
+
   args = parser.parse_args()
   print args
 
+  if args.version_1_output:
+    generate_version_1_html(args)
 
   build_new_page(args.left, args.center, args.right)
-  exit()
 
-  LEFT = sorted(glob.glob("%s/*.pdf" % (args.left)))
-  CENTER = sorted(glob.glob("%s/*.pdf" % (args.center)))
-  RIGHT = sorted(glob.glob("%s/*.pdf" % (args.right)))
-  titlelist = (args.left, args.center, args.right)
-
-
-  # unused??
-  def build_list_imgs_in_category(category, image_list):
-    list_of_imgs_in_category = []
-    for image in image_list:
-      print classify(image)
-      if classify(image) == category:
-        list_of_imgs_in_category.append(image)
-
-    return list_of_imgs_in_category
-
-
-  with open("three-view.html", 'w') as f:
-    f.write( generate_page(LEFT, CENTER, RIGHT, titlelist, tag_type=args.display_method[0]) )
 
 

--- a/scripts/generate-html-viewer.py
+++ b/scripts/generate-html-viewer.py
@@ -140,6 +140,13 @@ def NEW_template():
         <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
       <![endif]-->
 
+      <script>
+        !window.jQuery && alert("This page won't work properly without " + 
+          "jQuery and Boostrap, which are loaded from a Content Delivery " +
+          "Network, and cached locally. Try again when you are conncected to " +
+          "the internet.");
+      </script>
+
       <style type="text/css">
 
         .fixed-column-headerbox {

--- a/scripts/generate-html-viewer.py
+++ b/scripts/generate-html-viewer.py
@@ -89,8 +89,11 @@ def generate_head_tag():
 
 def NEW_template():
   '''
-  Parameters that must be passed to render(...)
-  ---------------------------------------------
+  Returns a jinja2 template instance. To use the template instance, 
+  call template.render(...)
+
+  Parameters that must be passed to template.render(...)
+  -------------------------------------------------------
   dm : dict
     A dict mapping 'categories' to lists of image
     paths (one list for each column).
@@ -227,9 +230,13 @@ def build_new_page(left_path, center_path, right_path):
         del dirs[:]
 
   def classify(filepath):
-    '''Attempts to 'classify' a file based on the underscore seperated fields.
+    '''
+    Attempts to 'classify' a file based on the underscore seperated fields.
     Expects a file name something like:
-      "sometag_Vegetation_pft0.png" or "_histo_pestplot.png"
+        "sometag_Vegetation_pft0.png"
+        "_histo_pestplot.png"
+    The category is the last field before the file-name extension, unless the 
+    last field containes pft, in which case, the seconds to last field is used.
 
     Parameters
     ----------
@@ -257,7 +264,12 @@ def build_new_page(left_path, center_path, right_path):
       pdfs += [os.path.join(root, filename) for filename in fnmatch.filter(files, "*.pdf")]
       pngs += [os.path.join(root, filename) for filename in fnmatch.filter(files, "*.png")]
 
+    print "%s" % path
+    print "_" * len(path)
+    print "pdfs: %8i" % len(pdfs)
+    print "pngs: %8i" % len(pngs)
     images = pdfs + pngs
+
     return images
 
   # Find all the images in the left, center and right paths/trees - recursive!!
@@ -265,7 +277,8 @@ def build_new_page(left_path, center_path, right_path):
   center_img_list = build_full_image_list(args.center, depth=1)
   right_img_list = build_full_image_list(args.right, depth=1)
 
-  # Figure out what rows we need
+  # Figure out what rows we need - one row for every category, that shows up in 
+  # any of the three lists.
   categories = set(map(classify, left_img_list+center_img_list+right_img_list))
 
   # Build up this dict mapping 'categories' of plots to lists of file paths
@@ -281,7 +294,6 @@ def build_new_page(left_path, center_path, right_path):
     'C':center_path,
     'R':right_path,
   }
-
 
   ns = NEW_template().render(dm=dm, titles=titles)
  
@@ -388,9 +400,14 @@ if __name__ == '__main__':
     #formatter_class=argparse.RawDescriptionHelpFormatter,
     formatter_class=argparse.ArgumentDefaultsHelpFormatter,
     description=textwrap.dedent('''
-      Generate an HTML page for looking at sets of dvmdostem \
-      calibraiton plots side by side. Open the resulting .html file
-      in a webbrowser to see the plots.
+      Generate an HTML page with a 3-column layout for looking at sets of 
+      dvmdostem output plots side by side. 
+
+      The resulting three column page has a collapsible row for each "category"
+      of images found in the directories provided with the --left, --center, 
+      and --right arguments.
+
+      Open the resulting .html file in a web-browser to see the plots.
     ''')
   )
 
@@ -412,7 +429,7 @@ if __name__ == '__main__':
     .pdf images in the --left, --right and --center directories.'''))
 
   args = parser.parse_args()
-  print args
+  #print args
 
   if args.version_1_output:
     generate_version_1_html(args)


### PR DESCRIPTION
Re-work the output viewer. Now uses some more modern HTML stuff to allow for responsive page layout, and collapsible rows. 

Fixes a few issues, the main one being that previously, if you had mis-matched image lists in the different directories, then the viewer was more or less useless as the plots would not line up across the columns. Now the images are sorted by "category" and displayed in collapsible rows, so if there is a mis-match in image lists, it doesn't break the whole layout.