### PR TITLE
Fix bug runmask util

### DIFF
--- a/scripts/runmask-util.py
+++ b/scripts/runmask-util.py
@@ -29,8 +29,8 @@ if __name__ == '__main__':
   parser.add_argument('--reset', action='store_true', 
       help=textwrap.dedent('''Set all pixels to zero (don't run).'''))
 
-  parser.add_argument("--xy", nargs=2,
-  		help=textwrap.dedent('''The x, y position of the pixel to turn on.'''))
+  parser.add_argument("--xy", nargs=2, type=int,
+      help=textwrap.dedent('''The x, y position of the pixel to turn on.'''))
 
   parser.add_argument("--show", action='store_true',
       help=textwrap.dedent('''Print the mask after modification.'''))

--- a/scripts/runmask-util.py
+++ b/scripts/runmask-util.py
@@ -18,9 +18,9 @@ def show_mask(file, note):
 if __name__ == '__main__':
 
   parser = argparse.ArgumentParser(
-	  formatter_class=argparse.RawDescriptionHelpFormatter,
- 		description=textwrap.dedent('''
-    	Helper script for modifying a dvm-dos-tem runmask netcdf file.
+    formatter_class=argparse.RawDescriptionHelpFormatter,
+    description=textwrap.dedent('''
+      Helper script for modifying a dvm-dos-tem runmask netcdf file.
     ''')
   )
   parser.add_argument('file', metavar=('file'), 
@@ -33,23 +33,23 @@ if __name__ == '__main__':
   		help=textwrap.dedent('''The x, y position of the pixel to turn on.'''))
 
   parser.add_argument("--show", action='store_true',
-  		help=textwrap.dedent('''Print the mask after modification.'''))
+      help=textwrap.dedent('''Print the mask after modification.'''))
 
   args = parser.parse_args()
 
   if args.show:
-  	show_mask(args.file, "BEFORE")
+    show_mask(args.file, "BEFORE")
 
   with nc.Dataset(args.file, 'a') as mask:
 
-	  if args.reset:
-	  	print "Setting all pixels in runmask to '0' (OFF)."
-	  	mask.variables['run'][:] = 0
+    if args.reset:
+      print "Setting all pixels in runmask to '0' (OFF)."
+      mask.variables['run'][:] = 0
 
-	  if args.xy:
-	  	X,Y = args.xy
-	  	print "Turning pixel(x,y) to '1', (ON)."
-	  	mask.variables['run'][X,Y] = 1
+    if args.xy:
+      X,Y = args.xy
+      print "Turning pixel(x,y) to '1', (ON)."
+      mask.variables['run'][X,Y] = 1
 
   # Show the after state
   if args.show:


### PR DESCRIPTION
Adds type specification to command line argument. without this the script fails with some versions of `netCDF4` library.