### PR TITLE
Implement open mp

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -110,6 +110,14 @@ if platform_name == 'Linux':
 
 
 elif platform_name == 'Darwin':
+ 
+  # See ua-snap/dvm-dos-tem PR #300 for discussion
+  if(USEOMP):
+    print "%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%"
+    print "NOTE: OpenMP not working on OSX! Reverting to serial build...."
+    print "%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%"
+    print ""
+    USEOMP = False
 
   # On OSX, using Homebrew, alternate g++ versions are installed so as not
   # to interfere with the system g++, so here, we have to set the compiler

--- a/SConstruct
+++ b/SConstruct
@@ -7,7 +7,7 @@ import platform
 import distutils.spawn
 import subprocess
 
-USEOMP = True
+USEOMP = False
 USEMPI = False
 
 libs = Split("""jsoncpp

--- a/SConstruct
+++ b/SConstruct
@@ -7,6 +7,7 @@ import platform
 import distutils.spawn
 import subprocess
 
+USEOMP = True
 USEMPI = False
 
 libs = Split("""jsoncpp
@@ -155,6 +156,10 @@ if comp_name == 'atlas.snap.uaf.edu':
   platform_library_path.insert(0, '/home/UA/tcarman2/boost_1_55_0/stage/lib')
 
 
+if(USEOMP):
+  #append build flag for openmp
+  compiler_flags = compiler_flags + ' -fopenmp'
+
 # Modify setup for MPI, if necessary
 if(USEMPI):
   compiler = distutils.spawn.find_executable('mpic++')
@@ -186,5 +191,6 @@ object_list = Object(src_files, CXX=compiler, CPPPATH=platform_include_path,
 #object_file_list = [os.path.basename(str(object)) for object in object_list]
 
 Program('dvmdostem', object_list, CXX=compiler, CPPPATH=local_include_paths,
-        LIBS=platform_libs, LIBPATH=platform_library_path)
+        LIBS=platform_libs, LIBPATH=platform_library_path, 
+        LINKFLAGS="-fopenmp")
 #Library()

--- a/scripts/compare_nc_output.sh
+++ b/scripts/compare_nc_output.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+#This script requires nccmp, found at http://nccmp.sourceforge.net/
+
+input_dirA=$1
+input_dirB=$2
+
+for file in $input_dirA/*.nc; do
+
+  filename=${file##*/}
+  echo $filename
+
+  nccmp -d "${input_dirA}/${filename}" "${input_dirB}/${filename}"
+
+done #for each file
+
+

--- a/src/Runner.cpp
+++ b/src/Runner.cpp
@@ -866,16 +866,24 @@ void Runner::output_debug_daily_drivers(int iy, boost::filesystem::path p) {
 
 
 void Runner::output_netCDF_monthly(int year, int month, std::string stage){
-  BOOST_LOG_SEV(glg, debug)<<"NetCDF monthly output, year: "<<year<<" month: "<<month;
-  output_netCDF(md.monthly_netcdf_outputs, year, month, stage);
-
-  BOOST_LOG_SEV(glg, debug)<<"Outputting accumulated daily data on the monthly timestep";
-  output_netCDF(md.daily_netcdf_outputs, year, month, stage);
+  #pragma omp critical(NetCDFmonthly)
+  {
+    BOOST_LOG_SEV(glg, debug)<<"NetCDF monthly output, year: "<<year<<" month: "<<month;
+    output_netCDF(md.monthly_netcdf_outputs, year, month, stage);
+  }
+  #pragma omp critical(NetCDFdaily)
+  {
+    BOOST_LOG_SEV(glg, debug)<<"Outputting accumulated daily data on the monthly timestep";
+    output_netCDF(md.daily_netcdf_outputs, year, month, stage);
+  }
 }
 
 void Runner::output_netCDF_yearly(int year, std::string stage){
-  BOOST_LOG_SEV(glg, debug)<<"NetCDF yearly output, year: "<<year;
-  output_netCDF(md.yearly_netcdf_outputs, year, 0, stage);
+  #pragma omp critical(NetCDFyearly)
+  {
+    BOOST_LOG_SEV(glg, debug)<<"NetCDF yearly output, year: "<<year;
+    output_netCDF(md.yearly_netcdf_outputs, year, 0, stage);
+  }
 }
 
 void Runner::output_netCDF(std::map<std::string, output_spec> &netcdf_outputs, int year, int month, std::string stage){

--- a/src/Runner.cpp
+++ b/src/Runner.cpp
@@ -866,24 +866,16 @@ void Runner::output_debug_daily_drivers(int iy, boost::filesystem::path p) {
 
 
 void Runner::output_netCDF_monthly(int year, int month, std::string stage){
-  #pragma omp critical(NetCDFmonthly)
-  {
     BOOST_LOG_SEV(glg, debug)<<"NetCDF monthly output, year: "<<year<<" month: "<<month;
     output_netCDF(md.monthly_netcdf_outputs, year, month, stage);
-  }
-  #pragma omp critical(NetCDFdaily)
-  {
+
     BOOST_LOG_SEV(glg, debug)<<"Outputting accumulated daily data on the monthly timestep";
     output_netCDF(md.daily_netcdf_outputs, year, month, stage);
-  }
 }
 
 void Runner::output_netCDF_yearly(int year, std::string stage){
-  #pragma omp critical(NetCDFyearly)
-  {
     BOOST_LOG_SEV(glg, debug)<<"NetCDF yearly output, year: "<<year;
     output_netCDF(md.yearly_netcdf_outputs, year, 0, stage);
-  }
 }
 
 void Runner::output_netCDF(std::map<std::string, output_spec> &netcdf_outputs, int year, int month, std::string stage){
@@ -1001,12 +993,15 @@ void Runner::output_netCDF(std::map<std::string, output_spec> &netcdf_outputs, i
     curr_spec = map_itr->second;
     curr_filename = curr_spec.file_path + curr_spec.filename_prefix + file_stage_suffix;
 
-    temutil::nc( nc_open(curr_filename.c_str(), NC_WRITE, &ncid) );
-    temutil::nc( nc_inq_varid(ncid, "ALD", &cv) );
-    start3[0] = year;
+    #pragma omp critical(outputALD)
+    {
+      temutil::nc( nc_open(curr_filename.c_str(), NC_WRITE, &ncid) );
+      temutil::nc( nc_inq_varid(ncid, "ALD", &cv) );
+      start3[0] = year;
 
-    temutil::nc( nc_put_var1_double(ncid, cv, start3, &cohort.edall->y_soid.ald) );
-    temutil::nc( nc_close(ncid) );
+      temutil::nc( nc_put_var1_double(ncid, cv, start3, &cohort.edall->y_soid.ald) );
+      temutil::nc( nc_close(ncid) );
+    }//end critical(outputALD)
   }//end ALD
   map_itr = netcdf_outputs.end();
 
@@ -1017,21 +1012,24 @@ void Runner::output_netCDF(std::map<std::string, output_spec> &netcdf_outputs, i
     curr_spec = map_itr->second;
     curr_filename = curr_spec.file_path + curr_spec.filename_prefix + file_stage_suffix;
 
-    temutil::nc( nc_open(curr_filename.c_str(), NC_WRITE, &ncid) );
-    temutil::nc( nc_inq_varid(ncid, "DEEPDZ", &cv) );
-    start3[0] = year;
+    #pragma omp critical(outputDEEPDZ)
+    {
+      temutil::nc( nc_open(curr_filename.c_str(), NC_WRITE, &ncid) );
+      temutil::nc( nc_inq_varid(ncid, "DEEPDZ", &cv) );
+      start3[0] = year;
 
-    double deepdz = 0;
-    Layer* currL = cohort.ground.toplayer;
-    while(currL!=NULL){
-      if(currL->isHumic){
-        deepdz += currL->dz;
+      double deepdz = 0;
+      Layer* currL = cohort.ground.toplayer;
+      while(currL!=NULL){
+        if(currL->isHumic){
+          deepdz += currL->dz;
+        }
+        currL = currL->nextl;
       }
-      currL = currL->nextl;
-    }
 
-    temutil::nc( nc_put_var1_double(ncid, cv, start3, &deepdz) );
-    temutil::nc( nc_close(ncid) );
+      temutil::nc( nc_put_var1_double(ncid, cv, start3, &deepdz) );
+      temutil::nc( nc_close(ncid) );
+    }//end critical(outputDEEPDZ)
   }//end DEEPDZ
   map_itr = netcdf_outputs.end();
 
@@ -1042,14 +1040,17 @@ void Runner::output_netCDF(std::map<std::string, output_spec> &netcdf_outputs, i
     curr_spec = map_itr->second;
     curr_filename = curr_spec.file_path + curr_spec.filename_prefix + file_stage_suffix;
 
-    temutil::nc( nc_open(curr_filename.c_str(), NC_WRITE, &ncid) );
-    temutil::nc( nc_inq_varid(ncid, "GROWEND", &cv) );
-    start3[0] = year;
+    #pragma omp critical(outputGROWEND)
+    {
+      temutil::nc( nc_open(curr_filename.c_str(), NC_WRITE, &ncid) );
+      temutil::nc( nc_inq_varid(ncid, "GROWEND", &cv) );
+      start3[0] = year;
 
-    double growend = cohort.edall->y_soid.rtdpGEoutput;
+      double growend = cohort.edall->y_soid.rtdpGEoutput;
 
-    temutil::nc( nc_put_var1_double(ncid, cv, start3, &growend) );
-    temutil::nc( nc_close(ncid) );
+      temutil::nc( nc_put_var1_double(ncid, cv, start3, &growend) );
+      temutil::nc( nc_close(ncid) );
+    }//end critical(outputGROWEND)
   }//end GROWEND
   map_itr = netcdf_outputs.end();
 
@@ -1060,14 +1061,17 @@ void Runner::output_netCDF(std::map<std::string, output_spec> &netcdf_outputs, i
     curr_spec = map_itr->second;
     curr_filename = curr_spec.file_path + curr_spec.filename_prefix + file_stage_suffix;
 
-    temutil::nc( nc_open(curr_filename.c_str(), NC_WRITE, &ncid) );
-    temutil::nc( nc_inq_varid(ncid, "GROWSTART", &cv) );
-    start3[0] = year;
+    #pragma omp critical(outputGROWSTART)
+    {
+      temutil::nc( nc_open(curr_filename.c_str(), NC_WRITE, &ncid) );
+      temutil::nc( nc_inq_varid(ncid, "GROWSTART", &cv) );
+      start3[0] = year;
 
-    double growstart = cohort.edall->y_soid.rtdpGSoutput;
+      double growstart = cohort.edall->y_soid.rtdpGSoutput;
 
-    temutil::nc( nc_put_var1_double(ncid, cv, start3, &growstart) );
-    temutil::nc( nc_close(ncid) );
+      temutil::nc( nc_put_var1_double(ncid, cv, start3, &growstart) );
+      temutil::nc( nc_close(ncid) );
+    }//end critical(outputGROWSTART)
   }//end GROWSTART
   map_itr = netcdf_outputs.end();
 
@@ -1078,23 +1082,26 @@ void Runner::output_netCDF(std::map<std::string, output_spec> &netcdf_outputs, i
     curr_spec = map_itr->second;
     curr_filename = curr_spec.file_path + curr_spec.filename_prefix + file_stage_suffix;
 
-    temutil::nc( nc_open(curr_filename.c_str(), NC_WRITE, &ncid) );
-    temutil::nc( nc_inq_varid(ncid, "MOSSDZ", &cv) );
-    start3[0] = year;
+    #pragma omp critical(outputMOSSDZ)
+    {
+      temutil::nc( nc_open(curr_filename.c_str(), NC_WRITE, &ncid) );
+      temutil::nc( nc_inq_varid(ncid, "MOSSDZ", &cv) );
+      start3[0] = year;
 
-    double mossdz = 0;
-    Layer* currL = cohort.ground.toplayer;
-    while(currL!=NULL){
-      if(currL->isMoss){
-        mossdz += currL->dz;
+      double mossdz = 0;
+      Layer* currL = cohort.ground.toplayer;
+      while(currL!=NULL){
+        if(currL->isMoss){
+          mossdz += currL->dz;
+        }
+        currL = currL->nextl;
       }
-      currL = currL->nextl;
-    }
-    //The following may never get set to anything useful?
-    //y_soil.mossthick;
+      //The following may never get set to anything useful?
+      //y_soil.mossthick;
 
-    temutil::nc( nc_put_var1_double(ncid, cv, start3, &mossdz) );
-    temutil::nc( nc_close(ncid) );
+      temutil::nc( nc_put_var1_double(ncid, cv, start3, &mossdz) );
+      temutil::nc( nc_close(ncid) );
+    }//end critical(outputMOSSDZ)
   }//end MOSSDZ
   map_itr = netcdf_outputs.end();
 
@@ -1105,23 +1112,26 @@ void Runner::output_netCDF(std::map<std::string, output_spec> &netcdf_outputs, i
     curr_spec = map_itr->second;
     curr_filename = curr_spec.file_path + curr_spec.filename_prefix + file_stage_suffix;
 
-    temutil::nc( nc_open(curr_filename.c_str(), NC_WRITE, &ncid) );
-    temutil::nc( nc_inq_varid(ncid, "ROLB", &cv) );
+    #pragma omp critical(outputROLB)
+    {
+      temutil::nc( nc_open(curr_filename.c_str(), NC_WRITE, &ncid) );
+      temutil::nc( nc_inq_varid(ncid, "ROLB", &cv) );
 
-    double rolb;
-    if(curr_spec.monthly){
-      start3[0] = month_timestep;
-      rolb = cohort.year_fd[month].fire_soid.rolb;
-    }
-    else if(curr_spec.yearly){
-      start3[0] = year;
-      //FIX. This will not work if there is more than one fire per year
-      // What does yearly ROLB even mean with multiple fires?
-      rolb = cohort.fd->fire_soid.rolb;
-    }
+      double rolb;
+      if(curr_spec.monthly){
+        start3[0] = month_timestep;
+        rolb = cohort.year_fd[month].fire_soid.rolb;
+      }
+      else if(curr_spec.yearly){
+        start3[0] = year;
+        //FIX. This will not work if there is more than one fire per year
+        // What does yearly ROLB even mean with multiple fires?
+        rolb = cohort.fd->fire_soid.rolb;
+      }
 
-    temutil::nc( nc_put_var1_double(ncid, cv, start3, &rolb) );
-    temutil::nc( nc_close(ncid) );
+      temutil::nc( nc_put_var1_double(ncid, cv, start3, &rolb) );
+      temutil::nc( nc_close(ncid) );
+    }//end critical(outputROLB)
   }//end ROLB
   map_itr = netcdf_outputs.end();
 
@@ -1132,14 +1142,17 @@ void Runner::output_netCDF(std::map<std::string, output_spec> &netcdf_outputs, i
     curr_spec = map_itr->second;
     curr_filename = curr_spec.file_path + curr_spec.filename_prefix + file_stage_suffix;
 
-    temutil::nc( nc_open(curr_filename.c_str(), NC_WRITE, &ncid) );
-    temutil::nc( nc_inq_varid(ncid, "PERMAFROST", &cv) );
-    start3[0] = year;
+    #pragma omp critical(outputPERMAFROST)
+    {
+      temutil::nc( nc_open(curr_filename.c_str(), NC_WRITE, &ncid) );
+      temutil::nc( nc_inq_varid(ncid, "PERMAFROST", &cv) );
+      start3[0] = year;
 
-    double permafrost = cohort.edall->y_soid.permafrost;
+      double permafrost = cohort.edall->y_soid.permafrost;
 
-    temutil::nc( nc_put_var1_double(ncid, cv, start3, &permafrost) );
-    temutil::nc( nc_close(ncid) );
+      temutil::nc( nc_put_var1_double(ncid, cv, start3, &permafrost) );
+      temutil::nc( nc_close(ncid) );
+    }//end critical(outputPERMAFROST)
   }//end PERMAFROST
   map_itr = netcdf_outputs.end();
 
@@ -1150,21 +1163,24 @@ void Runner::output_netCDF(std::map<std::string, output_spec> &netcdf_outputs, i
     curr_spec = map_itr->second;
     curr_filename = curr_spec.file_path + curr_spec.filename_prefix + file_stage_suffix;
 
-    temutil::nc( nc_open(curr_filename.c_str(), NC_WRITE, &ncid) );
-    temutil::nc( nc_inq_varid(ncid, "SHLWDZ", &cv) );
-    start3[0] = year;
+    #pragma omp critical(outputSHLWDZ)
+    {
+      temutil::nc( nc_open(curr_filename.c_str(), NC_WRITE, &ncid) );
+      temutil::nc( nc_inq_varid(ncid, "SHLWDZ", &cv) );
+      start3[0] = year;
 
-    double shlwdz = 0;
-    Layer* currL = cohort.ground.toplayer;
-    while(currL!=NULL){
-      if(currL->isFibric){
-        shlwdz += currL->dz;
+      double shlwdz = 0;
+      Layer* currL = cohort.ground.toplayer;
+      while(currL!=NULL){
+        if(currL->isFibric){
+          shlwdz += currL->dz;
+        }
+        currL = currL->nextl;
       }
-      currL = currL->nextl;
-    }
 
-    temutil::nc( nc_put_var1_double(ncid, cv, start3, &shlwdz) );
-    temutil::nc( nc_close(ncid) );
+      temutil::nc( nc_put_var1_double(ncid, cv, start3, &shlwdz) );
+      temutil::nc( nc_close(ncid) );
+    }//end critical(outputSHLWDZ)
   }//end SHLWDZ
   map_itr = netcdf_outputs.end();
 
@@ -1175,14 +1191,17 @@ void Runner::output_netCDF(std::map<std::string, output_spec> &netcdf_outputs, i
     curr_spec = map_itr->second;
     curr_filename = curr_spec.file_path + curr_spec.filename_prefix + file_stage_suffix;
 
-    temutil::nc( nc_open(curr_filename.c_str(), NC_WRITE, &ncid) );
-    temutil::nc( nc_inq_varid(ncid, "SNOWEND", &cv) );
-    start3[0] = year;
+    #pragma omp critical(outputSNOWEND)
+    {
+      temutil::nc( nc_open(curr_filename.c_str(), NC_WRITE, &ncid) );
+      temutil::nc( nc_inq_varid(ncid, "SNOWEND", &cv) );
+      start3[0] = year;
 
-    double snowend = cohort.edall->y_snws.snowend;
+      double snowend = cohort.edall->y_snws.snowend;
 
-    temutil::nc( nc_put_var1_double(ncid, cv, start3, &snowend) );
-    temutil::nc( nc_close(ncid) );
+      temutil::nc( nc_put_var1_double(ncid, cv, start3, &snowend) );
+      temutil::nc( nc_close(ncid) );
+    }//end critical(outputSNOWEND)
   }//end SNOWEND
   map_itr = netcdf_outputs.end();
 
@@ -1193,14 +1212,17 @@ void Runner::output_netCDF(std::map<std::string, output_spec> &netcdf_outputs, i
     curr_spec = map_itr->second;
     curr_filename = curr_spec.file_path + curr_spec.filename_prefix + file_stage_suffix;
 
-    temutil::nc( nc_open(curr_filename.c_str(), NC_WRITE, &ncid) );
-    temutil::nc( nc_inq_varid(ncid, "SNOWSTART", &cv) );
-    start3[0] = year;
+    #pragma omp critical(outputSNOWSTART)
+    {
+      temutil::nc( nc_open(curr_filename.c_str(), NC_WRITE, &ncid) );
+      temutil::nc( nc_inq_varid(ncid, "SNOWSTART", &cv) );
+      start3[0] = year;
 
-    double snowstart = cohort.edall->y_snws.snowstart;
+      double snowstart = cohort.edall->y_snws.snowstart;
 
-    temutil::nc( nc_put_var1_double(ncid, cv, start3, &snowstart) );
-    temutil::nc( nc_close(ncid) );
+      temutil::nc( nc_put_var1_double(ncid, cv, start3, &snowstart) );
+      temutil::nc( nc_close(ncid) );
+    }//end critical(outputSNOWSTART)
   }//end SNOWSTART
   map_itr = netcdf_outputs.end();
 
@@ -1212,14 +1234,17 @@ void Runner::output_netCDF(std::map<std::string, output_spec> &netcdf_outputs, i
     curr_spec = map_itr->second;
     curr_filename = curr_spec.file_path + curr_spec.filename_prefix + file_stage_suffix;
 
-    temutil::nc( nc_open(curr_filename.c_str(), NC_WRITE, &ncid) );
-    temutil::nc( nc_inq_varid(ncid, "YSD", &cv) );
-    start3[0] = year;
+    #pragma omp critical(outputYSD)
+    {
+      temutil::nc( nc_open(curr_filename.c_str(), NC_WRITE, &ncid) );
+      temutil::nc( nc_inq_varid(ncid, "YSD", &cv) );
+      start3[0] = year;
 
-    double ysd = cohort.cd.yrsdist;
+      double ysd = cohort.cd.yrsdist;
 
-    temutil::nc( nc_put_var1_double(ncid, cv, start3, &ysd) );
-    temutil::nc( nc_close(ncid) );
+      temutil::nc( nc_put_var1_double(ncid, cv, start3, &ysd) );
+      temutil::nc( nc_close(ncid) );
+    }//end critical(outputYSD)
   }//end PERMAFROST
   map_itr = netcdf_outputs.end();
 
@@ -1231,24 +1256,27 @@ void Runner::output_netCDF(std::map<std::string, output_spec> &netcdf_outputs, i
     curr_spec = map_itr->second;
     curr_filename = curr_spec.file_path + curr_spec.filename_prefix + file_stage_suffix;
 
-    temutil::nc( nc_open(curr_filename.c_str(), NC_WRITE, &ncid) );
-    temutil::nc( nc_inq_varid(ncid, "BURNAIR2SOIN", &cv) );
+    #pragma omp critical(outputBURNAIR2SOIN)
+    {
+      temutil::nc( nc_open(curr_filename.c_str(), NC_WRITE, &ncid) );
+      temutil::nc( nc_inq_varid(ncid, "BURNAIR2SOIN", &cv) );
 
-    double burnair2soin;
-    if(curr_spec.monthly){
-      start3[0] = month_timestep;
-      burnair2soin = cohort.year_fd[month].fire_a2soi.orgn;
-    }
-    else if(curr_spec.yearly){
-      start3[0] = year;
-      burnair2soin = 0;
-      for(int im=0; im<12; im++){
-        burnair2soin += cohort.year_fd[im].fire_a2soi.orgn;
+      double burnair2soin;
+      if(curr_spec.monthly){
+        start3[0] = month_timestep;
+        burnair2soin = cohort.year_fd[month].fire_a2soi.orgn;
       }
-    }
+      else if(curr_spec.yearly){
+        start3[0] = year;
+        burnair2soin = 0;
+        for(int im=0; im<12; im++){
+          burnair2soin += cohort.year_fd[im].fire_a2soi.orgn;
+        }
+      }
 
-    temutil::nc( nc_put_var1_double(ncid, cv, start3, &burnair2soin) );
-    temutil::nc( nc_close(ncid) );
+      temutil::nc( nc_put_var1_double(ncid, cv, start3, &burnair2soin) );
+      temutil::nc( nc_close(ncid) );
+    }//end critical(outputBURNAIR2SOIN)
   }//end BURNAIR2SOIN
   map_itr = netcdf_outputs.end();
 
@@ -1260,24 +1288,27 @@ void Runner::output_netCDF(std::map<std::string, output_spec> &netcdf_outputs, i
     curr_spec = map_itr->second;
     curr_filename = curr_spec.file_path + curr_spec.filename_prefix + file_stage_suffix;
 
-    temutil::nc( nc_open(curr_filename.c_str(), NC_WRITE, &ncid) );
-    temutil::nc( nc_inq_varid(ncid, "BURNTHICK", &cv) );
+    #pragma omp critical(outputBURNTHICK)
+    {
+      temutil::nc( nc_open(curr_filename.c_str(), NC_WRITE, &ncid) );
+      temutil::nc( nc_inq_varid(ncid, "BURNTHICK", &cv) );
 
-    double burnthick;
-    if(curr_spec.monthly){
-      start3[0] = month_timestep;
-      burnthick = cohort.year_fd[month].fire_soid.burnthick;
-    }
-    else if(curr_spec.yearly){
-      start3[0] = year;
-      burnthick = 0;
-      for(int im=0; im<12; im++){
-        burnthick += cohort.year_fd[im].fire_soid.burnthick;
+      double burnthick;
+      if(curr_spec.monthly){
+        start3[0] = month_timestep;
+        burnthick = cohort.year_fd[month].fire_soid.burnthick;
       }
-    }
+      else if(curr_spec.yearly){
+        start3[0] = year;
+        burnthick = 0;
+        for(int im=0; im<12; im++){
+          burnthick += cohort.year_fd[im].fire_soid.burnthick;
+        }
+      }
 
-    temutil::nc( nc_put_var1_double(ncid, cv, start3, &burnthick) );
-    temutil::nc( nc_close(ncid) );
+      temutil::nc( nc_put_var1_double(ncid, cv, start3, &burnthick) );
+      temutil::nc( nc_close(ncid) );
+    }//end critical(outputBURNTHICK)
   }//end BURNTHICK
   map_itr = netcdf_outputs.end();
 
@@ -1289,21 +1320,24 @@ void Runner::output_netCDF(std::map<std::string, output_spec> &netcdf_outputs, i
     curr_spec = map_itr->second;
     curr_filename = curr_spec.file_path + curr_spec.filename_prefix + file_stage_suffix;
 
-    temutil::nc( nc_open(curr_filename.c_str(), NC_WRITE, &ncid) );
-    temutil::nc( nc_inq_varid(ncid, "DEADC", &cv) );
+    #pragma omp critical(outputDEADC)
+    {
+      temutil::nc( nc_open(curr_filename.c_str(), NC_WRITE, &ncid) );
+      temutil::nc( nc_inq_varid(ncid, "DEADC", &cv) );
 
-    double deadc;
-    if(curr_spec.monthly){
-      start3[0] = month_timestep;
-      deadc = cohort.bdall->m_vegs.deadc;
-    }
-    else if(curr_spec.yearly){
-      start3[0] = year;
-      deadc = cohort.bdall->y_vegs.deadc;
-    }
+      double deadc;
+      if(curr_spec.monthly){
+        start3[0] = month_timestep;
+        deadc = cohort.bdall->m_vegs.deadc;
+      }
+      else if(curr_spec.yearly){
+        start3[0] = year;
+        deadc = cohort.bdall->y_vegs.deadc;
+      }
 
-    temutil::nc( nc_put_var1_double(ncid, cv, start3, &deadc) );
-    temutil::nc( nc_close(ncid) );
+      temutil::nc( nc_put_var1_double(ncid, cv, start3, &deadc) );
+      temutil::nc( nc_close(ncid) );
+    }//end critical(outputDEADC)
   }//end DEADC
   map_itr = netcdf_outputs.end();
 
@@ -1315,21 +1349,24 @@ void Runner::output_netCDF(std::map<std::string, output_spec> &netcdf_outputs, i
     curr_spec = map_itr->second;
     curr_filename = curr_spec.file_path + curr_spec.filename_prefix + file_stage_suffix;
 
-    temutil::nc( nc_open(curr_filename.c_str(), NC_WRITE, &ncid) );
-    temutil::nc( nc_inq_varid(ncid, "DEADN", &cv) );
+    #pragma omp critical(outputDEADN)
+    {
+      temutil::nc( nc_open(curr_filename.c_str(), NC_WRITE, &ncid) );
+      temutil::nc( nc_inq_varid(ncid, "DEADN", &cv) );
 
-    double deadn;
-    if(curr_spec.monthly){
-      start3[0] = month_timestep;
-      deadn = cohort.bdall->m_vegs.deadn;
-    }
-    else if(curr_spec.yearly){
-      start3[0] = year;
-      deadn = cohort.bdall->y_vegs.deadn;
-    }
+      double deadn;
+      if(curr_spec.monthly){
+        start3[0] = month_timestep;
+        deadn = cohort.bdall->m_vegs.deadn;
+      }
+      else if(curr_spec.yearly){
+        start3[0] = year;
+        deadn = cohort.bdall->y_vegs.deadn;
+      }
 
-    temutil::nc( nc_put_var1_double(ncid, cv, start3, &deadn) );
-    temutil::nc( nc_close(ncid) );
+      temutil::nc( nc_put_var1_double(ncid, cv, start3, &deadn) );
+      temutil::nc( nc_close(ncid) );
+    }//end critical(outputDEADN)
   }//end DEADN
   map_itr = netcdf_outputs.end();
 
@@ -1341,21 +1378,24 @@ void Runner::output_netCDF(std::map<std::string, output_spec> &netcdf_outputs, i
     curr_spec = map_itr->second;
     curr_filename = curr_spec.file_path + curr_spec.filename_prefix + file_stage_suffix;
 
-    temutil::nc( nc_open(curr_filename.c_str(), NC_WRITE, &ncid) );
-    temutil::nc( nc_inq_varid(ncid, "DEEPC", &cv) );
+    #pragma omp critical(outputDEEPC)
+    {
+      temutil::nc( nc_open(curr_filename.c_str(), NC_WRITE, &ncid) );
+      temutil::nc( nc_inq_varid(ncid, "DEEPC", &cv) );
 
-    double deepc;
-    if(curr_spec.monthly){
-      start3[0] = month_timestep;
-      deepc = cohort.bdall->m_soid.deepc;
-    }
-    else if(curr_spec.yearly){
-      start3[0] = year;
-      deepc = cohort.bdall->y_soid.deepc;
-    }
+      double deepc;
+      if(curr_spec.monthly){
+        start3[0] = month_timestep;
+        deepc = cohort.bdall->m_soid.deepc;
+      }
+      else if(curr_spec.yearly){
+        start3[0] = year;
+        deepc = cohort.bdall->y_soid.deepc;
+      }
 
-    temutil::nc( nc_put_var1_double(ncid, cv, start3, &deepc) );
-    temutil::nc( nc_close(ncid) ); 
+      temutil::nc( nc_put_var1_double(ncid, cv, start3, &deepc) );
+      temutil::nc( nc_close(ncid) ); 
+    }//end critical(outputDEEPC)
   }//end DEEPC
   map_itr = netcdf_outputs.end();
 
@@ -1367,21 +1407,24 @@ void Runner::output_netCDF(std::map<std::string, output_spec> &netcdf_outputs, i
     curr_spec = map_itr->second;
     curr_filename = curr_spec.file_path + curr_spec.filename_prefix + file_stage_suffix;
 
-    temutil::nc( nc_open(curr_filename.c_str(), NC_WRITE, &ncid) );
-    temutil::nc( nc_inq_varid(ncid, "DWDC", &cv) );
+    #pragma omp critical(outputDWDC)
+    {
+      temutil::nc( nc_open(curr_filename.c_str(), NC_WRITE, &ncid) );
+      temutil::nc( nc_inq_varid(ncid, "DWDC", &cv) );
 
-    double woodyc;
-    if(curr_spec.monthly){
-      start3[0] = month_timestep;
-      woodyc = cohort.bdall->m_sois.wdebrisc;
-    }
-    else if(curr_spec.yearly){
-      start3[0] = year;
-      woodyc = cohort.bdall->y_sois.wdebrisc;
-    }
+      double woodyc;
+      if(curr_spec.monthly){
+        start3[0] = month_timestep;
+        woodyc = cohort.bdall->m_sois.wdebrisc;
+      }
+      else if(curr_spec.yearly){
+        start3[0] = year;
+        woodyc = cohort.bdall->y_sois.wdebrisc;
+      }
 
-    temutil::nc( nc_put_var1_double(ncid, cv, start3, &woodyc) );
-    temutil::nc( nc_close(ncid) );
+      temutil::nc( nc_put_var1_double(ncid, cv, start3, &woodyc) );
+      temutil::nc( nc_close(ncid) );
+    }//end critical(outputDWDC)
   }//end DWDC
   map_itr = netcdf_outputs.end();
 
@@ -1393,21 +1436,24 @@ void Runner::output_netCDF(std::map<std::string, output_spec> &netcdf_outputs, i
     curr_spec = map_itr->second;
     curr_filename = curr_spec.file_path + curr_spec.filename_prefix + file_stage_suffix;
 
-    temutil::nc( nc_open(curr_filename.c_str(), NC_WRITE, &ncid) );
-    temutil::nc( nc_inq_varid(ncid, "DWDN", &cv) );
+    #pragma omp critical(outputDWDN)
+    {
+      temutil::nc( nc_open(curr_filename.c_str(), NC_WRITE, &ncid) );
+      temutil::nc( nc_inq_varid(ncid, "DWDN", &cv) );
 
-    double woodyn;
-    if(curr_spec.monthly){
-      start3[0] = month_timestep;
-      woodyn = cohort.bdall->m_sois.wdebrisn;
-    }
-    else if(curr_spec.yearly){
-      start3[0] = year;
-      woodyn = cohort.bdall->y_sois.wdebrisn;
-    }
+      double woodyn;
+      if(curr_spec.monthly){
+        start3[0] = month_timestep;
+        woodyn = cohort.bdall->m_sois.wdebrisn;
+      }
+      else if(curr_spec.yearly){
+        start3[0] = year;
+        woodyn = cohort.bdall->y_sois.wdebrisn;
+      }
 
-    temutil::nc( nc_put_var1_double(ncid, cv, start3, &woodyn) );
-    temutil::nc( nc_close(ncid) );
+      temutil::nc( nc_put_var1_double(ncid, cv, start3, &woodyn) );
+      temutil::nc( nc_close(ncid) );
+    }//end critical(outputDWDN)
   }//end DWDN
   map_itr = netcdf_outputs.end();
 
@@ -1419,25 +1465,28 @@ void Runner::output_netCDF(std::map<std::string, output_spec> &netcdf_outputs, i
     curr_spec = map_itr->second;
     curr_filename = curr_spec.file_path + curr_spec.filename_prefix + file_stage_suffix;
 
-    temutil::nc( nc_open(curr_filename.c_str(), NC_WRITE, &ncid) );
-    temutil::nc( nc_inq_varid(ncid, "MINEC", &cv) );
+    #pragma omp critical(outputMINEC)
+    {
+      temutil::nc( nc_open(curr_filename.c_str(), NC_WRITE, &ncid) );
+      temutil::nc( nc_inq_varid(ncid, "MINEC", &cv) );
 
-    double minec;
-    if(curr_spec.monthly){
-      start3[0] = month_timestep;
-      minec = cohort.bdall->m_soid.mineac
-              + cohort.bdall->m_soid.minebc
-              + cohort.bdall->m_soid.minecc;
-    }
-    else if(curr_spec.yearly){
-      start3[0] = year;
-      minec = cohort.bdall->y_soid.mineac
-              + cohort.bdall->y_soid.minebc
-              + cohort.bdall->y_soid.minecc;
-    }
+      double minec;
+      if(curr_spec.monthly){
+        start3[0] = month_timestep;
+        minec = cohort.bdall->m_soid.mineac
+                + cohort.bdall->m_soid.minebc
+                + cohort.bdall->m_soid.minecc;
+      }
+      else if(curr_spec.yearly){
+        start3[0] = year;
+        minec = cohort.bdall->y_soid.mineac
+                + cohort.bdall->y_soid.minebc
+                + cohort.bdall->y_soid.minecc;
+      }
 
-    temutil::nc( nc_put_var1_double(ncid, cv, start3, &minec) );
-    temutil::nc( nc_close(ncid) ); 
+      temutil::nc( nc_put_var1_double(ncid, cv, start3, &minec) );
+      temutil::nc( nc_close(ncid) ); 
+    }//end critical(outputMINEC)
   }//end MINEC
   map_itr = netcdf_outputs.end();
 
@@ -1449,21 +1498,24 @@ void Runner::output_netCDF(std::map<std::string, output_spec> &netcdf_outputs, i
     curr_spec = map_itr->second;
     curr_filename = curr_spec.file_path + curr_spec.filename_prefix + file_stage_suffix;
 
-    temutil::nc( nc_open(curr_filename.c_str(), NC_WRITE, &ncid) );
-    temutil::nc( nc_inq_varid(ncid, "MOSSDEATHC", &cv) );
+    #pragma omp critical(outputMOSSDEATHC)
+    {
+      temutil::nc( nc_open(curr_filename.c_str(), NC_WRITE, &ncid) );
+      temutil::nc( nc_inq_varid(ncid, "MOSSDEATHC", &cv) );
 
-    double mossdeathc = 0;
-    if(curr_spec.monthly){
-      start3[0] = month_timestep;
-      mossdeathc = cohort.bdall->m_v2soi.mossdeathc; 
-    }
-    else if(curr_spec.yearly){
-      start3[0] = year;
-      mossdeathc = cohort.bdall->y_v2soi.mossdeathc; 
-    }
+      double mossdeathc = 0;
+      if(curr_spec.monthly){
+        start3[0] = month_timestep;
+        mossdeathc = cohort.bdall->m_v2soi.mossdeathc; 
+      }
+      else if(curr_spec.yearly){
+        start3[0] = year;
+        mossdeathc = cohort.bdall->y_v2soi.mossdeathc; 
+      }
 
-    temutil::nc( nc_put_var1_double(ncid, cv, start3, &mossdeathc) ); 
-    temutil::nc( nc_close(ncid) ); 
+      temutil::nc( nc_put_var1_double(ncid, cv, start3, &mossdeathc) ); 
+      temutil::nc( nc_close(ncid) ); 
+    }//end critical(outputMOSSDEATHC)
   }//end MOSSDEATHC
   map_itr = netcdf_outputs.end();
 
@@ -1475,21 +1527,24 @@ void Runner::output_netCDF(std::map<std::string, output_spec> &netcdf_outputs, i
     curr_spec = map_itr->second;
     curr_filename = curr_spec.file_path + curr_spec.filename_prefix + file_stage_suffix;
 
-    temutil::nc( nc_open(curr_filename.c_str(), NC_WRITE, &ncid) );
-    temutil::nc( nc_inq_varid(ncid, "MOSSDEATHN", &cv) );
+    #pragma omp critical(outputMOSSDEATHN)
+    {
+      temutil::nc( nc_open(curr_filename.c_str(), NC_WRITE, &ncid) );
+      temutil::nc( nc_inq_varid(ncid, "MOSSDEATHN", &cv) );
 
-    double mossdeathn = 0;
-    if(curr_spec.monthly){
-      start3[0] = month_timestep;
-      mossdeathn = cohort.bdall->m_v2soi.mossdeathn; 
-    }
-    else if(curr_spec.yearly){
-      start3[0] = year;
-      mossdeathn = cohort.bdall->y_v2soi.mossdeathn; 
-    }
+      double mossdeathn = 0;
+      if(curr_spec.monthly){
+        start3[0] = month_timestep;
+        mossdeathn = cohort.bdall->m_v2soi.mossdeathn; 
+      }
+      else if(curr_spec.yearly){
+        start3[0] = year;
+        mossdeathn = cohort.bdall->y_v2soi.mossdeathn; 
+      }
 
-    temutil::nc( nc_put_var1_double(ncid, cv, start3, &mossdeathn) ); 
-    temutil::nc( nc_close(ncid) ); 
+      temutil::nc( nc_put_var1_double(ncid, cv, start3, &mossdeathn) ); 
+      temutil::nc( nc_close(ncid) ); 
+    }//end critical(outputMOSSDEATHN)
   }//end MOSSDEATHN
   map_itr = netcdf_outputs.end();
 
@@ -1501,21 +1556,24 @@ void Runner::output_netCDF(std::map<std::string, output_spec> &netcdf_outputs, i
     curr_spec = map_itr->second;
     curr_filename = curr_spec.file_path + curr_spec.filename_prefix + file_stage_suffix;
 
-    temutil::nc( nc_open(curr_filename.c_str(), NC_WRITE, &ncid) );
-    temutil::nc( nc_inq_varid(ncid, "QDRAINAGE", &cv) );
+    #pragma omp critical(outputQDRAINAGE)
+    {
+      temutil::nc( nc_open(curr_filename.c_str(), NC_WRITE, &ncid) );
+      temutil::nc( nc_inq_varid(ncid, "QDRAINAGE", &cv) );
 
-    double qdrainage = 0;
-    if(curr_spec.monthly){
-      start3[0] = month_timestep;
-      qdrainage = cohort.edall->m_soi2l.qdrain; 
-    }
-    else if(curr_spec.yearly){
-      start3[0] = year;
-      qdrainage = cohort.edall->y_soi2l.qdrain; 
-    }
+      double qdrainage = 0;
+      if(curr_spec.monthly){
+        start3[0] = month_timestep;
+        qdrainage = cohort.edall->m_soi2l.qdrain; 
+      }
+      else if(curr_spec.yearly){
+        start3[0] = year;
+        qdrainage = cohort.edall->y_soi2l.qdrain; 
+      }
 
-    temutil::nc( nc_put_var1_double(ncid, cv, start3, &qdrainage) );
-    temutil::nc( nc_close(ncid) ); 
+      temutil::nc( nc_put_var1_double(ncid, cv, start3, &qdrainage) );
+      temutil::nc( nc_close(ncid) ); 
+    }//end critical(outputQDRAINAGE)
   }//end QDRAINAGE 
   map_itr = netcdf_outputs.end();
 
@@ -1527,21 +1585,24 @@ void Runner::output_netCDF(std::map<std::string, output_spec> &netcdf_outputs, i
     curr_spec = map_itr->second;
     curr_filename = curr_spec.file_path + curr_spec.filename_prefix + file_stage_suffix;
 
-    temutil::nc( nc_open(curr_filename.c_str(), NC_WRITE, &ncid) );
-    temutil::nc( nc_inq_varid(ncid, "QINFILTRATION", &cv) );
+    #pragma omp critical(outputQINFILTRATION)
+    {
+      temutil::nc( nc_open(curr_filename.c_str(), NC_WRITE, &ncid) );
+      temutil::nc( nc_inq_varid(ncid, "QINFILTRATION", &cv) );
 
-    double qinfil = 0;
-    if(curr_spec.monthly){
-      start3[0] = month_timestep;
-      qinfil = cohort.edall->m_soi2l.qinfl; 
-    }
-    else if(curr_spec.yearly){
-      start3[0] = year;
-      qinfil = cohort.edall->y_soi2l.qinfl; 
-    }
+      double qinfil = 0;
+      if(curr_spec.monthly){
+        start3[0] = month_timestep;
+        qinfil = cohort.edall->m_soi2l.qinfl; 
+      }
+      else if(curr_spec.yearly){
+        start3[0] = year;
+        qinfil = cohort.edall->y_soi2l.qinfl; 
+      }
 
-    temutil::nc( nc_put_var1_double(ncid, cv, start3, &qinfil) );
-    temutil::nc( nc_close(ncid) ); 
+      temutil::nc( nc_put_var1_double(ncid, cv, start3, &qinfil) );
+      temutil::nc( nc_close(ncid) ); 
+    }//end critical(outputQINFILTRATION)
   }//end QINFILTRATION
   map_itr = netcdf_outputs.end();
 
@@ -1553,21 +1614,24 @@ void Runner::output_netCDF(std::map<std::string, output_spec> &netcdf_outputs, i
     curr_spec = map_itr->second;
     curr_filename = curr_spec.file_path + curr_spec.filename_prefix + file_stage_suffix;
 
-    temutil::nc( nc_open(curr_filename.c_str(), NC_WRITE, &ncid) );
-    temutil::nc( nc_inq_varid(ncid, "QRUNOFF", &cv) );
+    #pragma omp critical(outputQRUNOFF)
+    {
+      temutil::nc( nc_open(curr_filename.c_str(), NC_WRITE, &ncid) );
+      temutil::nc( nc_inq_varid(ncid, "QRUNOFF", &cv) );
 
-    double qrunoff = 0;
-    if(curr_spec.monthly){
-      start3[0] = month_timestep;
-      qrunoff = cohort.edall->m_soi2l.qover; 
-    }
-    else if(curr_spec.yearly){
-      start3[0] = year;
-      qrunoff = cohort.edall->y_soi2l.qover;
-    }
+      double qrunoff = 0;
+      if(curr_spec.monthly){
+        start3[0] = month_timestep;
+        qrunoff = cohort.edall->m_soi2l.qover; 
+      }
+      else if(curr_spec.yearly){
+        start3[0] = year;
+        qrunoff = cohort.edall->y_soi2l.qover;
+      }
 
-    temutil::nc( nc_put_var1_double(ncid, cv, start3, &qrunoff) );
-    temutil::nc( nc_close(ncid) ); 
+      temutil::nc( nc_put_var1_double(ncid, cv, start3, &qrunoff) );
+      temutil::nc( nc_close(ncid) ); 
+    }//end critical(outputQRUNOFF)
   }//end QRUNOFF 
   map_itr = netcdf_outputs.end();
 
@@ -1579,21 +1643,24 @@ void Runner::output_netCDF(std::map<std::string, output_spec> &netcdf_outputs, i
     curr_spec = map_itr->second;
     curr_filename = curr_spec.file_path + curr_spec.filename_prefix + file_stage_suffix;
 
-    temutil::nc( nc_open(curr_filename.c_str(), NC_WRITE, &ncid) );
-    temutil::nc( nc_inq_varid(ncid, "SHLWC", &cv) );
+    #pragma omp critical(outputSHLWC)
+    {
+      temutil::nc( nc_open(curr_filename.c_str(), NC_WRITE, &ncid) );
+      temutil::nc( nc_inq_varid(ncid, "SHLWC", &cv) );
 
-    double shlwc;
-    if(curr_spec.monthly){
-      start3[0] = month_timestep;
-      shlwc = cohort.bdall->m_soid.shlwc;
-    }
-    else if(curr_spec.yearly){
-      start3[0] = year;
-      shlwc = cohort.bdall->y_soid.shlwc;
-    }
+      double shlwc;
+      if(curr_spec.monthly){
+        start3[0] = month_timestep;
+        shlwc = cohort.bdall->m_soid.shlwc;
+      }
+      else if(curr_spec.yearly){
+        start3[0] = year;
+        shlwc = cohort.bdall->y_soid.shlwc;
+      }
 
-    temutil::nc( nc_put_var1_double(ncid, cv, start3, &shlwc) );
-    temutil::nc( nc_close(ncid) ); 
+      temutil::nc( nc_put_var1_double(ncid, cv, start3, &shlwc) );
+      temutil::nc( nc_close(ncid) ); 
+    }//end critical(outputSHLWC)
   }//end SHLWC 
   map_itr = netcdf_outputs.end();
 
@@ -1605,21 +1672,24 @@ void Runner::output_netCDF(std::map<std::string, output_spec> &netcdf_outputs, i
     curr_spec = map_itr->second;
     curr_filename = curr_spec.file_path + curr_spec.filename_prefix + file_stage_suffix;
 
-    temutil::nc( nc_open(curr_filename.c_str(), NC_WRITE, &ncid) );
-    temutil::nc( nc_inq_varid(ncid, "WDRH", &cv) );
+    #pragma omp critical(outputWDRH)
+    {
+      temutil::nc( nc_open(curr_filename.c_str(), NC_WRITE, &ncid) );
+      temutil::nc( nc_inq_varid(ncid, "WDRH", &cv) );
 
-    double woodyrh;
-    if(curr_spec.monthly){
-      start3[0] = month_timestep;
-      woodyrh = cohort.bdall->m_soi2a.rhwdeb;
-    }
-    else if(curr_spec.yearly){
-      start3[0] = year;
-      woodyrh = cohort.bdall->y_soi2a.rhwdeb;
-    }
+      double woodyrh;
+      if(curr_spec.monthly){
+        start3[0] = month_timestep;
+        woodyrh = cohort.bdall->m_soi2a.rhwdeb;
+      }
+      else if(curr_spec.yearly){
+        start3[0] = year;
+        woodyrh = cohort.bdall->y_soi2a.rhwdeb;
+      }
 
-    temutil::nc( nc_put_var1_double(ncid, cv, start3, &woodyrh) );
-    temutil::nc( nc_close(ncid) ); 
+      temutil::nc( nc_put_var1_double(ncid, cv, start3, &woodyrh) );
+      temutil::nc( nc_close(ncid) ); 
+    }//end critical(outputWDRH)
   }//end WDRH
   map_itr = netcdf_outputs.end();
 
@@ -1632,26 +1702,29 @@ void Runner::output_netCDF(std::map<std::string, output_spec> &netcdf_outputs, i
     curr_spec = map_itr->second;
     curr_filename = curr_spec.file_path + curr_spec.filename_prefix + file_stage_suffix;
 
-    temutil::nc( nc_open(curr_filename.c_str(), NC_WRITE, &ncid) );
-    temutil::nc( nc_inq_varid(ncid, "HKDEEP", &cv) );
+    #pragma omp critical(outputHKDEEP)
+    {
+      temutil::nc( nc_open(curr_filename.c_str(), NC_WRITE, &ncid) );
+      temutil::nc( nc_inq_varid(ncid, "HKDEEP", &cv) );
 
-    double hkdeep;
-    if(curr_spec.daily){
-      start3[0] = day_timestep; 
-      temutil::nc( nc_put_vara_double(ncid, cv, start3, count3, &cohort.edall->daily_hkdeep[0]) );
-    }
-    else if(curr_spec.monthly){
-      start3[0] = month_timestep;
-      hkdeep = cohort.edall->m_soid.hkdeep;
-      temutil::nc( nc_put_var1_double(ncid, cv, start3, &hkdeep) );
-    }
-    else if(curr_spec.yearly){
-      start3[0] = year;
-      hkdeep = cohort.edall->y_soid.hkdeep;
-      temutil::nc( nc_put_var1_double(ncid, cv, start3, &hkdeep) );
-    }
+      double hkdeep;
+      if(curr_spec.daily){
+        start3[0] = day_timestep; 
+        temutil::nc( nc_put_vara_double(ncid, cv, start3, count3, &cohort.edall->daily_hkdeep[0]) );
+      }
+      else if(curr_spec.monthly){
+        start3[0] = month_timestep;
+        hkdeep = cohort.edall->m_soid.hkdeep;
+        temutil::nc( nc_put_var1_double(ncid, cv, start3, &hkdeep) );
+      }
+      else if(curr_spec.yearly){
+        start3[0] = year;
+        hkdeep = cohort.edall->y_soid.hkdeep;
+        temutil::nc( nc_put_var1_double(ncid, cv, start3, &hkdeep) );
+      }
 
-    temutil::nc( nc_close(ncid) );
+      temutil::nc( nc_close(ncid) );
+    }//end critical(outputHKDEEP)
   }//end HKDEEP 
   map_itr = netcdf_outputs.end();
 
@@ -1663,19 +1736,23 @@ void Runner::output_netCDF(std::map<std::string, output_spec> &netcdf_outputs, i
     curr_spec = map_itr->second;
     curr_filename = curr_spec.file_path + curr_spec.filename_prefix + file_stage_suffix;
 
-    temutil::nc( nc_open(curr_filename.c_str(), NC_WRITE, &ncid) );
-    temutil::nc( nc_inq_varid(ncid, "HKLAYER", &cv) );
+    #pragma omp critical(outputHKLAYER)
+    {
+      temutil::nc( nc_open(curr_filename.c_str(), NC_WRITE, &ncid) );
+      temutil::nc( nc_inq_varid(ncid, "HKLAYER", &cv) );
 
-    if(curr_spec.monthly){
-      soilstart4[0] = month_timestep;
-      temutil::nc( nc_put_vara_double(ncid, cv, soilstart4, soilcount4, &cohort.edall->m_soid.hcond[0]) );
-    }
-    else if(curr_spec.yearly){
-      soilstart4[0] = year;
-      temutil::nc( nc_put_vara_double(ncid, cv, soilstart4, soilcount4, &cohort.edall->y_soid.hcond[0]) );
-    }
+      if(curr_spec.monthly){
+        soilstart4[0] = month_timestep;
+        temutil::nc( nc_put_vara_double(ncid, cv, soilstart4, soilcount4, &cohort.edall->m_soid.hcond[0]) );
+      }
+      else if(curr_spec.yearly){
+        soilstart4[0] = year;
+        temutil::nc( nc_put_vara_double(ncid, cv, soilstart4, soilcount4, &cohort.edall->y_soid.hcond[0]) );
+      }
 
-    temutil::nc( nc_close(ncid) );
+      temutil::nc( nc_close(ncid) );
+    }//end critical(outputHKLAYER)
+
   }//end HKLAYER
   map_itr = netcdf_outputs.end();
 
@@ -1687,26 +1764,29 @@ void Runner::output_netCDF(std::map<std::string, output_spec> &netcdf_outputs, i
     curr_spec = map_itr->second;
     curr_filename = curr_spec.file_path + curr_spec.filename_prefix + file_stage_suffix;
 
-    temutil::nc( nc_open(curr_filename.c_str(), NC_WRITE, &ncid) );
-    temutil::nc( nc_inq_varid(ncid, "HKMINEA", &cv) );
+    #pragma omp critical(outputHKMINEA)
+    {
+      temutil::nc( nc_open(curr_filename.c_str(), NC_WRITE, &ncid) );
+      temutil::nc( nc_inq_varid(ncid, "HKMINEA", &cv) );
 
-    double hkminea;
-    if(curr_spec.daily){
-      start3[0] = day_timestep; 
-      temutil::nc( nc_put_vara_double(ncid, cv, start3, count3, &cohort.edall->daily_hkminea[0]) );
-    }
-    else if(curr_spec.monthly){
-      start3[0] = month_timestep;
-      hkminea = cohort.edall->m_soid.hkminea;
-      temutil::nc( nc_put_var1_double(ncid, cv, start3, &hkminea) );
-    }
-    else if(curr_spec.yearly){
-      start3[0] = year;
-      hkminea = cohort.edall->y_soid.hkminea;
-      temutil::nc( nc_put_var1_double(ncid, cv, start3, &hkminea) );
-    }
+      double hkminea;
+      if(curr_spec.daily){
+        start3[0] = day_timestep; 
+        temutil::nc( nc_put_vara_double(ncid, cv, start3, count3, &cohort.edall->daily_hkminea[0]) );
+      }
+      else if(curr_spec.monthly){
+        start3[0] = month_timestep;
+        hkminea = cohort.edall->m_soid.hkminea;
+        temutil::nc( nc_put_var1_double(ncid, cv, start3, &hkminea) );
+      }
+      else if(curr_spec.yearly){
+        start3[0] = year;
+        hkminea = cohort.edall->y_soid.hkminea;
+        temutil::nc( nc_put_var1_double(ncid, cv, start3, &hkminea) );
+      }
 
-    temutil::nc( nc_close(ncid) );
+      temutil::nc( nc_close(ncid) );
+    }//end critical(outputHKMINEA)
   }//end HKMINEA
   map_itr = netcdf_outputs.end();
 
@@ -1718,26 +1798,29 @@ void Runner::output_netCDF(std::map<std::string, output_spec> &netcdf_outputs, i
     curr_spec = map_itr->second;
     curr_filename = curr_spec.file_path + curr_spec.filename_prefix + file_stage_suffix;
 
-    temutil::nc( nc_open(curr_filename.c_str(), NC_WRITE, &ncid) );
-    temutil::nc( nc_inq_varid(ncid, "HKMINEB", &cv) );
+    #pragma omp critical(outputHKMINEB)
+    {
+      temutil::nc( nc_open(curr_filename.c_str(), NC_WRITE, &ncid) );
+      temutil::nc( nc_inq_varid(ncid, "HKMINEB", &cv) );
 
-    double hkmineb;
-    if(curr_spec.daily){
-      start3[0] = day_timestep; 
-      temutil::nc( nc_put_vara_double(ncid, cv, start3, count3, &cohort.edall->daily_hkmineb[0]) );
-    }
-    else if(curr_spec.monthly){
-      start3[0] = month_timestep;
-      hkmineb = cohort.edall->m_soid.hkmineb;
-      temutil::nc( nc_put_var1_double(ncid, cv, start3, &hkmineb) );
-    }
-    else if(curr_spec.yearly){
-      start3[0] = year;
-      hkmineb = cohort.edall->y_soid.hkmineb;
-      temutil::nc( nc_put_var1_double(ncid, cv, start3, &hkmineb) );
-    }
+      double hkmineb;
+      if(curr_spec.daily){
+        start3[0] = day_timestep; 
+        temutil::nc( nc_put_vara_double(ncid, cv, start3, count3, &cohort.edall->daily_hkmineb[0]) );
+      }
+      else if(curr_spec.monthly){
+        start3[0] = month_timestep;
+        hkmineb = cohort.edall->m_soid.hkmineb;
+        temutil::nc( nc_put_var1_double(ncid, cv, start3, &hkmineb) );
+      }
+      else if(curr_spec.yearly){
+        start3[0] = year;
+        hkmineb = cohort.edall->y_soid.hkmineb;
+        temutil::nc( nc_put_var1_double(ncid, cv, start3, &hkmineb) );
+      }
 
-    temutil::nc( nc_close(ncid) );
+      temutil::nc( nc_close(ncid) );
+    }//end critical(outputHKMINEB)
   }//end HKMINEB
   map_itr = netcdf_outputs.end();
 
@@ -1749,26 +1832,29 @@ void Runner::output_netCDF(std::map<std::string, output_spec> &netcdf_outputs, i
     curr_spec = map_itr->second;
     curr_filename = curr_spec.file_path + curr_spec.filename_prefix + file_stage_suffix;
 
-    temutil::nc( nc_open(curr_filename.c_str(), NC_WRITE, &ncid) );
-    temutil::nc( nc_inq_varid(ncid, "HKMINEC", &cv) );
+    #pragma omp critical(outputHKMINEC)
+    {
+      temutil::nc( nc_open(curr_filename.c_str(), NC_WRITE, &ncid) );
+      temutil::nc( nc_inq_varid(ncid, "HKMINEC", &cv) );
 
-    double hkminec;
-    if(curr_spec.daily){
-      start3[0] = day_timestep; 
-      temutil::nc( nc_put_vara_double(ncid, cv, start3, count3, &cohort.edall->daily_hkminec[0]) );
-    }
-    else if(curr_spec.monthly){
-      start3[0] = month_timestep;
-      hkminec = cohort.edall->m_soid.hkminec;
-      temutil::nc( nc_put_var1_double(ncid, cv, start3, &hkminec) );
-    }
-    else if(curr_spec.yearly){
-      start3[0] = year;
-      hkminec = cohort.edall->y_soid.hkminec;
-      temutil::nc( nc_put_var1_double(ncid, cv, start3, &hkminec) );
-    }
+      double hkminec;
+      if(curr_spec.daily){
+        start3[0] = day_timestep; 
+        temutil::nc( nc_put_vara_double(ncid, cv, start3, count3, &cohort.edall->daily_hkminec[0]) );
+      }
+      else if(curr_spec.monthly){
+        start3[0] = month_timestep;
+        hkminec = cohort.edall->m_soid.hkminec;
+        temutil::nc( nc_put_var1_double(ncid, cv, start3, &hkminec) );
+      }
+      else if(curr_spec.yearly){
+        start3[0] = year;
+        hkminec = cohort.edall->y_soid.hkminec;
+        temutil::nc( nc_put_var1_double(ncid, cv, start3, &hkminec) );
+      }
 
-    temutil::nc( nc_close(ncid) );
+      temutil::nc( nc_close(ncid) );
+    }//end critical(outputHKMINEC)
   }//end HKMINEC
   map_itr = netcdf_outputs.end();
 
@@ -1780,26 +1866,29 @@ void Runner::output_netCDF(std::map<std::string, output_spec> &netcdf_outputs, i
     curr_spec = map_itr->second;
     curr_filename = curr_spec.file_path + curr_spec.filename_prefix + file_stage_suffix;
 
-    temutil::nc( nc_open(curr_filename.c_str(), NC_WRITE, &ncid) );
-    temutil::nc( nc_inq_varid(ncid, "HKSHLW", &cv) );
+    #pragma omp critical(outputHKSHLW)
+    {
+      temutil::nc( nc_open(curr_filename.c_str(), NC_WRITE, &ncid) );
+      temutil::nc( nc_inq_varid(ncid, "HKSHLW", &cv) );
 
-    double hkshlw;
-    if(curr_spec.daily){
-      start3[0] = day_timestep; 
-      temutil::nc( nc_put_vara_double(ncid, cv, start3, count3, &cohort.edall->daily_hkshlw[0]) );
-    }
-    else if(curr_spec.monthly){
-      start3[0] = month_timestep;
-      hkshlw = cohort.edall->m_soid.hkshlw;
-      temutil::nc( nc_put_var1_double(ncid, cv, start3, &hkshlw) );
-    }
-    else if(curr_spec.yearly){
-      start3[0] = year;
-      hkshlw = cohort.edall->y_soid.hkshlw;
-      temutil::nc( nc_put_var1_double(ncid, cv, start3, &hkshlw) );
-    }
+      double hkshlw;
+      if(curr_spec.daily){
+        start3[0] = day_timestep; 
+        temutil::nc( nc_put_vara_double(ncid, cv, start3, count3, &cohort.edall->daily_hkshlw[0]) );
+      }
+      else if(curr_spec.monthly){
+        start3[0] = month_timestep;
+        hkshlw = cohort.edall->m_soid.hkshlw;
+        temutil::nc( nc_put_var1_double(ncid, cv, start3, &hkshlw) );
+      }
+      else if(curr_spec.yearly){
+        start3[0] = year;
+        hkshlw = cohort.edall->y_soid.hkshlw;
+        temutil::nc( nc_put_var1_double(ncid, cv, start3, &hkshlw) );
+      }
 
-    temutil::nc( nc_close(ncid) );
+      temutil::nc( nc_close(ncid) );
+    }
   }//end HKSHLW 
   map_itr = netcdf_outputs.end();
 
@@ -1811,36 +1900,39 @@ void Runner::output_netCDF(std::map<std::string, output_spec> &netcdf_outputs, i
     curr_spec = map_itr->second;
     curr_filename = curr_spec.file_path + curr_spec.filename_prefix + file_stage_suffix;
 
-    temutil::nc( nc_open(curr_filename.c_str(), NC_WRITE, &ncid) );
-    temutil::nc( nc_inq_varid(ncid, "SNOWTHICK", &cv) );
+    #pragma omp critical(outputSNOWTHICK)
+    {
+      temutil::nc( nc_open(curr_filename.c_str(), NC_WRITE, &ncid) );
+      temutil::nc( nc_inq_varid(ncid, "SNOWTHICK", &cv) );
 
-    if(curr_spec.daily){
-      start3[0] = day_timestep;
-      temutil::nc( nc_put_vara_double(ncid, cv, start3, count3, &cohort.edall->daily_snowthick[0]) );
-    }
-    else if(curr_spec.monthly){
-      start3[0] = month_timestep;
-      double snowthick;
-      Layer* currL = cohort.ground.toplayer;
-      while(currL->isSnow){
-        snowthick += currL->dz;
-        currL = currL->nextl;
+      if(curr_spec.daily){
+        start3[0] = day_timestep;
+        temutil::nc( nc_put_vara_double(ncid, cv, start3, count3, &cohort.edall->daily_snowthick[0]) );
+      }
+      else if(curr_spec.monthly){
+        start3[0] = month_timestep;
+        double snowthick;
+        Layer* currL = cohort.ground.toplayer;
+        while(currL->isSnow){
+          snowthick += currL->dz;
+          currL = currL->nextl;
+        }
+
+        temutil::nc( nc_put_var1_double(ncid, cv, start3, &snowthick) );
+      }
+      else if(curr_spec.yearly){
+        start3[0] = year;
+        double snowthick;
+        Layer* currL = cohort.ground.toplayer;
+        while(currL->isSnow){
+          snowthick += currL->dz;
+          currL = currL->nextl;
+        }
+        temutil::nc( nc_put_var1_double(ncid, cv, start3, &snowthick) );
       }
 
-      temutil::nc( nc_put_var1_double(ncid, cv, start3, &snowthick) );
-    }
-    else if(curr_spec.yearly){
-      start3[0] = year;
-      double snowthick;
-      Layer* currL = cohort.ground.toplayer;
-      while(currL->isSnow){
-        snowthick += currL->dz;
-        currL = currL->nextl;
-      }
-      temutil::nc( nc_put_var1_double(ncid, cv, start3, &snowthick) );
-    }
-
-    temutil::nc( nc_close(ncid) ); 
+      temutil::nc( nc_close(ncid) ); 
+    }//end critical(outputSNOWTHICK)
   }//end SNOWTHICK
   map_itr = netcdf_outputs.end();
 
@@ -1852,25 +1944,28 @@ void Runner::output_netCDF(std::map<std::string, output_spec> &netcdf_outputs, i
     curr_spec = map_itr->second;
     curr_filename = curr_spec.file_path + curr_spec.filename_prefix + file_stage_suffix;
 
-    temutil::nc( nc_open(curr_filename.c_str(), NC_WRITE, &ncid) );
-    temutil::nc( nc_inq_varid(ncid, "SWE", &cv) );
+    #pragma omp critical(outputSWE)
+    {
+      temutil::nc( nc_open(curr_filename.c_str(), NC_WRITE, &ncid) );
+      temutil::nc( nc_inq_varid(ncid, "SWE", &cv) );
 
-    double swe;
-    if(curr_spec.daily){
-      start3[0] = day_timestep;
-      temutil::nc( nc_put_vara_double(ncid, cv, start3, count3, &cohort.edall->daily_swesum[0]) );
-    }
+      double swe;
+      if(curr_spec.daily){
+        start3[0] = day_timestep;
+        temutil::nc( nc_put_vara_double(ncid, cv, start3, count3, &cohort.edall->daily_swesum[0]) );
+      }
 
-    else if(curr_spec.monthly){
-      start3[0] = month_timestep;
-      temutil::nc( nc_put_var1_double(ncid, cv, start3, &cohort.edall->m_snws.swesum) );
-    }
-    else if(curr_spec.yearly){
-      start3[0] = year;
-      temutil::nc( nc_put_var1_double(ncid, cv, start3, &cohort.edall->y_snws.swesum) );
-    }
+      else if(curr_spec.monthly){
+        start3[0] = month_timestep;
+        temutil::nc( nc_put_var1_double(ncid, cv, start3, &cohort.edall->m_snws.swesum) );
+      }
+      else if(curr_spec.yearly){
+        start3[0] = year;
+        temutil::nc( nc_put_var1_double(ncid, cv, start3, &cohort.edall->y_snws.swesum) );
+      }
 
-    temutil::nc( nc_close(ncid) ); 
+      temutil::nc( nc_close(ncid) ); 
+    }//end critical(outputSWE)
   }//end SWE
   map_itr = netcdf_outputs.end();
 
@@ -1882,26 +1977,29 @@ void Runner::output_netCDF(std::map<std::string, output_spec> &netcdf_outputs, i
     curr_spec = map_itr->second;
     curr_filename = curr_spec.file_path + curr_spec.filename_prefix + file_stage_suffix;
 
-    temutil::nc( nc_open(curr_filename.c_str(), NC_WRITE, &ncid) );
-    temutil::nc( nc_inq_varid(ncid, "TCDEEP", &cv) );
+    #pragma omp critical(outputTCDEEP)
+    {
+      temutil::nc( nc_open(curr_filename.c_str(), NC_WRITE, &ncid) );
+      temutil::nc( nc_inq_varid(ncid, "TCDEEP", &cv) );
 
-    double tcdeep;
-    if(curr_spec.daily){
-      start3[0] = day_timestep;
-      temutil::nc( nc_put_vara_double(ncid, cv, start3, count3, &cohort.edall->daily_tcdeep[0]) );
-    }
-    else if(curr_spec.monthly){
-      start3[0] = month_timestep;
-      tcdeep = cohort.edall->m_soid.tcdeep;
-      temutil::nc( nc_put_var1_double(ncid, cv, start3, &tcdeep) );
-    }
-    else if(curr_spec.yearly){
-      start3[0] = year;
-      tcdeep = cohort.edall->y_soid.tcdeep;
-      temutil::nc( nc_put_var1_double(ncid, cv, start3, &tcdeep) );
-    }
+      double tcdeep;
+      if(curr_spec.daily){
+        start3[0] = day_timestep;
+        temutil::nc( nc_put_vara_double(ncid, cv, start3, count3, &cohort.edall->daily_tcdeep[0]) );
+      }
+      else if(curr_spec.monthly){
+        start3[0] = month_timestep;
+        tcdeep = cohort.edall->m_soid.tcdeep;
+        temutil::nc( nc_put_var1_double(ncid, cv, start3, &tcdeep) );
+      }
+      else if(curr_spec.yearly){
+        start3[0] = year;
+        tcdeep = cohort.edall->y_soid.tcdeep;
+        temutil::nc( nc_put_var1_double(ncid, cv, start3, &tcdeep) );
+      }
 
-    temutil::nc( nc_close(ncid) );
+      temutil::nc( nc_close(ncid) );
+    }//end critical(outputTCDEEP)
   }//end TCDEEP
   map_itr = netcdf_outputs.end();
 
@@ -1913,19 +2011,22 @@ void Runner::output_netCDF(std::map<std::string, output_spec> &netcdf_outputs, i
     curr_spec = map_itr->second;
     curr_filename = curr_spec.file_path + curr_spec.filename_prefix + file_stage_suffix;
 
-    temutil::nc( nc_open(curr_filename.c_str(), NC_WRITE, &ncid) );
-    temutil::nc( nc_inq_varid(ncid, "TCLAYER", &cv) );
+    #pragma omp critical(outputTCLAYER)
+    {
+      temutil::nc( nc_open(curr_filename.c_str(), NC_WRITE, &ncid) );
+      temutil::nc( nc_inq_varid(ncid, "TCLAYER", &cv) );
 
-    if(curr_spec.monthly){
-      soilstart4[0] = month_timestep;
-      temutil::nc( nc_put_vara_double(ncid, cv, soilstart4, soilcount4, &cohort.edall->m_soid.tcond[0]) );
-    }
-    else if(curr_spec.yearly){
-      soilstart4[0] = year;
-      temutil::nc( nc_put_vara_double(ncid, cv, soilstart4, soilcount4, &cohort.edall->y_soid.tcond[0]) );
-    }
+      if(curr_spec.monthly){
+        soilstart4[0] = month_timestep;
+        temutil::nc( nc_put_vara_double(ncid, cv, soilstart4, soilcount4, &cohort.edall->m_soid.tcond[0]) );
+      }
+      else if(curr_spec.yearly){
+        soilstart4[0] = year;
+        temutil::nc( nc_put_vara_double(ncid, cv, soilstart4, soilcount4, &cohort.edall->y_soid.tcond[0]) );
+      }
 
-    temutil::nc( nc_close(ncid) );
+      temutil::nc( nc_close(ncid) );
+    }//end critical(outputTCLAYER)
   }//end TCLAYER
   map_itr = netcdf_outputs.end();
 
@@ -1937,25 +2038,28 @@ void Runner::output_netCDF(std::map<std::string, output_spec> &netcdf_outputs, i
     curr_spec = map_itr->second;
     curr_filename = curr_spec.file_path + curr_spec.filename_prefix + file_stage_suffix;
 
-    temutil::nc( nc_open(curr_filename.c_str(), NC_WRITE, &ncid) );
-    temutil::nc( nc_inq_varid(ncid, "TCMINEA", &cv) );
+    #pragma omp critical(outputTCMINEA)
+    {
+      temutil::nc( nc_open(curr_filename.c_str(), NC_WRITE, &ncid) );
+      temutil::nc( nc_inq_varid(ncid, "TCMINEA", &cv) );
 
-    double tcminea;
-    if(curr_spec.daily){
-      start3[0] = day_timestep;
-      temutil::nc( nc_put_vara_double(ncid, cv, start3, count3, &cohort.edall->daily_tcminea[0]) );
-    }
-    else if(curr_spec.monthly){
-      start3[0] = month_timestep;
-      tcminea = cohort.edall->m_soid.tcminea;
-      temutil::nc( nc_put_var1_double(ncid, cv, start3, &tcminea) );
-    }
-    else if(curr_spec.yearly){
-      start3[0] = year;
-      tcminea = cohort.edall->y_soid.tcminea;
-      temutil::nc( nc_put_var1_double(ncid, cv, start3, &tcminea) );
-    }
-    temutil::nc( nc_close(ncid) );
+      double tcminea;
+      if(curr_spec.daily){
+        start3[0] = day_timestep;
+        temutil::nc( nc_put_vara_double(ncid, cv, start3, count3, &cohort.edall->daily_tcminea[0]) );
+      }
+      else if(curr_spec.monthly){
+        start3[0] = month_timestep;
+        tcminea = cohort.edall->m_soid.tcminea;
+        temutil::nc( nc_put_var1_double(ncid, cv, start3, &tcminea) );
+      }
+      else if(curr_spec.yearly){
+        start3[0] = year;
+        tcminea = cohort.edall->y_soid.tcminea;
+        temutil::nc( nc_put_var1_double(ncid, cv, start3, &tcminea) );
+      }
+      temutil::nc( nc_close(ncid) );
+    }//end critical(outputTCMINEA)
   }//end TCMINEA
   map_itr = netcdf_outputs.end();
 
@@ -1967,25 +2071,28 @@ void Runner::output_netCDF(std::map<std::string, output_spec> &netcdf_outputs, i
     curr_spec = map_itr->second;
     curr_filename = curr_spec.file_path + curr_spec.filename_prefix + file_stage_suffix;
 
-    temutil::nc( nc_open(curr_filename.c_str(), NC_WRITE, &ncid) );
-    temutil::nc( nc_inq_varid(ncid, "TCMINEB", &cv) );
+    #pragma omp critical(outputTCMINEB)
+    {
+      temutil::nc( nc_open(curr_filename.c_str(), NC_WRITE, &ncid) );
+      temutil::nc( nc_inq_varid(ncid, "TCMINEB", &cv) );
 
-    double tcmineb;
-    if(curr_spec.daily){
-      start3[0] = day_timestep;
-      temutil::nc( nc_put_vara_double(ncid, cv, start3, count3, &cohort.edall->daily_tcmineb[0]) );
-    }
-    else if(curr_spec.monthly){
-      start3[0] = month_timestep;
-      tcmineb = cohort.edall->m_soid.tcmineb;
-      temutil::nc( nc_put_var1_double(ncid, cv, start3, &tcmineb) );
-    }
-    else if(curr_spec.yearly){
-      start3[0] = year;
-      tcmineb = cohort.edall->y_soid.tcmineb;
-      temutil::nc( nc_put_var1_double(ncid, cv, start3, &tcmineb) );
-    }
-    temutil::nc( nc_close(ncid) );
+      double tcmineb;
+      if(curr_spec.daily){
+        start3[0] = day_timestep;
+        temutil::nc( nc_put_vara_double(ncid, cv, start3, count3, &cohort.edall->daily_tcmineb[0]) );
+      }
+      else if(curr_spec.monthly){
+        start3[0] = month_timestep;
+        tcmineb = cohort.edall->m_soid.tcmineb;
+        temutil::nc( nc_put_var1_double(ncid, cv, start3, &tcmineb) );
+      }
+      else if(curr_spec.yearly){
+        start3[0] = year;
+        tcmineb = cohort.edall->y_soid.tcmineb;
+        temutil::nc( nc_put_var1_double(ncid, cv, start3, &tcmineb) );
+      }
+      temutil::nc( nc_close(ncid) );
+    }//end critical(outputTCMINEB)
   }//end TCMINEB
   map_itr = netcdf_outputs.end();
 
@@ -1997,25 +2104,28 @@ void Runner::output_netCDF(std::map<std::string, output_spec> &netcdf_outputs, i
     curr_spec = map_itr->second;
     curr_filename = curr_spec.file_path + curr_spec.filename_prefix + file_stage_suffix;
 
-    temutil::nc( nc_open(curr_filename.c_str(), NC_WRITE, &ncid) );
-    temutil::nc( nc_inq_varid(ncid, "TCMINEC", &cv) );
+    #pragma omp critical(outputTCMINEC)
+    {
+      temutil::nc( nc_open(curr_filename.c_str(), NC_WRITE, &ncid) );
+      temutil::nc( nc_inq_varid(ncid, "TCMINEC", &cv) );
 
-    double tcminec;
-    if(curr_spec.daily){
-      start3[0] = day_timestep;
-      temutil::nc( nc_put_vara_double(ncid, cv, start3, count3, &cohort.edall->daily_tcminec[0]) );
-    }
-    else if(curr_spec.monthly){
-      start3[0] = month_timestep;
-      tcminec = cohort.edall->m_soid.tcminec;
-      temutil::nc( nc_put_var1_double(ncid, cv, start3, &tcminec) );
-    }
-    else if(curr_spec.yearly){
-      start3[0] = year;
-      tcminec = cohort.edall->y_soid.tcminec;
-      temutil::nc( nc_put_var1_double(ncid, cv, start3, &tcminec) );
-    }
-    temutil::nc( nc_close(ncid) );
+      double tcminec;
+      if(curr_spec.daily){
+        start3[0] = day_timestep;
+        temutil::nc( nc_put_vara_double(ncid, cv, start3, count3, &cohort.edall->daily_tcminec[0]) );
+      }
+      else if(curr_spec.monthly){
+        start3[0] = month_timestep;
+        tcminec = cohort.edall->m_soid.tcminec;
+        temutil::nc( nc_put_var1_double(ncid, cv, start3, &tcminec) );
+      }
+      else if(curr_spec.yearly){
+        start3[0] = year;
+        tcminec = cohort.edall->y_soid.tcminec;
+        temutil::nc( nc_put_var1_double(ncid, cv, start3, &tcminec) );
+      }
+      temutil::nc( nc_close(ncid) );
+    }//end critical(outputTCMINEC)
   }//end TCMINEC
   map_itr = netcdf_outputs.end();
 
@@ -2027,25 +2137,28 @@ void Runner::output_netCDF(std::map<std::string, output_spec> &netcdf_outputs, i
     curr_spec = map_itr->second;
     curr_filename = curr_spec.file_path + curr_spec.filename_prefix + file_stage_suffix;
 
-    temutil::nc( nc_open(curr_filename.c_str(), NC_WRITE, &ncid) );
-    temutil::nc( nc_inq_varid(ncid, "TCSHLW", &cv) );
+    #pragma omp critical(outputTCSHLW)
+    {
+      temutil::nc( nc_open(curr_filename.c_str(), NC_WRITE, &ncid) );
+      temutil::nc( nc_inq_varid(ncid, "TCSHLW", &cv) );
 
-    double tcshlw;
-    if(curr_spec.daily){
-      start3[0] = day_timestep;
-      temutil::nc( nc_put_vara_double(ncid, cv, start3, count3, &cohort.edall->daily_tcshlw[0]) );
-    }
-    else if(curr_spec.monthly){
-      start3[0] = month_timestep;
-      tcshlw = cohort.edall->m_soid.tcshlw;
-      temutil::nc( nc_put_var1_double(ncid, cv, start3, &tcshlw) );
-    }
-    else if(curr_spec.yearly){
-      start3[0] = year;
-      tcshlw = cohort.edall->y_soid.tcshlw;
-      temutil::nc( nc_put_var1_double(ncid, cv, start3, &tcshlw) );
-    }
-    temutil::nc( nc_close(ncid) );
+      double tcshlw;
+      if(curr_spec.daily){
+        start3[0] = day_timestep;
+        temutil::nc( nc_put_vara_double(ncid, cv, start3, count3, &cohort.edall->daily_tcshlw[0]) );
+      }
+      else if(curr_spec.monthly){
+        start3[0] = month_timestep;
+        tcshlw = cohort.edall->m_soid.tcshlw;
+        temutil::nc( nc_put_var1_double(ncid, cv, start3, &tcshlw) );
+      }
+      else if(curr_spec.yearly){
+        start3[0] = year;
+        tcshlw = cohort.edall->y_soid.tcshlw;
+        temutil::nc( nc_put_var1_double(ncid, cv, start3, &tcshlw) );
+      }
+      temutil::nc( nc_close(ncid) );
+    }//end critical(outputTCSHLW)
   }//end TCSHLW
   map_itr = netcdf_outputs.end();
 
@@ -2057,25 +2170,28 @@ void Runner::output_netCDF(std::map<std::string, output_spec> &netcdf_outputs, i
     curr_spec = map_itr->second;
     curr_filename = curr_spec.file_path + curr_spec.filename_prefix + file_stage_suffix;
 
-    temutil::nc( nc_open(curr_filename.c_str(), NC_WRITE, &ncid) );
-    temutil::nc( nc_inq_varid(ncid, "TDEEP", &cv) );
+    #pragma omp critical(outputTDEEP)
+    {
+      temutil::nc( nc_open(curr_filename.c_str(), NC_WRITE, &ncid) );
+      temutil::nc( nc_inq_varid(ncid, "TDEEP", &cv) );
 
-    double tdeep;
-    if(curr_spec.daily){
-      start3[0] = day_timestep;
-      temutil::nc( nc_put_vara_double(ncid, cv, start3, count3, &cohort.edall->daily_tdeep[0]) );
-    }
-    else if(curr_spec.monthly){
-      start3[0] = month_timestep;
-      tdeep = cohort.edall->m_soid.tdeep;
-      temutil::nc( nc_put_var1_double(ncid, cv, start3, &tdeep) );
-    }
-    else if(curr_spec.yearly){
-      start3[0] = year;
-      tdeep = cohort.edall->y_soid.tdeep;
-      temutil::nc( nc_put_var1_double(ncid, cv, start3, &tdeep) );
-    }
-    temutil::nc( nc_close(ncid) );
+      double tdeep;
+      if(curr_spec.daily){
+        start3[0] = day_timestep;
+        temutil::nc( nc_put_vara_double(ncid, cv, start3, count3, &cohort.edall->daily_tdeep[0]) );
+      }
+      else if(curr_spec.monthly){
+        start3[0] = month_timestep;
+        tdeep = cohort.edall->m_soid.tdeep;
+        temutil::nc( nc_put_var1_double(ncid, cv, start3, &tdeep) );
+      }
+      else if(curr_spec.yearly){
+        start3[0] = year;
+        tdeep = cohort.edall->y_soid.tdeep;
+        temutil::nc( nc_put_var1_double(ncid, cv, start3, &tdeep) );
+      }
+      temutil::nc( nc_close(ncid) );
+    }//end critical(outputTDEEP)
   }//end TDEEP
   map_itr = netcdf_outputs.end();
 
@@ -2087,19 +2203,22 @@ void Runner::output_netCDF(std::map<std::string, output_spec> &netcdf_outputs, i
     curr_spec = map_itr->second;
     curr_filename = curr_spec.file_path + curr_spec.filename_prefix + file_stage_suffix;
 
-    temutil::nc( nc_open(curr_filename.c_str(), NC_WRITE, &ncid) );
-    temutil::nc( nc_inq_varid(ncid, "TLAYER", &cv) );
+    #pragma omp critical(outputTLAYER)
+    {
+      temutil::nc( nc_open(curr_filename.c_str(), NC_WRITE, &ncid) );
+      temutil::nc( nc_inq_varid(ncid, "TLAYER", &cv) );
 
-    if(curr_spec.monthly){
-      soilstart4[0] = month_timestep;
-      temutil::nc( nc_put_vara_double(ncid, cv, soilstart4, soilcount4, &cohort.edall->m_sois.ts[0]) );
-    }
-    else if(curr_spec.yearly){
-      soilstart4[0] = year;
-      temutil::nc( nc_put_vara_double(ncid, cv, soilstart4, soilcount4, &cohort.edall->y_sois.ts[0]) );
-    }
+      if(curr_spec.monthly){
+        soilstart4[0] = month_timestep;
+        temutil::nc( nc_put_vara_double(ncid, cv, soilstart4, soilcount4, &cohort.edall->m_sois.ts[0]) );
+      }
+      else if(curr_spec.yearly){
+        soilstart4[0] = year;
+        temutil::nc( nc_put_vara_double(ncid, cv, soilstart4, soilcount4, &cohort.edall->y_sois.ts[0]) );
+      }
 
-    temutil::nc( nc_close(ncid) );
+      temutil::nc( nc_close(ncid) );
+    }//end critical(outputTLAYER)
   }//end TLAYER
   map_itr = netcdf_outputs.end();
 
@@ -2111,25 +2230,28 @@ void Runner::output_netCDF(std::map<std::string, output_spec> &netcdf_outputs, i
     curr_spec = map_itr->second;
     curr_filename = curr_spec.file_path + curr_spec.filename_prefix + file_stage_suffix;
 
-    temutil::nc( nc_open(curr_filename.c_str(), NC_WRITE, &ncid) );
-    temutil::nc( nc_inq_varid(ncid, "TMINEA", &cv) );
+    #pragma omp critical(outputTMINEA)
+    {
+      temutil::nc( nc_open(curr_filename.c_str(), NC_WRITE, &ncid) );
+      temutil::nc( nc_inq_varid(ncid, "TMINEA", &cv) );
 
-    double tminea;
-    if(curr_spec.daily){
-      start3[0] = day_timestep;
-      temutil::nc( nc_put_vara_double(ncid, cv, start3, count3, &cohort.edall->daily_tminea[0]) );
-    }
-    else if(curr_spec.monthly){
-      start3[0] = month_timestep;
-      tminea = cohort.edall->m_soid.tminea;
-      temutil::nc( nc_put_var1_double(ncid, cv, start3, &tminea) );
-    }
-    else if(curr_spec.yearly){
-      start3[0] = year;
-      tminea = cohort.edall->y_soid.tminea;
-      temutil::nc( nc_put_var1_double(ncid, cv, start3, &tminea) );
-    }
-    temutil::nc( nc_close(ncid) );
+      double tminea;
+      if(curr_spec.daily){
+        start3[0] = day_timestep;
+        temutil::nc( nc_put_vara_double(ncid, cv, start3, count3, &cohort.edall->daily_tminea[0]) );
+      }
+      else if(curr_spec.monthly){
+        start3[0] = month_timestep;
+        tminea = cohort.edall->m_soid.tminea;
+        temutil::nc( nc_put_var1_double(ncid, cv, start3, &tminea) );
+      }
+      else if(curr_spec.yearly){
+        start3[0] = year;
+        tminea = cohort.edall->y_soid.tminea;
+        temutil::nc( nc_put_var1_double(ncid, cv, start3, &tminea) );
+      }
+      temutil::nc( nc_close(ncid) );
+    }//end critical(outputTMINEA)
   }//end TMINEA
   map_itr = netcdf_outputs.end();
 
@@ -2141,25 +2263,28 @@ void Runner::output_netCDF(std::map<std::string, output_spec> &netcdf_outputs, i
     curr_spec = map_itr->second;
     curr_filename = curr_spec.file_path + curr_spec.filename_prefix + file_stage_suffix;
 
-    temutil::nc( nc_open(curr_filename.c_str(), NC_WRITE, &ncid) );
-    temutil::nc( nc_inq_varid(ncid, "TMINEB", &cv) );
+    #pragma omp critical(outputTMINEB)
+    {
+      temutil::nc( nc_open(curr_filename.c_str(), NC_WRITE, &ncid) );
+      temutil::nc( nc_inq_varid(ncid, "TMINEB", &cv) );
 
-    double tmineb;
-    if(curr_spec.daily){
-      start3[0] = day_timestep;
-      temutil::nc( nc_put_vara_double(ncid, cv, start3, count3, &cohort.edall->daily_tmineb[0]) );
-    }
-    else if(curr_spec.monthly){
-      start3[0] = month_timestep;
-      tmineb = cohort.edall->m_soid.tmineb;
-      temutil::nc( nc_put_var1_double(ncid, cv, start3, &tmineb) );
-    }
-    else if(curr_spec.yearly){
-      start3[0] = year;
-      tmineb = cohort.edall->y_soid.tmineb;
-      temutil::nc( nc_put_var1_double(ncid, cv, start3, &tmineb) );
-    }
-    temutil::nc( nc_close(ncid) );
+      double tmineb;
+      if(curr_spec.daily){
+        start3[0] = day_timestep;
+        temutil::nc( nc_put_vara_double(ncid, cv, start3, count3, &cohort.edall->daily_tmineb[0]) );
+      }
+      else if(curr_spec.monthly){
+        start3[0] = month_timestep;
+        tmineb = cohort.edall->m_soid.tmineb;
+        temutil::nc( nc_put_var1_double(ncid, cv, start3, &tmineb) );
+      }
+      else if(curr_spec.yearly){
+        start3[0] = year;
+        tmineb = cohort.edall->y_soid.tmineb;
+        temutil::nc( nc_put_var1_double(ncid, cv, start3, &tmineb) );
+      }
+      temutil::nc( nc_close(ncid) );
+    }//end critical(outputTMINEB)
   }//end TMINEB
   map_itr = netcdf_outputs.end();
 
@@ -2171,25 +2296,28 @@ void Runner::output_netCDF(std::map<std::string, output_spec> &netcdf_outputs, i
     curr_spec = map_itr->second;
     curr_filename = curr_spec.file_path + curr_spec.filename_prefix + file_stage_suffix;
 
-    temutil::nc( nc_open(curr_filename.c_str(), NC_WRITE, &ncid) );
-    temutil::nc( nc_inq_varid(ncid, "TMINEC", &cv) );
+    #pragma omp critical(outputTMINEC)
+    {
+      temutil::nc( nc_open(curr_filename.c_str(), NC_WRITE, &ncid) );
+      temutil::nc( nc_inq_varid(ncid, "TMINEC", &cv) );
 
-    double tminec;
-    if(curr_spec.daily){
-      start3[0] = day_timestep;
-      temutil::nc( nc_put_vara_double(ncid, cv, start3, count3, &cohort.edall->daily_tminec[0]) );
-    }
-    else if(curr_spec.monthly){
-      start3[0] = month_timestep;
-      tminec = cohort.edall->m_soid.tminec;
-      temutil::nc( nc_put_var1_double(ncid, cv, start3, &tminec) );
-    }
-    else if(curr_spec.yearly){
-      start3[0] = year;
-      tminec = cohort.edall->y_soid.tminec;
-      temutil::nc( nc_put_var1_double(ncid, cv, start3, &tminec) );
-    }
-    temutil::nc( nc_close(ncid) );
+      double tminec;
+      if(curr_spec.daily){
+        start3[0] = day_timestep;
+        temutil::nc( nc_put_vara_double(ncid, cv, start3, count3, &cohort.edall->daily_tminec[0]) );
+      }
+      else if(curr_spec.monthly){
+        start3[0] = month_timestep;
+        tminec = cohort.edall->m_soid.tminec;
+        temutil::nc( nc_put_var1_double(ncid, cv, start3, &tminec) );
+      }
+      else if(curr_spec.yearly){
+        start3[0] = year;
+        tminec = cohort.edall->y_soid.tminec;
+        temutil::nc( nc_put_var1_double(ncid, cv, start3, &tminec) );
+      }
+      temutil::nc( nc_close(ncid) );
+    }//end critical(outputTMINEC)
   }//end TMINEC
   map_itr = netcdf_outputs.end();
 
@@ -2201,25 +2329,28 @@ void Runner::output_netCDF(std::map<std::string, output_spec> &netcdf_outputs, i
     curr_spec = map_itr->second;
     curr_filename = curr_spec.file_path + curr_spec.filename_prefix + file_stage_suffix;
 
-    temutil::nc( nc_open(curr_filename.c_str(), NC_WRITE, &ncid) );
-    temutil::nc( nc_inq_varid(ncid, "TSHLW", &cv) );
+    #pragma omp critical(outputTSHLW)
+    {
+      temutil::nc( nc_open(curr_filename.c_str(), NC_WRITE, &ncid) );
+      temutil::nc( nc_inq_varid(ncid, "TSHLW", &cv) );
 
-    double tshlw;
-    if(curr_spec.daily){
-      start3[0] = day_timestep;
-      temutil::nc( nc_put_vara_double(ncid, cv, start3, count3, &cohort.edall->daily_tshlw[0]) );
-    }
-    else if(curr_spec.monthly){
-      start3[0] = month_timestep;
-      tshlw = cohort.edall->m_soid.tshlw;
-      temutil::nc( nc_put_var1_double(ncid, cv, start3, &tshlw) );
-    }
-    else if(curr_spec.yearly){
-      start3[0] = year;
-      tshlw = cohort.edall->y_soid.tshlw;
-      temutil::nc( nc_put_var1_double(ncid, cv, start3, &tshlw) );
-    }
-    temutil::nc( nc_close(ncid) );
+      double tshlw;
+      if(curr_spec.daily){
+        start3[0] = day_timestep;
+        temutil::nc( nc_put_vara_double(ncid, cv, start3, count3, &cohort.edall->daily_tshlw[0]) );
+      }
+      else if(curr_spec.monthly){
+        start3[0] = month_timestep;
+        tshlw = cohort.edall->m_soid.tshlw;
+        temutil::nc( nc_put_var1_double(ncid, cv, start3, &tshlw) );
+      }
+      else if(curr_spec.yearly){
+        start3[0] = year;
+        tshlw = cohort.edall->y_soid.tshlw;
+        temutil::nc( nc_put_var1_double(ncid, cv, start3, &tshlw) );
+      }
+      temutil::nc( nc_close(ncid) );
+    }//end critical(outputTSHLW)
   }//end TSHLW
   map_itr = netcdf_outputs.end();
 
@@ -2231,25 +2362,28 @@ void Runner::output_netCDF(std::map<std::string, output_spec> &netcdf_outputs, i
     curr_spec = map_itr->second;
     curr_filename = curr_spec.file_path + curr_spec.filename_prefix + file_stage_suffix;
 
-    temutil::nc( nc_open(curr_filename.c_str(), NC_WRITE, &ncid) );
-    temutil::nc( nc_inq_varid(ncid, "VWCDEEP", &cv) );
+    #pragma omp critical(outputVWCDEEP)
+    {
+      temutil::nc( nc_open(curr_filename.c_str(), NC_WRITE, &ncid) );
+      temutil::nc( nc_inq_varid(ncid, "VWCDEEP", &cv) );
 
-    double vwcdeep;
-    if(curr_spec.daily){
-      start3[0] = day_timestep;
-      temutil::nc( nc_put_vara_double(ncid, cv, start3, count3, &cohort.edall->daily_vwcdeep[0]) );
-    }
-    else if(curr_spec.monthly){
-      start3[0] = month_timestep;
-      vwcdeep = cohort.edall->m_soid.vwcdeep;
-      temutil::nc( nc_put_var1_double(ncid, cv, start3, &vwcdeep) );
-    }
-    else if(curr_spec.yearly){
-      start3[0] = year;
-      vwcdeep = cohort.edall->y_soid.vwcdeep;
-      temutil::nc( nc_put_var1_double(ncid, cv, start3, &vwcdeep) );
-    }
-    temutil::nc( nc_close(ncid) );
+      double vwcdeep;
+      if(curr_spec.daily){
+        start3[0] = day_timestep;
+        temutil::nc( nc_put_vara_double(ncid, cv, start3, count3, &cohort.edall->daily_vwcdeep[0]) );
+      }
+      else if(curr_spec.monthly){
+        start3[0] = month_timestep;
+        vwcdeep = cohort.edall->m_soid.vwcdeep;
+        temutil::nc( nc_put_var1_double(ncid, cv, start3, &vwcdeep) );
+      }
+      else if(curr_spec.yearly){
+        start3[0] = year;
+        vwcdeep = cohort.edall->y_soid.vwcdeep;
+        temutil::nc( nc_put_var1_double(ncid, cv, start3, &vwcdeep) );
+      }
+      temutil::nc( nc_close(ncid) );
+    }//end critical(outputVWCDEEP)
   }//end VWCDEEP
   map_itr = netcdf_outputs.end();
 
@@ -2261,19 +2395,22 @@ void Runner::output_netCDF(std::map<std::string, output_spec> &netcdf_outputs, i
     curr_spec = map_itr->second;
     curr_filename = curr_spec.file_path + curr_spec.filename_prefix + file_stage_suffix;
 
-    temutil::nc( nc_open(curr_filename.c_str(), NC_WRITE, &ncid) );
-    temutil::nc( nc_inq_varid(ncid, "VWCLAYER", &cv) );
+    #pragma omp critical(outputVWCLAYER)
+    {
+      temutil::nc( nc_open(curr_filename.c_str(), NC_WRITE, &ncid) );
+      temutil::nc( nc_inq_varid(ncid, "VWCLAYER", &cv) );
 
-    if(curr_spec.monthly){
-      soilstart4[0] = month_timestep;
-      temutil::nc( nc_put_vara_double(ncid, cv, soilstart4, soilcount4, &cohort.edall->m_soid.vwc[0]) );
-    }
-    else if(curr_spec.yearly){
-      soilstart4[0] = year;
-      temutil::nc( nc_put_vara_double(ncid, cv, soilstart4, soilcount4, &cohort.edall->y_soid.vwc[0]) );
-    }
+      if(curr_spec.monthly){
+        soilstart4[0] = month_timestep;
+        temutil::nc( nc_put_vara_double(ncid, cv, soilstart4, soilcount4, &cohort.edall->m_soid.vwc[0]) );
+      }
+      else if(curr_spec.yearly){
+        soilstart4[0] = year;
+        temutil::nc( nc_put_vara_double(ncid, cv, soilstart4, soilcount4, &cohort.edall->y_soid.vwc[0]) );
+      }
 
-    temutil::nc( nc_close(ncid) );
+      temutil::nc( nc_close(ncid) );
+    }//end critical(outputVWCLAYER)
   }//end VWCLAYER
   map_itr = netcdf_outputs.end();
 
@@ -2285,25 +2422,28 @@ void Runner::output_netCDF(std::map<std::string, output_spec> &netcdf_outputs, i
     curr_spec = map_itr->second;
     curr_filename = curr_spec.file_path + curr_spec.filename_prefix + file_stage_suffix;
 
-    temutil::nc( nc_open(curr_filename.c_str(), NC_WRITE, &ncid) );
-    temutil::nc( nc_inq_varid(ncid, "VWCMINEA", &cv) );
+    #pragma omp critical(outputVWCMINEA)
+    {
+      temutil::nc( nc_open(curr_filename.c_str(), NC_WRITE, &ncid) );
+      temutil::nc( nc_inq_varid(ncid, "VWCMINEA", &cv) );
 
-    double vwcminea;
-    if(curr_spec.daily){
-      start3[0] = day_timestep;
-      temutil::nc( nc_put_vara_double(ncid, cv, start3, count3, &cohort.edall->daily_vwcminea[0]) );
-    }
-    else if(curr_spec.monthly){
-      start3[0] = month_timestep;
-      vwcminea = cohort.edall->m_soid.vwcminea;
-      temutil::nc( nc_put_var1_double(ncid, cv, start3, &vwcminea) );
-    }
-    else if(curr_spec.yearly){
-      start3[0] = year;
-      vwcminea = cohort.edall->y_soid.vwcminea;
-      temutil::nc( nc_put_var1_double(ncid, cv, start3, &vwcminea) );
-    }
-    temutil::nc( nc_close(ncid) );
+      double vwcminea;
+      if(curr_spec.daily){
+        start3[0] = day_timestep;
+        temutil::nc( nc_put_vara_double(ncid, cv, start3, count3, &cohort.edall->daily_vwcminea[0]) );
+      }
+      else if(curr_spec.monthly){
+        start3[0] = month_timestep;
+        vwcminea = cohort.edall->m_soid.vwcminea;
+        temutil::nc( nc_put_var1_double(ncid, cv, start3, &vwcminea) );
+      }
+      else if(curr_spec.yearly){
+        start3[0] = year;
+        vwcminea = cohort.edall->y_soid.vwcminea;
+        temutil::nc( nc_put_var1_double(ncid, cv, start3, &vwcminea) );
+      }
+      temutil::nc( nc_close(ncid) );
+    }//end critical(outputVWCMINEA)
   }//end VWCMINEA
   map_itr = netcdf_outputs.end();
 
@@ -2315,25 +2455,28 @@ void Runner::output_netCDF(std::map<std::string, output_spec> &netcdf_outputs, i
     curr_spec = map_itr->second;
     curr_filename = curr_spec.file_path + curr_spec.filename_prefix + file_stage_suffix;
 
-    temutil::nc( nc_open(curr_filename.c_str(), NC_WRITE, &ncid) );
-    temutil::nc( nc_inq_varid(ncid, "VWCMINEB", &cv) );
+    #pragma omp critical(outputVWCMINEB)
+    {
+      temutil::nc( nc_open(curr_filename.c_str(), NC_WRITE, &ncid) );
+      temutil::nc( nc_inq_varid(ncid, "VWCMINEB", &cv) );
 
-    double vwcmineb;
-    if(curr_spec.daily){
-      start3[0] = day_timestep;
-      temutil::nc( nc_put_vara_double(ncid, cv, start3, count3, &cohort.edall->daily_vwcmineb[0]) );
-    }
-    else if(curr_spec.monthly){
-      start3[0] = month_timestep;
-      vwcmineb = cohort.edall->m_soid.vwcmineb;
-      temutil::nc( nc_put_var1_double(ncid, cv, start3, &vwcmineb) );
-    }
-    else if(curr_spec.yearly){
-      start3[0] = year;
-      vwcmineb = cohort.edall->y_soid.vwcmineb;
-      temutil::nc( nc_put_var1_double(ncid, cv, start3, &vwcmineb) );
-    }
-    temutil::nc( nc_close(ncid) );
+      double vwcmineb;
+      if(curr_spec.daily){
+        start3[0] = day_timestep;
+        temutil::nc( nc_put_vara_double(ncid, cv, start3, count3, &cohort.edall->daily_vwcmineb[0]) );
+      }
+      else if(curr_spec.monthly){
+        start3[0] = month_timestep;
+        vwcmineb = cohort.edall->m_soid.vwcmineb;
+        temutil::nc( nc_put_var1_double(ncid, cv, start3, &vwcmineb) );
+      }
+      else if(curr_spec.yearly){
+        start3[0] = year;
+        vwcmineb = cohort.edall->y_soid.vwcmineb;
+        temutil::nc( nc_put_var1_double(ncid, cv, start3, &vwcmineb) );
+      }
+      temutil::nc( nc_close(ncid) );
+    }//end critical(outputVWCMINEB)
   }//end VWCMINEB
   map_itr = netcdf_outputs.end();
 
@@ -2345,25 +2488,28 @@ void Runner::output_netCDF(std::map<std::string, output_spec> &netcdf_outputs, i
     curr_spec = map_itr->second;
     curr_filename = curr_spec.file_path + curr_spec.filename_prefix + file_stage_suffix;
 
-    temutil::nc( nc_open(curr_filename.c_str(), NC_WRITE, &ncid) );
-    temutil::nc( nc_inq_varid(ncid, "VWCMINEC", &cv) );
+    #pragma omp critical(outputVWCMINEC)
+    {
+      temutil::nc( nc_open(curr_filename.c_str(), NC_WRITE, &ncid) );
+      temutil::nc( nc_inq_varid(ncid, "VWCMINEC", &cv) );
 
-    double vwcminec;
-    if(curr_spec.daily){
-      start3[0] = day_timestep;
-      temutil::nc( nc_put_vara_double(ncid, cv, start3, count3, &cohort.edall->daily_vwcminec[0]) );
-    }
-    else if(curr_spec.monthly){
-      start3[0] = month_timestep;
-      vwcminec = cohort.edall->m_soid.vwcminec;
-      temutil::nc( nc_put_var1_double(ncid, cv, start3, &vwcminec) );
-    }
-    else if(curr_spec.yearly){
-      start3[0] = year;
-      vwcminec = cohort.edall->y_soid.vwcminec;
-      temutil::nc( nc_put_var1_double(ncid, cv, start3, &vwcminec) );
-    }
-    temutil::nc( nc_close(ncid) );
+      double vwcminec;
+      if(curr_spec.daily){
+        start3[0] = day_timestep;
+        temutil::nc( nc_put_vara_double(ncid, cv, start3, count3, &cohort.edall->daily_vwcminec[0]) );
+      }
+      else if(curr_spec.monthly){
+        start3[0] = month_timestep;
+        vwcminec = cohort.edall->m_soid.vwcminec;
+        temutil::nc( nc_put_var1_double(ncid, cv, start3, &vwcminec) );
+      }
+      else if(curr_spec.yearly){
+        start3[0] = year;
+        vwcminec = cohort.edall->y_soid.vwcminec;
+        temutil::nc( nc_put_var1_double(ncid, cv, start3, &vwcminec) );
+      }
+      temutil::nc( nc_close(ncid) );
+    }//end critical(outputVWCMINEC)
   }//end VWCMINEC
   map_itr = netcdf_outputs.end();
 
@@ -2375,25 +2521,28 @@ void Runner::output_netCDF(std::map<std::string, output_spec> &netcdf_outputs, i
     curr_spec = map_itr->second;
     curr_filename = curr_spec.file_path + curr_spec.filename_prefix + file_stage_suffix;
 
-    temutil::nc( nc_open(curr_filename.c_str(), NC_WRITE, &ncid) );
-    temutil::nc( nc_inq_varid(ncid, "VWCSHLW", &cv) );
+    #pragma omp critical(outputVWCSHLW)
+    {
+      temutil::nc( nc_open(curr_filename.c_str(), NC_WRITE, &ncid) );
+      temutil::nc( nc_inq_varid(ncid, "VWCSHLW", &cv) );
 
-    double vwcshlw;
-    if(curr_spec.daily){
-      start3[0] = day_timestep;
-      temutil::nc( nc_put_vara_double(ncid, cv, start3, count3, &cohort.edall->daily_vwcshlw[0]) );      
-    }
-    else if(curr_spec.monthly){
-      start3[0] = month_timestep;
-      vwcshlw = cohort.edall->m_soid.vwcshlw;
-      temutil::nc( nc_put_var1_double(ncid, cv, start3, &vwcshlw) );
-    }
-    else if(curr_spec.yearly){
-      start3[0] = year;
-      vwcshlw = cohort.edall->y_soid.vwcshlw;
-      temutil::nc( nc_put_var1_double(ncid, cv, start3, &vwcshlw) );
-    }
-    temutil::nc( nc_close(ncid) );
+      double vwcshlw;
+      if(curr_spec.daily){
+        start3[0] = day_timestep;
+        temutil::nc( nc_put_vara_double(ncid, cv, start3, count3, &cohort.edall->daily_vwcshlw[0]) );      
+      }
+      else if(curr_spec.monthly){
+        start3[0] = month_timestep;
+        vwcshlw = cohort.edall->m_soid.vwcshlw;
+        temutil::nc( nc_put_var1_double(ncid, cv, start3, &vwcshlw) );
+      }
+      else if(curr_spec.yearly){
+        start3[0] = year;
+        vwcshlw = cohort.edall->y_soid.vwcshlw;
+        temutil::nc( nc_put_var1_double(ncid, cv, start3, &vwcshlw) );
+      }
+      temutil::nc( nc_close(ncid) );
+    }//end critical(outputVWCSHLW)
   }//end VWCSHLW
   map_itr = netcdf_outputs.end();
 
@@ -2405,25 +2554,28 @@ void Runner::output_netCDF(std::map<std::string, output_spec> &netcdf_outputs, i
     curr_spec = map_itr->second;
     curr_filename = curr_spec.file_path + curr_spec.filename_prefix + file_stage_suffix;
 
-    temutil::nc( nc_open(curr_filename.c_str(), NC_WRITE, &ncid) );
-    temutil::nc( nc_inq_varid(ncid, "WATERTAB", &cv) );
+    #pragma omp critical(outputWATERTAB)
+    {
+      temutil::nc( nc_open(curr_filename.c_str(), NC_WRITE, &ncid) );
+      temutil::nc( nc_inq_varid(ncid, "WATERTAB", &cv) );
 
-    double watertab;
-    if(curr_spec.daily){
-      start3[0] = day_timestep;
-      temutil::nc( nc_put_vara_double(ncid, cv, start3, count3, &cohort.edall->daily_watertab[0]) );      
-    }
-    else if(curr_spec.monthly){
-      start3[0] = month_timestep;
-      watertab = cohort.edall->m_sois.watertab;
-      temutil::nc( nc_put_var1_double(ncid, cv, start3, &watertab) );
-    }
-    else if(curr_spec.yearly){
-      start3[0] = year;
-      watertab = cohort.edall->y_sois.watertab;
-      temutil::nc( nc_put_var1_double(ncid, cv, start3, &watertab) );
-    }
-    temutil::nc( nc_close(ncid) );
+      double watertab;
+      if(curr_spec.daily){
+        start3[0] = day_timestep;
+        temutil::nc( nc_put_vara_double(ncid, cv, start3, count3, &cohort.edall->daily_watertab[0]) );      
+      }
+      else if(curr_spec.monthly){
+        start3[0] = month_timestep;
+        watertab = cohort.edall->m_sois.watertab;
+        temutil::nc( nc_put_var1_double(ncid, cv, start3, &watertab) );
+      }
+      else if(curr_spec.yearly){
+        start3[0] = year;
+        watertab = cohort.edall->y_sois.watertab;
+        temutil::nc( nc_put_var1_double(ncid, cv, start3, &watertab) );
+      }
+      temutil::nc( nc_close(ncid) );
+    }//end critical(outputWATERTAB)
   }//end WATERTAB
   map_itr = netcdf_outputs.end();
 
@@ -2436,19 +2588,22 @@ void Runner::output_netCDF(std::map<std::string, output_spec> &netcdf_outputs, i
     curr_spec = map_itr->second;
     curr_filename = curr_spec.file_path + curr_spec.filename_prefix + file_stage_suffix;
 
-    temutil::nc( nc_open(curr_filename.c_str(), NC_WRITE, &ncid) );
-    temutil::nc( nc_inq_varid(ncid, "LAYERDEPTH", &cv) );
+    #pragma omp critical(outputLAYERDEPTH)
+    {
+      temutil::nc( nc_open(curr_filename.c_str(), NC_WRITE, &ncid) );
+      temutil::nc( nc_inq_varid(ncid, "LAYERDEPTH", &cv) );
 
-    if(curr_spec.monthly){
-      soilstart4[0] = month_timestep;
-      temutil::nc( nc_put_vara_double(ncid, cv, soilstart4, soilcount4, &cohort.cd.m_soil.z[0]) );
-    }
-    else if(curr_spec.yearly){
-      soilstart4[0] = year;
-      temutil::nc( nc_put_vara_double(ncid, cv, soilstart4, soilcount4, &cohort.cd.y_soil.z[0]) );
-    }
+      if(curr_spec.monthly){
+        soilstart4[0] = month_timestep;
+        temutil::nc( nc_put_vara_double(ncid, cv, soilstart4, soilcount4, &cohort.cd.m_soil.z[0]) );
+      }
+      else if(curr_spec.yearly){
+        soilstart4[0] = year;
+        temutil::nc( nc_put_vara_double(ncid, cv, soilstart4, soilcount4, &cohort.cd.y_soil.z[0]) );
+      }
 
-    temutil::nc( nc_close(ncid) );
+      temutil::nc( nc_close(ncid) );
+    }//end critical(outputLAYERDEPTH)
   }//end LAYERDEPTH 
   map_itr = netcdf_outputs.end();
 
@@ -2460,19 +2615,22 @@ void Runner::output_netCDF(std::map<std::string, output_spec> &netcdf_outputs, i
     curr_spec = map_itr->second;
     curr_filename = curr_spec.file_path + curr_spec.filename_prefix + file_stage_suffix;
 
-    temutil::nc( nc_open(curr_filename.c_str(), NC_WRITE, &ncid) );
-    temutil::nc( nc_inq_varid(ncid, "LAYERDZ", &cv) );
+    #pragma omp critical(outputLAYERDZ)
+    {
+      temutil::nc( nc_open(curr_filename.c_str(), NC_WRITE, &ncid) );
+      temutil::nc( nc_inq_varid(ncid, "LAYERDZ", &cv) );
 
-    if(curr_spec.monthly){
-      soilstart4[0] = month_timestep;
-      temutil::nc( nc_put_vara_double(ncid, cv, soilstart4, soilcount4, &cohort.cd.m_soil.dz[0]) );
-    }
-    else if(curr_spec.yearly){
-      soilstart4[0] = year;
-      temutil::nc( nc_put_vara_double(ncid, cv, soilstart4, soilcount4, &cohort.cd.y_soil.dz[0]) );
-    }
+      if(curr_spec.monthly){
+        soilstart4[0] = month_timestep;
+        temutil::nc( nc_put_vara_double(ncid, cv, soilstart4, soilcount4, &cohort.cd.m_soil.dz[0]) );
+      }
+      else if(curr_spec.yearly){
+        soilstart4[0] = year;
+        temutil::nc( nc_put_vara_double(ncid, cv, soilstart4, soilcount4, &cohort.cd.y_soil.dz[0]) );
+      }
 
-    temutil::nc( nc_close(ncid) );
+      temutil::nc( nc_close(ncid) );
+    }//end critical(outputLAYERDZ)
   }//end LAYERDZ 
   map_itr = netcdf_outputs.end();
 
@@ -2484,19 +2642,22 @@ void Runner::output_netCDF(std::map<std::string, output_spec> &netcdf_outputs, i
     curr_spec = map_itr->second;
     curr_filename = curr_spec.file_path + curr_spec.filename_prefix + file_stage_suffix;
 
-    temutil::nc( nc_open(curr_filename.c_str(), NC_WRITE, &ncid) );
-    temutil::nc( nc_inq_varid(ncid, "LAYERTYPE", &cv) );
+    #pragma omp critical(outputLAYERTYPE)
+    {
+      temutil::nc( nc_open(curr_filename.c_str(), NC_WRITE, &ncid) );
+      temutil::nc( nc_inq_varid(ncid, "LAYERTYPE", &cv) );
 
-    if(curr_spec.monthly){
-      soilstart4[0] = month_timestep;
-      temutil::nc( nc_put_vara_int(ncid, cv, soilstart4, soilcount4, &cohort.cd.m_soil.type[0]) );
-    }
-    else if(curr_spec.yearly){
-      soilstart4[0] = year;
-      temutil::nc( nc_put_vara_int(ncid, cv, soilstart4, soilcount4, &cohort.cd.y_soil.type[0]) );
-    }
+      if(curr_spec.monthly){
+        soilstart4[0] = month_timestep;
+        temutil::nc( nc_put_vara_int(ncid, cv, soilstart4, soilcount4, &cohort.cd.m_soil.type[0]) );
+      }
+      else if(curr_spec.yearly){
+        soilstart4[0] = year;
+        temutil::nc( nc_put_vara_int(ncid, cv, soilstart4, soilcount4, &cohort.cd.y_soil.type[0]) );
+      }
 
-    temutil::nc( nc_close(ncid) );
+      temutil::nc( nc_close(ncid) );
+    }//end critical(outputLAYERTYPE)
   }//end LAYERTYPE 
   map_itr = netcdf_outputs.end();
 
@@ -2509,40 +2670,43 @@ void Runner::output_netCDF(std::map<std::string, output_spec> &netcdf_outputs, i
     curr_spec = map_itr->second;
     curr_filename = curr_spec.file_path + curr_spec.filename_prefix + file_stage_suffix;
 
-    temutil::nc( nc_open(curr_filename.c_str(), NC_WRITE, &ncid) );
-    temutil::nc( nc_inq_varid(ncid, "AVLN", &cv) );
+    #pragma omp critical(outputAVLN)
+    {
+      temutil::nc( nc_open(curr_filename.c_str(), NC_WRITE, &ncid) );
+      temutil::nc( nc_inq_varid(ncid, "AVLN", &cv) );
 
-    if(curr_spec.layer){
+      if(curr_spec.layer){
 
-      double avln[MAX_SOI_LAY];
-      if(curr_spec.monthly){
-        soilstart4[0] = month_timestep;
-        for(int il=0; il<MAX_SOI_LAY; il++){
-          avln[il] = cohort.bdall->m_sois.avln[il];
+        double avln[MAX_SOI_LAY];
+        if(curr_spec.monthly){
+          soilstart4[0] = month_timestep;
+          for(int il=0; il<MAX_SOI_LAY; il++){
+            avln[il] = cohort.bdall->m_sois.avln[il];
+          }
         }
-      }
-      else if(curr_spec.yearly){
-        soilstart4[0] = year;
-        for(int il=0; il<MAX_SOI_LAY; il++){
-          avln[il] = cohort.bdall->y_sois.avln[il];
+        else if(curr_spec.yearly){
+          soilstart4[0] = year;
+          for(int il=0; il<MAX_SOI_LAY; il++){
+            avln[il] = cohort.bdall->y_sois.avln[il];
+          }
         }
+        temutil::nc( nc_put_vara_double(ncid, cv, soilstart4, soilcount4, &avln[0]) );
       }
-      temutil::nc( nc_put_vara_double(ncid, cv, soilstart4, soilcount4, &avln[0]) );
-    }
-    else if(!curr_spec.layer){
+      else if(!curr_spec.layer){
 
-      double avln;
-      if(curr_spec.monthly){
-        start3[0] = month_timestep;
-        avln = cohort.bdall->m_soid.avlnsum;
+        double avln;
+        if(curr_spec.monthly){
+          start3[0] = month_timestep;
+          avln = cohort.bdall->m_soid.avlnsum;
+        }
+        else if(curr_spec.yearly){
+          start3[0] = year;
+          avln = cohort.bdall->y_soid.avlnsum;
+        }
+        temutil::nc( nc_put_var1_double(ncid, cv, start3, &avln) );
       }
-      else if(curr_spec.yearly){
-        start3[0] = year;
-        avln = cohort.bdall->y_soid.avlnsum;
-      }
-      temutil::nc( nc_put_var1_double(ncid, cv, start3, &avln) );
-    }
-    temutil::nc( nc_close(ncid) );
+      temutil::nc( nc_close(ncid) );
+    }//end critical(outputAVLN)
   }//end AVLN
   map_itr = netcdf_outputs.end();
 
@@ -2554,30 +2718,33 @@ void Runner::output_netCDF(std::map<std::string, output_spec> &netcdf_outputs, i
     curr_spec = map_itr->second;
     curr_filename = curr_spec.file_path + curr_spec.filename_prefix + file_stage_suffix;
 
-    temutil::nc( nc_open(curr_filename.c_str(), NC_WRITE, &ncid) );
-    temutil::nc( nc_inq_varid(ncid, "BURNSOIC", &cv) );
+    #pragma omp critical(outputBURNSOIC)
+    {
+      temutil::nc( nc_open(curr_filename.c_str(), NC_WRITE, &ncid) );
+      temutil::nc( nc_inq_varid(ncid, "BURNSOIC", &cv) );
 
-    if(curr_spec.layer){
-      /*** STUB ***/
-      //By-layer may not be feasible yet.
-    }
-    else if(!curr_spec.layer){
-
-      double burnsoilC;
-      if(curr_spec.monthly){
-        start3[0] = month_timestep;
-        burnsoilC = cohort.year_fd[month].fire_soi2a.orgc;
+      if(curr_spec.layer){
+        /*** STUB ***/
+        //By-layer may not be feasible yet.
       }
-      else if(curr_spec.yearly){
-        start3[0] = year;
-        burnsoilC = 0;
-        for(int im=0; im<12; im++){
-          burnsoilC += cohort.year_fd[im].fire_soi2a.orgc;
+      else if(!curr_spec.layer){
+
+        double burnsoilC;
+        if(curr_spec.monthly){
+          start3[0] = month_timestep;
+          burnsoilC = cohort.year_fd[month].fire_soi2a.orgc;
         }
+        else if(curr_spec.yearly){
+          start3[0] = year;
+          burnsoilC = 0;
+          for(int im=0; im<12; im++){
+            burnsoilC += cohort.year_fd[im].fire_soi2a.orgc;
+          }
+        }
+        temutil::nc( nc_put_var1_double(ncid, cv, start3, &burnsoilC) );
       }
-      temutil::nc( nc_put_var1_double(ncid, cv, start3, &burnsoilC) );
-    }
-    temutil::nc( nc_close(ncid) );
+      temutil::nc( nc_close(ncid) );
+    }//end critical(outputBURNSOIC)
   }//end BURNSOIC
   map_itr = netcdf_outputs.end();
 
@@ -2589,30 +2756,33 @@ void Runner::output_netCDF(std::map<std::string, output_spec> &netcdf_outputs, i
     curr_spec = map_itr->second;
     curr_filename = curr_spec.file_path + curr_spec.filename_prefix + file_stage_suffix;
 
-    temutil::nc( nc_open(curr_filename.c_str(), NC_WRITE, &ncid) );
-    temutil::nc( nc_inq_varid(ncid, "BURNSOILN", &cv) );
+    #pragma omp critical(outputBURNSOILN)
+    {
+      temutil::nc( nc_open(curr_filename.c_str(), NC_WRITE, &ncid) );
+      temutil::nc( nc_inq_varid(ncid, "BURNSOILN", &cv) );
 
-    if(curr_spec.layer){
-      /*** STUB ***/
-    }
-    else if(!curr_spec.layer){
-
-      double burnSoilN;
-      if(curr_spec.monthly){
-        start3[0] = month_timestep;
-        burnSoilN = cohort.year_fd[month].fire_soi2a.orgn;
+      if(curr_spec.layer){
+        /*** STUB ***/
       }
-      else if(curr_spec.yearly){
-        start3[0] = year;
-        burnSoilN = 0;
-        for(int im=0; im<12; im++){
-          burnSoilN += cohort.year_fd[im].fire_soi2a.orgn;
+      else if(!curr_spec.layer){
+
+        double burnSoilN;
+        if(curr_spec.monthly){
+          start3[0] = month_timestep;
+          burnSoilN = cohort.year_fd[month].fire_soi2a.orgn;
         }
+        else if(curr_spec.yearly){
+          start3[0] = year;
+          burnSoilN = 0;
+          for(int im=0; im<12; im++){
+            burnSoilN += cohort.year_fd[im].fire_soi2a.orgn;
+          }
+        }
+        temutil::nc( nc_put_var1_double(ncid, cv, start3, &burnSoilN) );
       }
-      temutil::nc( nc_put_var1_double(ncid, cv, start3, &burnSoilN) );
-    }
 
-    temutil::nc( nc_close(ncid) );
+      temutil::nc( nc_close(ncid) );
+    }//end critical(outputBURNSOILN)
   }//end BURNSOILN
   map_itr = netcdf_outputs.end();
 
@@ -2624,40 +2794,43 @@ void Runner::output_netCDF(std::map<std::string, output_spec> &netcdf_outputs, i
     curr_spec = map_itr->second;
     curr_filename = curr_spec.file_path + curr_spec.filename_prefix + file_stage_suffix;
 
-    temutil::nc( nc_open(curr_filename.c_str(), NC_WRITE, &ncid) );
-    temutil::nc( nc_inq_varid(ncid, "NDRAIN", &cv) );
+    #pragma omp critical(outputNDRAIN)
+    {
+      temutil::nc( nc_open(curr_filename.c_str(), NC_WRITE, &ncid) );
+      temutil::nc( nc_inq_varid(ncid, "NDRAIN", &cv) );
 
-    if(curr_spec.layer){
+      if(curr_spec.layer){
 
-      if(curr_spec.monthly){
-        soilstart4[0] = month_timestep;
-        //temutil::nc( nc_put_vara_double(ncid, cv, soilstart4, soilcount4, &cohort.soilbgc.bd->m_soi2l.ndrain[0]) );
+        if(curr_spec.monthly){
+          soilstart4[0] = month_timestep;
+          //temutil::nc( nc_put_vara_double(ncid, cv, soilstart4, soilcount4, &cohort.soilbgc.bd->m_soi2l.ndrain[0]) );
+        }
+        else if(curr_spec.yearly){
+          /*** STUB ***/
+        }
       }
-      else if(curr_spec.yearly){
-        /*** STUB ***/
-      }
-    }
-    else if(!curr_spec.layer){
+      else if(!curr_spec.layer){
 
-      double ndrain = 0;
-      if(curr_spec.monthly){
-        start3[0] = month_timestep;
+        double ndrain = 0;
+        if(curr_spec.monthly){
+          start3[0] = month_timestep;
 
-        for(int il=0; il<MAX_SOI_LAY; il++){
-          //ndrain += bd->m_soi2l.ndrain[il];
+          for(int il=0; il<MAX_SOI_LAY; il++){
+            //ndrain += bd->m_soi2l.ndrain[il];
+            /*** STUB ***/
+          }
+
+        }
+        if(curr_spec.yearly){
+          start3[0] = year;
           /*** STUB ***/
         }
 
-      }
-      if(curr_spec.yearly){
-        start3[0] = year;
-        /*** STUB ***/
+        //temutil::nc( nc_put_var1_double(ncid, cv, start3, &ndrain) );
       }
 
-      //temutil::nc( nc_put_var1_double(ncid, cv, start3, &ndrain) );
-    }
-
-    temutil::nc( nc_close(ncid) );
+      temutil::nc( nc_close(ncid) );
+    }//end critical(outputNDRAIN)
   }//end NDRAIN
   map_itr = netcdf_outputs.end();
 
@@ -2669,41 +2842,44 @@ void Runner::output_netCDF(std::map<std::string, output_spec> &netcdf_outputs, i
     curr_spec = map_itr->second;
     curr_filename = curr_spec.file_path + curr_spec.filename_prefix + file_stage_suffix;
 
-    temutil::nc( nc_open(curr_filename.c_str(), NC_WRITE, &ncid) );
-    temutil::nc( nc_inq_varid(ncid, "NETNMIN", &cv) );
+    #pragma omp critical(outputNETNMIN)
+    {
+      temutil::nc( nc_open(curr_filename.c_str(), NC_WRITE, &ncid) );
+      temutil::nc( nc_inq_varid(ncid, "NETNMIN", &cv) );
 
-    if(curr_spec.layer){
+      if(curr_spec.layer){
 
-      double netnmin[MAX_SOI_LAY];
-      for(int il=0; il<MAX_SOI_LAY; il++){
+        double netnmin[MAX_SOI_LAY];
+        for(int il=0; il<MAX_SOI_LAY; il++){
+          if(curr_spec.monthly){
+            soilstart4[0] = month_timestep;
+            netnmin[il] = cohort.bdall->m_soi2soi.netnmin[il];
+          }
+          else if(curr_spec.yearly){
+            soilstart4[0] = year;
+            netnmin[il] = cohort.bdall->y_soi2soi.netnmin[il];
+          }
+        }
+
+        temutil::nc( nc_put_vara_double(ncid, cv, soilstart4, soilcount4, &netnmin[0]) );
+      }
+      //Total, instead of by layer
+      else if(!curr_spec.layer){
+
+        double netnmin;
         if(curr_spec.monthly){
-          soilstart4[0] = month_timestep;
-          netnmin[il] = cohort.bdall->m_soi2soi.netnmin[il];
+          start3[0] = month_timestep;
+          netnmin = cohort.bdall->m_soi2soi.netnminsum;
         }
         else if(curr_spec.yearly){
-          soilstart4[0] = year;
-          netnmin[il] = cohort.bdall->y_soi2soi.netnmin[il];
+          start3[0] = year;
+          netnmin = cohort.bdall->y_soi2soi.netnminsum;
         }
-      }
 
-      temutil::nc( nc_put_vara_double(ncid, cv, soilstart4, soilcount4, &netnmin[0]) );
-    }
-    //Total, instead of by layer
-    else if(!curr_spec.layer){
-
-      double netnmin;
-      if(curr_spec.monthly){
-        start3[0] = month_timestep;
-        netnmin = cohort.bdall->m_soi2soi.netnminsum;
+        temutil::nc( nc_put_var1_double(ncid, cv, start3, &netnmin) );
       }
-      else if(curr_spec.yearly){
-        start3[0] = year;
-        netnmin = cohort.bdall->y_soi2soi.netnminsum;
-      }
-
-      temutil::nc( nc_put_var1_double(ncid, cv, start3, &netnmin) );
-    }
-    temutil::nc( nc_close(ncid) );
+      temutil::nc( nc_close(ncid) );
+    }//end critical(outputNETNMIN)
   }//end NETNMIN
   map_itr = netcdf_outputs.end();
 
@@ -2715,41 +2891,44 @@ void Runner::output_netCDF(std::map<std::string, output_spec> &netcdf_outputs, i
     curr_spec = map_itr->second;
     curr_filename = curr_spec.file_path + curr_spec.filename_prefix + file_stage_suffix;
 
-    temutil::nc( nc_open(curr_filename.c_str(), NC_WRITE, &ncid) );
-    temutil::nc( nc_inq_varid(ncid, "NIMMOB", &cv) );
+    #pragma omp critical(outputNIMMOB)
+    {
+      temutil::nc( nc_open(curr_filename.c_str(), NC_WRITE, &ncid) );
+      temutil::nc( nc_inq_varid(ncid, "NIMMOB", &cv) );
 
-    if(curr_spec.layer){
+      if(curr_spec.layer){
 
-      double nimmob[MAX_SOI_LAY];
-      for(int il=0; il<MAX_SOI_LAY; il++){
+        double nimmob[MAX_SOI_LAY];
+        for(int il=0; il<MAX_SOI_LAY; il++){
+          if(curr_spec.monthly){
+            soilstart4[0] = month_timestep;
+            nimmob[il] = cohort.bdall->m_soi2soi.nimmob[il];
+          }
+          else if(curr_spec.yearly){
+            soilstart4[0] = year;
+            nimmob[il] = cohort.bdall->y_soi2soi.nimmob[il];
+          }
+        }
+
+        temutil::nc( nc_put_vara_double(ncid, cv, soilstart4, soilcount4, &nimmob[0]) );
+      }
+      else if(!curr_spec.layer){
+
+        double nimmob;
         if(curr_spec.monthly){
-          soilstart4[0] = month_timestep;
-          nimmob[il] = cohort.bdall->m_soi2soi.nimmob[il];
+          start3[0] = month_timestep;
+          nimmob = cohort.bdall->m_soi2soi.nimmobsum;
         }
         else if(curr_spec.yearly){
-          soilstart4[0] = year;
-          nimmob[il] = cohort.bdall->y_soi2soi.nimmob[il];
+          start3[0] = year;
+          nimmob = cohort.bdall->y_soi2soi.nimmobsum;
         }
+
+        temutil::nc( nc_put_var1_double(ncid, cv, start3, &nimmob) );
       }
 
-      temutil::nc( nc_put_vara_double(ncid, cv, soilstart4, soilcount4, &nimmob[0]) );
-    }
-    else if(!curr_spec.layer){
-
-      double nimmob;
-      if(curr_spec.monthly){
-        start3[0] = month_timestep;
-        nimmob = cohort.bdall->m_soi2soi.nimmobsum;
-      }
-      else if(curr_spec.yearly){
-        start3[0] = year;
-        nimmob = cohort.bdall->y_soi2soi.nimmobsum;
-      }
-
-      temutil::nc( nc_put_var1_double(ncid, cv, start3, &nimmob) );
-    }
-
-    temutil::nc( nc_close(ncid) );
+      temutil::nc( nc_close(ncid) );
+    }//end critical(outputNIMMOB)
   }//end NIMMOB
   map_itr = netcdf_outputs.end();
 
@@ -2761,28 +2940,31 @@ void Runner::output_netCDF(std::map<std::string, output_spec> &netcdf_outputs, i
     curr_spec = map_itr->second;
     curr_filename = curr_spec.file_path + curr_spec.filename_prefix + file_stage_suffix;
 
-    temutil::nc( nc_open(curr_filename.c_str(), NC_WRITE, &ncid) );
-    temutil::nc( nc_inq_varid(ncid, "NINPUT", &cv) );
+    #pragma omp critical(outputNINPUT)
+    {
+      temutil::nc( nc_open(curr_filename.c_str(), NC_WRITE, &ncid) );
+      temutil::nc( nc_inq_varid(ncid, "NINPUT", &cv) );
 
-    if(curr_spec.layer){
-      /*** STUB ***/
-    }
-    else if(!curr_spec.layer){
-
-      double ninput;
-      if(curr_spec.monthly){
-        start3[0] = month_timestep;
-        ninput = cohort.bdall->m_a2soi.avlninput;
+      if(curr_spec.layer){
+        /*** STUB ***/
       }
-      else if(curr_spec.yearly){
-        start3[0] = year;
-        ninput = cohort.bdall->y_a2soi.avlninput;
+      else if(!curr_spec.layer){
+
+        double ninput;
+        if(curr_spec.monthly){
+          start3[0] = month_timestep;
+          ninput = cohort.bdall->m_a2soi.avlninput;
+        }
+        else if(curr_spec.yearly){
+          start3[0] = year;
+          ninput = cohort.bdall->y_a2soi.avlninput;
+        }
+
+        temutil::nc( nc_put_var1_double(ncid, cv, start3, &ninput) );
       }
 
-      temutil::nc( nc_put_var1_double(ncid, cv, start3, &ninput) );
-    }
-
-    temutil::nc( nc_close(ncid) );
+      temutil::nc( nc_close(ncid) );
+    }//end critical(outputNINPUT)
   }//end NINPUT
   map_itr = netcdf_outputs.end();
 
@@ -2794,24 +2976,27 @@ void Runner::output_netCDF(std::map<std::string, output_spec> &netcdf_outputs, i
     curr_spec = map_itr->second;
     curr_filename = curr_spec.file_path + curr_spec.filename_prefix + file_stage_suffix;
 
-    temutil::nc( nc_open(curr_filename.c_str(), NC_WRITE, &ncid) );
-    temutil::nc( nc_inq_varid(ncid, "NLOST", &cv) );
+    #pragma omp critical(outputNLOST)
+    {
+      temutil::nc( nc_open(curr_filename.c_str(), NC_WRITE, &ncid) );
+      temutil::nc( nc_inq_varid(ncid, "NLOST", &cv) );
 
-    double nlost;
-    if(curr_spec.monthly){
-      start3[0] = month_timestep;
-      nlost = cohort.bdall->m_soi2l.avlnlost
-            + cohort.bdall->m_soi2l.orgnlost;
-    }
-    else if(curr_spec.yearly){
-      start3[0] = year;
-      nlost = cohort.bdall->y_soi2l.avlnlost
-            + cohort.bdall->y_soi2l.orgnlost;
- 
-    }
+      double nlost;
+      if(curr_spec.monthly){
+        start3[0] = month_timestep;
+        nlost = cohort.bdall->m_soi2l.avlnlost
+              + cohort.bdall->m_soi2l.orgnlost;
+      }
+      else if(curr_spec.yearly){
+        start3[0] = year;
+        nlost = cohort.bdall->y_soi2l.avlnlost
+              + cohort.bdall->y_soi2l.orgnlost;
+   
+      }
 
-    temutil::nc( nc_put_var1_double(ncid, cv, start3, &nlost) );
-    temutil::nc( nc_close(ncid) );
+      temutil::nc( nc_put_var1_double(ncid, cv, start3, &nlost) );
+      temutil::nc( nc_close(ncid) );
+    }//end critical(outputNLOST)
   }//end NLOST
   map_itr = netcdf_outputs.end();
 
@@ -2823,45 +3008,48 @@ void Runner::output_netCDF(std::map<std::string, output_spec> &netcdf_outputs, i
     curr_spec = map_itr->second;
     curr_filename = curr_spec.file_path + curr_spec.filename_prefix + file_stage_suffix;
 
-    temutil::nc( nc_open(curr_filename.c_str(), NC_WRITE, &ncid) );
-    temutil::nc( nc_inq_varid(ncid, "ORGN", &cv) );
+    #pragma omp critical(outputORGN)
+    {
+      temutil::nc( nc_open(curr_filename.c_str(), NC_WRITE, &ncid) );
+      temutil::nc( nc_inq_varid(ncid, "ORGN", &cv) );
 
-    if(curr_spec.layer){
+      if(curr_spec.layer){
 
-      if(curr_spec.monthly){
-        soilstart4[0] = month_timestep;
+        if(curr_spec.monthly){
+          soilstart4[0] = month_timestep;
+        }
+        else if(curr_spec.yearly){
+          soilstart4[0] = year;
+        }
+
+        double orgn[MAX_SOI_LAY];
+        int il = 0;
+        Layer* currL = this->cohort.ground.toplayer;
+        while(currL != NULL){
+          orgn[il] = currL->orgn;
+          il++;
+          currL = currL->nextl;
+        }
+
+        temutil::nc( nc_put_vara_double(ncid, cv, soilstart4, soilcount4, &orgn[0]) );
       }
-      else if(curr_spec.yearly){
-        soilstart4[0] = year;
-      }
+      //Total, instead of by layer
+      else if(!curr_spec.layer){
 
-      double orgn[MAX_SOI_LAY];
-      int il = 0;
-      Layer* currL = this->cohort.ground.toplayer;
-      while(currL != NULL){
-        orgn[il] = currL->orgn;
-        il++;
-        currL = currL->nextl;
-      }
+        double orgn;
+        if(curr_spec.monthly){
+          start3[0] = month_timestep;
+          orgn = cohort.bdall->m_soid.orgnsum;
+        }
+        else if(curr_spec.yearly){
+          start3[0] = year;
+          orgn = cohort.bdall->y_soid.orgnsum;
+        }
 
-      temutil::nc( nc_put_vara_double(ncid, cv, soilstart4, soilcount4, &orgn[0]) );
-    }
-    //Total, instead of by layer
-    else if(!curr_spec.layer){
-
-      double orgn;
-      if(curr_spec.monthly){
-        start3[0] = month_timestep;
-        orgn = cohort.bdall->m_soid.orgnsum;
+        temutil::nc( nc_put_var1_double(ncid, cv, start3, &orgn) );
       }
-      else if(curr_spec.yearly){
-        start3[0] = year;
-        orgn = cohort.bdall->y_soid.orgnsum;
-      }
-
-      temutil::nc( nc_put_var1_double(ncid, cv, start3, &orgn) );
-    }
-    temutil::nc( nc_close(ncid) );
+      temutil::nc( nc_close(ncid) );
+    }//end critical(outputORGN)
   }//end ORGN
   map_itr = netcdf_outputs.end();
 
@@ -2872,50 +3060,53 @@ void Runner::output_netCDF(std::map<std::string, output_spec> &netcdf_outputs, i
     curr_spec = map_itr->second;
     curr_filename = curr_spec.file_path + curr_spec.filename_prefix + file_stage_suffix;
 
-    temutil::nc( nc_open(curr_filename.c_str(), NC_WRITE, &ncid) );
-    temutil::nc( nc_inq_varid(ncid, "RH", &cv) );
+    #pragma omp critical(outputRH)
+    {
+      temutil::nc( nc_open(curr_filename.c_str(), NC_WRITE, &ncid) );
+      temutil::nc( nc_inq_varid(ncid, "RH", &cv) );
 
-    if(curr_spec.layer){
+      if(curr_spec.layer){
 
-      double rh[MAX_SOI_LAY];
-      if(curr_spec.monthly){
-        soilstart4[0] = month_timestep;
-        for(int il=0; il<MAX_SOI_LAY; il++){
-          rh[il] = cohort.bdall->m_soi2a.rhrawc[il]
-                 + cohort.bdall->m_soi2a.rhsoma[il]
-                 + cohort.bdall->m_soi2a.rhsompr[il]
-                 + cohort.bdall->m_soi2a.rhsomcr[il];
+        double rh[MAX_SOI_LAY];
+        if(curr_spec.monthly){
+          soilstart4[0] = month_timestep;
+          for(int il=0; il<MAX_SOI_LAY; il++){
+            rh[il] = cohort.bdall->m_soi2a.rhrawc[il]
+                   + cohort.bdall->m_soi2a.rhsoma[il]
+                   + cohort.bdall->m_soi2a.rhsompr[il]
+                   + cohort.bdall->m_soi2a.rhsomcr[il];
+          }
         }
-      }
-      else if(curr_spec.yearly){
-        soilstart4[0] = year;
-        for(int il=0; il<MAX_SOI_LAY; il++){
-          rh[il] = cohort.bdall->y_soi2a.rhrawc[il]
-                 + cohort.bdall->y_soi2a.rhsoma[il]
-                 + cohort.bdall->y_soi2a.rhsompr[il]
-                 + cohort.bdall->y_soi2a.rhsomcr[il];
+        else if(curr_spec.yearly){
+          soilstart4[0] = year;
+          for(int il=0; il<MAX_SOI_LAY; il++){
+            rh[il] = cohort.bdall->y_soi2a.rhrawc[il]
+                   + cohort.bdall->y_soi2a.rhsoma[il]
+                   + cohort.bdall->y_soi2a.rhsompr[il]
+                   + cohort.bdall->y_soi2a.rhsomcr[il];
+          }
         }
+
+        temutil::nc( nc_put_vara_double(ncid, cv, soilstart4, soilcount4, &rh[0]) );
       }
 
-      temutil::nc( nc_put_vara_double(ncid, cv, soilstart4, soilcount4, &rh[0]) );
-    }
+      else if(!curr_spec.layer){
 
-    else if(!curr_spec.layer){
+        double rh;
+        if(curr_spec.monthly){
+          start3[0] = month_timestep;
+          rh = cohort.bdall->m_soi2a.rhtot;
+        }
+        else if(curr_spec.yearly){
+          start3[0] = year;
+          rh = cohort.bdall->y_soi2a.rhtot;
+        }
 
-      double rh;
-      if(curr_spec.monthly){
-        start3[0] = month_timestep;
-        rh = cohort.bdall->m_soi2a.rhtot;
+        temutil::nc( nc_put_var1_double(ncid, cv, start3, &rh) );
       }
-      else if(curr_spec.yearly){
-        start3[0] = year;
-        rh = cohort.bdall->y_soi2a.rhtot;
-      }
 
-      temutil::nc( nc_put_var1_double(ncid, cv, start3, &rh) );
-    }
-
-    temutil::nc( nc_close(ncid) );
+      temutil::nc( nc_close(ncid) );
+    }//end critical(outputRH)
   }//end RH 
   map_itr = netcdf_outputs.end();
 
@@ -2927,45 +3118,48 @@ void Runner::output_netCDF(std::map<std::string, output_spec> &netcdf_outputs, i
     curr_spec = map_itr->second;
     curr_filename = curr_spec.file_path + curr_spec.filename_prefix + file_stage_suffix;
 
-    temutil::nc( nc_open(curr_filename.c_str(), NC_WRITE, &ncid) );
-    temutil::nc( nc_inq_varid(ncid, "SOC", &cv) );
+    #pragma omp critical(outputSOC)
+    {
+      temutil::nc( nc_open(curr_filename.c_str(), NC_WRITE, &ncid) );
+      temutil::nc( nc_inq_varid(ncid, "SOC", &cv) );
 
-    if(curr_spec.layer){
+      if(curr_spec.layer){
 
-      if(curr_spec.monthly){
-        soilstart4[0] = month_timestep;
+        if(curr_spec.monthly){
+          soilstart4[0] = month_timestep;
+        }
+        else if(curr_spec.yearly){
+          soilstart4[0] = year;
+        }
+
+        double soilc[MAX_SOI_LAY];
+        int il = 0;
+        Layer* currL = this->cohort.ground.toplayer;
+        while(currL != NULL){
+          soilc[il] = currL->rawc;
+          il++;
+          currL = currL->nextl;
+        }
+
+        temutil::nc( nc_put_vara_double(ncid, cv, soilstart4, soilcount4, &soilc[0]) );
       }
-      else if(curr_spec.yearly){
-        soilstart4[0] = year;
-      }
+      //Total, instead of by layer
+      else if(!curr_spec.layer){
 
-      double soilc[MAX_SOI_LAY];
-      int il = 0;
-      Layer* currL = this->cohort.ground.toplayer;
-      while(currL != NULL){
-        soilc[il] = currL->rawc;
-        il++;
-        currL = currL->nextl;
-      }
+        double soilc;
+        if(curr_spec.monthly){
+          start3[0] = month_timestep;
+          soilc = cohort.bdall->m_soid.rawcsum;
+        }
+        else if(curr_spec.yearly){
+          start3[0] = year;
+          soilc = cohort.bdall->y_soid.rawcsum;
+        }
 
-      temutil::nc( nc_put_vara_double(ncid, cv, soilstart4, soilcount4, &soilc[0]) );
-    }
-    //Total, instead of by layer
-    else if(!curr_spec.layer){
-
-      double soilc;
-      if(curr_spec.monthly){
-        start3[0] = month_timestep;
-        soilc = cohort.bdall->m_soid.rawcsum;
+        temutil::nc( nc_put_var1_double(ncid, cv, start3, &soilc) );
       }
-      else if(curr_spec.yearly){
-        start3[0] = year;
-        soilc = cohort.bdall->y_soid.rawcsum;
-      }
-
-      temutil::nc( nc_put_var1_double(ncid, cv, start3, &soilc) );
-    }
-    temutil::nc( nc_close(ncid) );
+      temutil::nc( nc_close(ncid) );
+    }//end critical(outputSOC)
   }//end SOC
   map_itr = netcdf_outputs.end();
 
@@ -2978,22 +3172,25 @@ void Runner::output_netCDF(std::map<std::string, output_spec> &netcdf_outputs, i
     curr_spec = map_itr->second;
     curr_filename = curr_spec.file_path + curr_spec.filename_prefix + file_stage_suffix;
 
-    temutil::nc( nc_open(curr_filename.c_str(), NC_WRITE, &ncid) );
-    temutil::nc( nc_inq_varid(ncid, "BURNVEG2AIRC", &cv) );
+    #pragma omp critical(outputBURNVEG2AIRC)
+    {
+      temutil::nc( nc_open(curr_filename.c_str(), NC_WRITE, &ncid) );
+      temutil::nc( nc_inq_varid(ncid, "BURNVEG2AIRC", &cv) );
 
-    double burnveg2airc;
-    if(curr_spec.monthly){
-      start3[0] = month_timestep;
-      burnveg2airc = cohort.year_fd[month].fire_v2a.orgc;
-    }
-    else if(curr_spec.yearly){
-      start3[0] = year;
-      burnveg2airc = cohort.fd->fire_v2a.orgc;
-    }
+      double burnveg2airc;
+      if(curr_spec.monthly){
+        start3[0] = month_timestep;
+        burnveg2airc = cohort.year_fd[month].fire_v2a.orgc;
+      }
+      else if(curr_spec.yearly){
+        start3[0] = year;
+        burnveg2airc = cohort.fd->fire_v2a.orgc;
+      }
 
-    temutil::nc( nc_put_var1_double(ncid, cv, start3, &burnveg2airc) );
+      temutil::nc( nc_put_var1_double(ncid, cv, start3, &burnveg2airc) );
 
-    temutil::nc( nc_close(ncid) );
+      temutil::nc( nc_close(ncid) );
+    }//end critical(outputBURNVEG2AIRC)
   }//end BURNVEG2AIRC
   map_itr = netcdf_outputs.end();
 
@@ -3005,22 +3202,25 @@ void Runner::output_netCDF(std::map<std::string, output_spec> &netcdf_outputs, i
     curr_spec = map_itr->second;
     curr_filename = curr_spec.file_path + curr_spec.filename_prefix + file_stage_suffix;
 
-    temutil::nc( nc_open(curr_filename.c_str(), NC_WRITE, &ncid) );
-    temutil::nc( nc_inq_varid(ncid, "BURNVEG2AIRN", &cv) );
+    #pragma omp critical(outputBURNVEG2AIRN)
+    {
+      temutil::nc( nc_open(curr_filename.c_str(), NC_WRITE, &ncid) );
+      temutil::nc( nc_inq_varid(ncid, "BURNVEG2AIRN", &cv) );
 
-    double burnveg2airn;
-    if(curr_spec.monthly){
-      start3[0] = month_timestep;
-      burnveg2airn = cohort.year_fd[month].fire_v2a.orgn;
-    }
-    else if(curr_spec.yearly){
-      start3[0] = year;
-      burnveg2airn = cohort.fd->fire_v2a.orgn;
-    }
+      double burnveg2airn;
+      if(curr_spec.monthly){
+        start3[0] = month_timestep;
+        burnveg2airn = cohort.year_fd[month].fire_v2a.orgn;
+      }
+      else if(curr_spec.yearly){
+        start3[0] = year;
+        burnveg2airn = cohort.fd->fire_v2a.orgn;
+      }
 
-    temutil::nc( nc_put_var1_double(ncid, cv, start3, &burnveg2airn) );
+      temutil::nc( nc_put_var1_double(ncid, cv, start3, &burnveg2airn) );
 
-    temutil::nc( nc_close(ncid) );
+      temutil::nc( nc_close(ncid) );
+    }//end critical(outputBURNVEG2AIRN)
   }//end BURNVEG2AIRN
   map_itr = netcdf_outputs.end();
 
@@ -3032,22 +3232,25 @@ void Runner::output_netCDF(std::map<std::string, output_spec> &netcdf_outputs, i
     curr_spec = map_itr->second;
     curr_filename = curr_spec.file_path + curr_spec.filename_prefix + file_stage_suffix;
 
-    temutil::nc( nc_open(curr_filename.c_str(), NC_WRITE, &ncid) );
-    temutil::nc( nc_inq_varid(ncid, "BURNVEG2DEADC", &cv) );
+    #pragma omp critical(outputBURNVEG2DEADC)
+    {
+      temutil::nc( nc_open(curr_filename.c_str(), NC_WRITE, &ncid) );
+      temutil::nc( nc_inq_varid(ncid, "BURNVEG2DEADC", &cv) );
 
-    double burnveg2deadc;
-    if(curr_spec.monthly){
-      start3[0] = month_timestep;
-      burnveg2deadc = cohort.year_fd[month].fire_v2dead.vegC;
-    }
-    else if(curr_spec.yearly){
-      start3[0] = year;
-      burnveg2deadc = cohort.fd->fire_v2dead.vegC;
-    }
+      double burnveg2deadc;
+      if(curr_spec.monthly){
+        start3[0] = month_timestep;
+        burnveg2deadc = cohort.year_fd[month].fire_v2dead.vegC;
+      }
+      else if(curr_spec.yearly){
+        start3[0] = year;
+        burnveg2deadc = cohort.fd->fire_v2dead.vegC;
+      }
 
-    temutil::nc( nc_put_var1_double(ncid, cv, start3, &burnveg2deadc) );
+      temutil::nc( nc_put_var1_double(ncid, cv, start3, &burnveg2deadc) );
 
-    temutil::nc( nc_close(ncid) );
+      temutil::nc( nc_close(ncid) );
+    }//end critical(outputBURNVEG2DEADC)
   }//end BURNVEG2DEADC
   map_itr = netcdf_outputs.end();
 
@@ -3059,22 +3262,25 @@ void Runner::output_netCDF(std::map<std::string, output_spec> &netcdf_outputs, i
     curr_spec = map_itr->second;
     curr_filename = curr_spec.file_path + curr_spec.filename_prefix + file_stage_suffix;
 
-    temutil::nc( nc_open(curr_filename.c_str(), NC_WRITE, &ncid) );
-    temutil::nc( nc_inq_varid(ncid, "BURNVEG2DEADN", &cv) );
+    #pragma omp critical(outputBURNVEG2DEADN)
+    {
+      temutil::nc( nc_open(curr_filename.c_str(), NC_WRITE, &ncid) );
+      temutil::nc( nc_inq_varid(ncid, "BURNVEG2DEADN", &cv) );
 
-    double burnveg2deadn;
-    if(curr_spec.monthly){
-      start3[0] = month_timestep;
-      burnveg2deadn = cohort.year_fd[month].fire_v2dead.strN;
-    }
-    else if(curr_spec.yearly){
-      start3[0] = year;
-      burnveg2deadn = cohort.fd->fire_v2dead.strN;
-    }
+      double burnveg2deadn;
+      if(curr_spec.monthly){
+        start3[0] = month_timestep;
+        burnveg2deadn = cohort.year_fd[month].fire_v2dead.strN;
+      }
+      else if(curr_spec.yearly){
+        start3[0] = year;
+        burnveg2deadn = cohort.fd->fire_v2dead.strN;
+      }
 
-    temutil::nc( nc_put_var1_double(ncid, cv, start3, &burnveg2deadn) );
+      temutil::nc( nc_put_var1_double(ncid, cv, start3, &burnveg2deadn) );
 
-    temutil::nc( nc_close(ncid) );
+      temutil::nc( nc_close(ncid) );
+    }//end critical(outputBURNVEG2DEADN)
   }//end BURNVEG2DEADN
   map_itr = netcdf_outputs.end();
 
@@ -3086,22 +3292,25 @@ void Runner::output_netCDF(std::map<std::string, output_spec> &netcdf_outputs, i
     curr_spec = map_itr->second;
     curr_filename = curr_spec.file_path + curr_spec.filename_prefix + file_stage_suffix;
 
-    temutil::nc( nc_open(curr_filename.c_str(), NC_WRITE, &ncid) );
-    temutil::nc( nc_inq_varid(ncid, "BURNVEG2SOIABVC", &cv) );
+    #pragma omp critical(outputBURNVEG2SOIABVC)
+    {
+      temutil::nc( nc_open(curr_filename.c_str(), NC_WRITE, &ncid) );
+      temutil::nc( nc_inq_varid(ncid, "BURNVEG2SOIABVC", &cv) );
 
-    double burnveg2soiabvc;
-    if(curr_spec.monthly){
-      start3[0] = month_timestep;
-      burnveg2soiabvc = cohort.year_fd[month].fire_v2soi.abvc;
-    }
-    else if(curr_spec.yearly){
-      start3[0] = year;
-      burnveg2soiabvc = cohort.fd->fire_v2soi.abvc;
-    }
+      double burnveg2soiabvc;
+      if(curr_spec.monthly){
+        start3[0] = month_timestep;
+        burnveg2soiabvc = cohort.year_fd[month].fire_v2soi.abvc;
+      }
+      else if(curr_spec.yearly){
+        start3[0] = year;
+        burnveg2soiabvc = cohort.fd->fire_v2soi.abvc;
+      }
 
-    temutil::nc( nc_put_var1_double(ncid, cv, start3, &burnveg2soiabvc) );
+      temutil::nc( nc_put_var1_double(ncid, cv, start3, &burnveg2soiabvc) );
 
-    temutil::nc( nc_close(ncid) );
+      temutil::nc( nc_close(ncid) );
+    }//end critical(outputBURNVEG2SOIABVC)
   }//end BURNVEG2SOIABVC
   map_itr = netcdf_outputs.end();
 
@@ -3113,22 +3322,25 @@ void Runner::output_netCDF(std::map<std::string, output_spec> &netcdf_outputs, i
     curr_spec = map_itr->second;
     curr_filename = curr_spec.file_path + curr_spec.filename_prefix + file_stage_suffix;
 
-    temutil::nc( nc_open(curr_filename.c_str(), NC_WRITE, &ncid) );
-    temutil::nc( nc_inq_varid(ncid, "BURNVEG2SOIABVN", &cv) );
+    #pragma omp critical(outputBURNVEG2SOIABVN)
+    {
+      temutil::nc( nc_open(curr_filename.c_str(), NC_WRITE, &ncid) );
+      temutil::nc( nc_inq_varid(ncid, "BURNVEG2SOIABVN", &cv) );
 
-    double burnveg2soiabvn;
-    if(curr_spec.monthly){
-      start3[0] = month_timestep;
-      burnveg2soiabvn = cohort.year_fd[month].fire_v2soi.abvn;
-    }
-    else if(curr_spec.yearly){
-      start3[0] = year;
-      burnveg2soiabvn = cohort.fd->fire_v2soi.abvn;
-    }
+      double burnveg2soiabvn;
+      if(curr_spec.monthly){
+        start3[0] = month_timestep;
+        burnveg2soiabvn = cohort.year_fd[month].fire_v2soi.abvn;
+      }
+      else if(curr_spec.yearly){
+        start3[0] = year;
+        burnveg2soiabvn = cohort.fd->fire_v2soi.abvn;
+      }
 
-    temutil::nc( nc_put_var1_double(ncid, cv, start3, &burnveg2soiabvn) );
+      temutil::nc( nc_put_var1_double(ncid, cv, start3, &burnveg2soiabvn) );
 
-    temutil::nc( nc_close(ncid) );
+      temutil::nc( nc_close(ncid) );
+    }//end critical(outputBURNVEG2SOIABVN)
   }//end BURNVEG2SOIABVN
   map_itr = netcdf_outputs.end();
 
@@ -3140,23 +3352,27 @@ void Runner::output_netCDF(std::map<std::string, output_spec> &netcdf_outputs, i
     curr_spec = map_itr->second;
     curr_filename = curr_spec.file_path + curr_spec.filename_prefix + file_stage_suffix;
 
-    temutil::nc( nc_open(curr_filename.c_str(), NC_WRITE, &ncid) );
-    temutil::nc( nc_inq_varid(ncid, "BURNVEG2SOIBLWC", &cv) );
+    #pragma omp critical(outputBURNVEG2SOIBLWC)
+    {
+      temutil::nc( nc_open(curr_filename.c_str(), NC_WRITE, &ncid) );
+      temutil::nc( nc_inq_varid(ncid, "BURNVEG2SOIBLWC", &cv) );
 
-    double burnveg2soiblwc;
-    if(curr_spec.monthly){
-      start3[0] = month_timestep;
-      burnveg2soiblwc = cohort.year_fd[month].fire_v2soi.blwc;
-    }
-    else if(curr_spec.yearly){
-      start3[0] = year;
-      burnveg2soiblwc = cohort.fd->fire_v2soi.blwc;
-    }
+      double burnveg2soiblwc;
+      if(curr_spec.monthly){
+        start3[0] = month_timestep;
+        burnveg2soiblwc = cohort.year_fd[month].fire_v2soi.blwc;
+      }
+      else if(curr_spec.yearly){
+        start3[0] = year;
+        burnveg2soiblwc = cohort.fd->fire_v2soi.blwc;
+      }
 
-    temutil::nc( nc_put_var1_double(ncid, cv, start3, &burnveg2soiblwc) );
+      temutil::nc( nc_put_var1_double(ncid, cv, start3, &burnveg2soiblwc) );
 
-    temutil::nc( nc_close(ncid) );
+      temutil::nc( nc_close(ncid) );
+    }//end critical(outputBURNVEG2SOIBLWC)
   }//end BURNVEG2SOIBLWC
+
   map_itr = netcdf_outputs.end();
 
 
@@ -3167,22 +3383,25 @@ void Runner::output_netCDF(std::map<std::string, output_spec> &netcdf_outputs, i
     curr_spec = map_itr->second;
     curr_filename = curr_spec.file_path + curr_spec.filename_prefix + file_stage_suffix;
 
-    temutil::nc( nc_open(curr_filename.c_str(), NC_WRITE, &ncid) );
-    temutil::nc( nc_inq_varid(ncid, "BURNVEG2SOIBLWN", &cv) );
+    #pragma omp critical(outputBURNVEG2SOIBLWN)
+    {
+      temutil::nc( nc_open(curr_filename.c_str(), NC_WRITE, &ncid) );
+      temutil::nc( nc_inq_varid(ncid, "BURNVEG2SOIBLWN", &cv) );
 
-    double burnveg2soiblwn;
-    if(curr_spec.monthly){
-      start3[0] = month_timestep;
-      burnveg2soiblwn = cohort.year_fd[month].fire_v2soi.blwn;
-    }
-    else if(curr_spec.yearly){
-      start3[0] = year;
-      burnveg2soiblwn = cohort.fd->fire_v2soi.blwn;
-    }
+      double burnveg2soiblwn;
+      if(curr_spec.monthly){
+        start3[0] = month_timestep;
+        burnveg2soiblwn = cohort.year_fd[month].fire_v2soi.blwn;
+      }
+      else if(curr_spec.yearly){
+        start3[0] = year;
+        burnveg2soiblwn = cohort.fd->fire_v2soi.blwn;
+      }
 
-    temutil::nc( nc_put_var1_double(ncid, cv, start3, &burnveg2soiblwn) );
+      temutil::nc( nc_put_var1_double(ncid, cv, start3, &burnveg2soiblwn) );
 
-    temutil::nc( nc_close(ncid) );
+      temutil::nc( nc_close(ncid) );
+    }//end critical(outputBURNVEG2SOIBLWN)
   }//end BURNVEG2SOIBLWN
   map_itr = netcdf_outputs.end();
 
@@ -3194,83 +3413,86 @@ void Runner::output_netCDF(std::map<std::string, output_spec> &netcdf_outputs, i
     curr_spec = map_itr->second;
     curr_filename = curr_spec.file_path + curr_spec.filename_prefix + file_stage_suffix;
 
-    temutil::nc( nc_open(curr_filename.c_str(), NC_WRITE, &ncid) );
-    temutil::nc( nc_inq_varid(ncid, "GPP", &cv) );
+    #pragma omp critical(outputGPP)
+    {
+      temutil::nc( nc_open(curr_filename.c_str(), NC_WRITE, &ncid) );
+      temutil::nc( nc_inq_varid(ncid, "GPP", &cv) );
 
-    //PFT and compartment
-    if(curr_spec.pft && curr_spec.compartment){
+      //PFT and compartment
+      if(curr_spec.pft && curr_spec.compartment){
 
-      double gpp[NUM_PFT_PART][NUM_PFT];
-      for(int ip=0; ip<NUM_PFT; ip++){
-        for(int ipp=0; ipp<NUM_PFT_PART; ipp++){
+        double gpp[NUM_PFT_PART][NUM_PFT];
+        for(int ip=0; ip<NUM_PFT; ip++){
+          for(int ipp=0; ipp<NUM_PFT_PART; ipp++){
 
-          if(curr_spec.monthly){
-            start5[0] = month_timestep;
-            gpp[ipp][ip] = cohort.bd[ip].m_a2v.gpp[ipp];
+            if(curr_spec.monthly){
+              start5[0] = month_timestep;
+              gpp[ipp][ip] = cohort.bd[ip].m_a2v.gpp[ipp];
+            }
+            else if(curr_spec.yearly){
+              start5[0] = year;
+              gpp[ipp][ip] = cohort.bd[ip].y_a2v.gpp[ipp];
+            }
           }
-          else if(curr_spec.yearly){
-            start5[0] = year;
-            gpp[ipp][ip] = cohort.bd[ip].y_a2v.gpp[ipp];
-          }
         }
+
+        temutil::nc( nc_put_vara_double(ncid, cv, start5, count5, &gpp[0][0]) );
       }
+      //PFT only
+      else if(curr_spec.pft && !curr_spec.compartment){
 
-      temutil::nc( nc_put_vara_double(ncid, cv, start5, count5, &gpp[0][0]) );
-    }
-    //PFT only
-    else if(curr_spec.pft && !curr_spec.compartment){
-
-      double gpp[NUM_PFT];
-      for(int ip=0; ip<NUM_PFT; ip++){
-
-        if(curr_spec.monthly){
-          PFTstart4[0] = month_timestep;
-          gpp[ip] = cohort.bd[ip].m_a2v.gppall; 
-        }
-        else if(curr_spec.yearly){
-          PFTstart4[0] = year;
-          gpp[ip] = cohort.bd[ip].y_a2v.gppall; 
-        }
-      }
-
-      temutil::nc( nc_put_vara_double(ncid, cv, PFTstart4, PFTcount4, &gpp[0]) );
-    }
-    //Compartment only
-    else if(!curr_spec.pft && curr_spec.compartment){
-
-      double gpp[NUM_PFT_PART] = {0};
-      for(int ipp=0; ipp<NUM_PFT_PART; ipp++){
+        double gpp[NUM_PFT];
         for(int ip=0; ip<NUM_PFT; ip++){
 
           if(curr_spec.monthly){
-            CompStart4[0] = month_timestep;
-            gpp[ipp] += cohort.bd[ip].m_a2v.gpp[ipp];
+            PFTstart4[0] = month_timestep;
+            gpp[ip] = cohort.bd[ip].m_a2v.gppall; 
           }
           else if(curr_spec.yearly){
-            CompStart4[0] = year;
-            gpp[ipp] += cohort.bd[ip].m_a2v.gpp[ipp];
+            PFTstart4[0] = year;
+            gpp[ip] = cohort.bd[ip].y_a2v.gppall; 
           }
         }
-      }
 
-      temutil::nc( nc_put_vara_double(ncid, cv, CompStart4, CompCount4, &gpp[0]) );
-    }
-    //Neither PFT nor Compartment - total instead
-    else if(!curr_spec.pft && !curr_spec.compartment){
-
-      double gpp;
-      if(curr_spec.monthly){
-        start3[0] = month_timestep;
-        gpp = cohort.bdall->m_a2v.gppall;
+        temutil::nc( nc_put_vara_double(ncid, cv, PFTstart4, PFTcount4, &gpp[0]) );
       }
-      else if(curr_spec.yearly){
-        start3[0] = year;
-        gpp = cohort.bdall->y_a2v.gppall;
-      }
+      //Compartment only
+      else if(!curr_spec.pft && curr_spec.compartment){
 
-      temutil::nc( nc_put_var1_double(ncid, cv, start3, &gpp) );
-    }
-    temutil::nc( nc_close(ncid) );
+        double gpp[NUM_PFT_PART] = {0};
+        for(int ipp=0; ipp<NUM_PFT_PART; ipp++){
+          for(int ip=0; ip<NUM_PFT; ip++){
+
+            if(curr_spec.monthly){
+              CompStart4[0] = month_timestep;
+              gpp[ipp] += cohort.bd[ip].m_a2v.gpp[ipp];
+            }
+            else if(curr_spec.yearly){
+              CompStart4[0] = year;
+              gpp[ipp] += cohort.bd[ip].m_a2v.gpp[ipp];
+            }
+          }
+        }
+
+        temutil::nc( nc_put_vara_double(ncid, cv, CompStart4, CompCount4, &gpp[0]) );
+      }
+      //Neither PFT nor Compartment - total instead
+      else if(!curr_spec.pft && !curr_spec.compartment){
+
+        double gpp;
+        if(curr_spec.monthly){
+          start3[0] = month_timestep;
+          gpp = cohort.bdall->m_a2v.gppall;
+        }
+        else if(curr_spec.yearly){
+          start3[0] = year;
+          gpp = cohort.bdall->y_a2v.gppall;
+        }
+
+        temutil::nc( nc_put_var1_double(ncid, cv, start3, &gpp) );
+      }
+      temutil::nc( nc_close(ncid) );
+    }//end critical(outputGPP)
   }//end GPP
   map_itr = netcdf_outputs.end();
 
@@ -3282,83 +3504,86 @@ void Runner::output_netCDF(std::map<std::string, output_spec> &netcdf_outputs, i
     curr_spec = map_itr->second;
     curr_filename = curr_spec.file_path + curr_spec.filename_prefix + file_stage_suffix;
 
-    temutil::nc( nc_open(curr_filename.c_str(), NC_WRITE, &ncid) );
-    temutil::nc( nc_inq_varid(ncid, "INGPP", &cv) );
+    #pragma omp critical(outputINGPP)
+    {
+      temutil::nc( nc_open(curr_filename.c_str(), NC_WRITE, &ncid) );
+      temutil::nc( nc_inq_varid(ncid, "INGPP", &cv) );
 
-    //PFT and compartment
-    if(curr_spec.pft && curr_spec.compartment){
+      //PFT and compartment
+      if(curr_spec.pft && curr_spec.compartment){
 
-      double ingpp[NUM_PFT_PART][NUM_PFT];
-      for(int ip=0; ip<NUM_PFT; ip++){
-        for(int ipp=0; ipp<NUM_PFT_PART; ipp++){
+        double ingpp[NUM_PFT_PART][NUM_PFT];
+        for(int ip=0; ip<NUM_PFT; ip++){
+          for(int ipp=0; ipp<NUM_PFT_PART; ipp++){
 
-          if(curr_spec.monthly){
-            start5[0] = month_timestep;
-            ingpp[ipp][ip] = cohort.bd[ip].m_a2v.ingpp[ipp];
+            if(curr_spec.monthly){
+              start5[0] = month_timestep;
+              ingpp[ipp][ip] = cohort.bd[ip].m_a2v.ingpp[ipp];
+            }
+            else if(curr_spec.yearly){
+              start5[0] = year;
+              ingpp[ipp][ip] = cohort.bd[ip].y_a2v.ingpp[ipp];
+            }
           }
-          else if(curr_spec.yearly){
-            start5[0] = year;
-            ingpp[ipp][ip] = cohort.bd[ip].y_a2v.ingpp[ipp];
-          }
         }
+
+        temutil::nc( nc_put_vara_double(ncid, cv, start5, count5, &ingpp[0][0]) );
       }
+      //PFT only
+      else if(curr_spec.pft && !curr_spec.compartment){
 
-      temutil::nc( nc_put_vara_double(ncid, cv, start5, count5, &ingpp[0][0]) );
-    }
-    //PFT only
-    else if(curr_spec.pft && !curr_spec.compartment){
-
-      double ingpp[NUM_PFT];
-      for(int ip=0; ip<NUM_PFT; ip++){
-
-        if(curr_spec.monthly){
-          PFTstart4[0] = month_timestep;
-          ingpp[ip] = cohort.bd[ip].m_a2v.ingppall; 
-        }
-        else if(curr_spec.yearly){
-          PFTstart4[0] = year;
-          ingpp[ip] = cohort.bd[ip].y_a2v.ingppall; 
-        }
-      }
-
-      temutil::nc( nc_put_vara_double(ncid, cv, PFTstart4, PFTcount4, &ingpp[0]) );
-    }
-    //Compartment only
-    else if(!curr_spec.pft && curr_spec.compartment){
-
-      double ingpp[NUM_PFT_PART] = {0};
-      for(int ipp=0; ipp<NUM_PFT_PART; ipp++){
+        double ingpp[NUM_PFT];
         for(int ip=0; ip<NUM_PFT; ip++){
 
           if(curr_spec.monthly){
-            CompStart4[0] = month_timestep;
-            ingpp[ipp] += cohort.bd[ip].m_a2v.ingpp[ipp];
+            PFTstart4[0] = month_timestep;
+            ingpp[ip] = cohort.bd[ip].m_a2v.ingppall; 
           }
           else if(curr_spec.yearly){
-            CompStart4[0] = year;
-            ingpp[ipp] += cohort.bd[ip].m_a2v.ingpp[ipp];
+            PFTstart4[0] = year;
+            ingpp[ip] = cohort.bd[ip].y_a2v.ingppall; 
           }
         }
-      }
 
-      temutil::nc( nc_put_vara_double(ncid, cv, CompStart4, CompCount4, &ingpp[0]) );
-    }
-    //Neither PFT nor Compartment - total instead
-    else if(!curr_spec.pft && !curr_spec.compartment){
-
-      double ingpp;
-      if(curr_spec.monthly){
-        start3[0] = month_timestep;
-        ingpp = cohort.bdall->m_a2v.ingppall;
+        temutil::nc( nc_put_vara_double(ncid, cv, PFTstart4, PFTcount4, &ingpp[0]) );
       }
-      else if(curr_spec.yearly){
-        start3[0] = year;
-        ingpp = cohort.bdall->y_a2v.ingppall;
-      }
+      //Compartment only
+      else if(!curr_spec.pft && curr_spec.compartment){
 
-      temutil::nc( nc_put_var1_double(ncid, cv, start3, &ingpp) );
-    }
-    temutil::nc( nc_close(ncid) );
+        double ingpp[NUM_PFT_PART] = {0};
+        for(int ipp=0; ipp<NUM_PFT_PART; ipp++){
+          for(int ip=0; ip<NUM_PFT; ip++){
+
+            if(curr_spec.monthly){
+              CompStart4[0] = month_timestep;
+              ingpp[ipp] += cohort.bd[ip].m_a2v.ingpp[ipp];
+            }
+            else if(curr_spec.yearly){
+              CompStart4[0] = year;
+              ingpp[ipp] += cohort.bd[ip].m_a2v.ingpp[ipp];
+            }
+          }
+        }
+
+        temutil::nc( nc_put_vara_double(ncid, cv, CompStart4, CompCount4, &ingpp[0]) );
+      }
+      //Neither PFT nor Compartment - total instead
+      else if(!curr_spec.pft && !curr_spec.compartment){
+
+        double ingpp;
+        if(curr_spec.monthly){
+          start3[0] = month_timestep;
+          ingpp = cohort.bdall->m_a2v.ingppall;
+        }
+        else if(curr_spec.yearly){
+          start3[0] = year;
+          ingpp = cohort.bdall->y_a2v.ingppall;
+        }
+
+        temutil::nc( nc_put_var1_double(ncid, cv, start3, &ingpp) );
+      }
+      temutil::nc( nc_close(ncid) );
+    }//end critical(outputINGPP)
   }//end INGPP
   map_itr = netcdf_outputs.end();
 
@@ -3370,83 +3595,86 @@ void Runner::output_netCDF(std::map<std::string, output_spec> &netcdf_outputs, i
     curr_spec = map_itr->second;
     curr_filename = curr_spec.file_path + curr_spec.filename_prefix + file_stage_suffix;
 
-    temutil::nc( nc_open(curr_filename.c_str(), NC_WRITE, &ncid) );
-    temutil::nc( nc_inq_varid(ncid, "INNPP", &cv) );
+    #pragma omp critical(outputINNPP)
+    {
+      temutil::nc( nc_open(curr_filename.c_str(), NC_WRITE, &ncid) );
+      temutil::nc( nc_inq_varid(ncid, "INNPP", &cv) );
 
-    //PFT and compartment
-    if(curr_spec.pft && curr_spec.compartment){
+      //PFT and compartment
+      if(curr_spec.pft && curr_spec.compartment){
 
-      double innpp[NUM_PFT_PART][NUM_PFT];
-      for(int ip=0; ip<NUM_PFT; ip++){
-        for(int ipp=0; ipp<NUM_PFT_PART; ipp++){
+        double innpp[NUM_PFT_PART][NUM_PFT];
+        for(int ip=0; ip<NUM_PFT; ip++){
+          for(int ipp=0; ipp<NUM_PFT_PART; ipp++){
 
-          if(curr_spec.monthly){
-            start5[0] = month_timestep;
-            innpp[ipp][ip] = cohort.bd[ip].m_a2v.innpp[ipp];
+            if(curr_spec.monthly){
+              start5[0] = month_timestep;
+              innpp[ipp][ip] = cohort.bd[ip].m_a2v.innpp[ipp];
+            }
+            else if(curr_spec.yearly){
+              start5[0] = year;
+              innpp[ipp][ip] = cohort.bd[ip].y_a2v.innpp[ipp];
+            }
           }
-          else if(curr_spec.yearly){
-            start5[0] = year;
-            innpp[ipp][ip] = cohort.bd[ip].y_a2v.innpp[ipp];
-          }
         }
+
+        temutil::nc( nc_put_vara_double(ncid, cv, start5, count5, &innpp[0][0]) );
       }
+      //PFT only
+      else if(curr_spec.pft && !curr_spec.compartment){
 
-      temutil::nc( nc_put_vara_double(ncid, cv, start5, count5, &innpp[0][0]) );
-    }
-    //PFT only
-    else if(curr_spec.pft && !curr_spec.compartment){
-
-      double innpp[NUM_PFT];
-      for(int ip=0; ip<NUM_PFT; ip++){
-
-        if(curr_spec.monthly){
-          PFTstart4[0] = month_timestep;
-          innpp[ip] = cohort.bd[ip].m_a2v.innppall; 
-        }
-        else if(curr_spec.yearly){
-          PFTstart4[0] = year;
-          innpp[ip] = cohort.bd[ip].y_a2v.innppall; 
-        }
-      }
-
-      temutil::nc( nc_put_vara_double(ncid, cv, PFTstart4, PFTcount4, &innpp[0]) );
-    }
-    //Compartment only
-    else if(!curr_spec.pft && curr_spec.compartment){
-
-      double innpp[NUM_PFT_PART] = {0};
-      for(int ipp=0; ipp<NUM_PFT_PART; ipp++){
+        double innpp[NUM_PFT];
         for(int ip=0; ip<NUM_PFT; ip++){
 
           if(curr_spec.monthly){
-            CompStart4[0] = month_timestep;
-            innpp[ipp] += cohort.bd[ip].m_a2v.innpp[ipp];
+            PFTstart4[0] = month_timestep;
+            innpp[ip] = cohort.bd[ip].m_a2v.innppall; 
           }
           else if(curr_spec.yearly){
-            CompStart4[0] = year;
-            innpp[ipp] += cohort.bd[ip].m_a2v.innpp[ipp];
+            PFTstart4[0] = year;
+            innpp[ip] = cohort.bd[ip].y_a2v.innppall; 
           }
         }
-      }
 
-      temutil::nc( nc_put_vara_double(ncid, cv, CompStart4, CompCount4, &innpp[0]) );
-    }
-    //Neither PFT nor Compartment - total instead
-    else if(!curr_spec.pft && !curr_spec.compartment){
-
-      double innpp;
-      if(curr_spec.monthly){
-        start3[0] = month_timestep;
-        innpp = cohort.bdall->m_a2v.innppall;
+        temutil::nc( nc_put_vara_double(ncid, cv, PFTstart4, PFTcount4, &innpp[0]) );
       }
-      else if(curr_spec.yearly){
-        start3[0] = year;
-        innpp = cohort.bdall->y_a2v.innppall;
-      }
+      //Compartment only
+      else if(!curr_spec.pft && curr_spec.compartment){
 
-      temutil::nc( nc_put_var1_double(ncid, cv, start3, &innpp) );
-    }
-    temutil::nc( nc_close(ncid) );
+        double innpp[NUM_PFT_PART] = {0};
+        for(int ipp=0; ipp<NUM_PFT_PART; ipp++){
+          for(int ip=0; ip<NUM_PFT; ip++){
+
+            if(curr_spec.monthly){
+              CompStart4[0] = month_timestep;
+              innpp[ipp] += cohort.bd[ip].m_a2v.innpp[ipp];
+            }
+            else if(curr_spec.yearly){
+              CompStart4[0] = year;
+              innpp[ipp] += cohort.bd[ip].m_a2v.innpp[ipp];
+            }
+          }
+        }
+
+        temutil::nc( nc_put_vara_double(ncid, cv, CompStart4, CompCount4, &innpp[0]) );
+      }
+      //Neither PFT nor Compartment - total instead
+      else if(!curr_spec.pft && !curr_spec.compartment){
+
+        double innpp;
+        if(curr_spec.monthly){
+          start3[0] = month_timestep;
+          innpp = cohort.bdall->m_a2v.innppall;
+        }
+        else if(curr_spec.yearly){
+          start3[0] = year;
+          innpp = cohort.bdall->y_a2v.innppall;
+        }
+
+        temutil::nc( nc_put_var1_double(ncid, cv, start3, &innpp) );
+      }
+      temutil::nc( nc_close(ncid) );
+    }//end critical(outputINNPP)
   }//end INNPP
   map_itr = netcdf_outputs.end();
 
@@ -3458,41 +3686,44 @@ void Runner::output_netCDF(std::map<std::string, output_spec> &netcdf_outputs, i
     curr_spec = map_itr->second;
     curr_filename = curr_spec.file_path + curr_spec.filename_prefix + file_stage_suffix;
 
-    temutil::nc( nc_open(curr_filename.c_str(), NC_WRITE, &ncid) );
-    temutil::nc( nc_inq_varid(ncid, "LAI", &cv) );
+    #pragma omp critical(outputLAI)
+    {
+      temutil::nc( nc_open(curr_filename.c_str(), NC_WRITE, &ncid) );
+      temutil::nc( nc_inq_varid(ncid, "LAI", &cv) );
 
-    //PFT
-    if(curr_spec.pft){
+      //PFT
+      if(curr_spec.pft){
 
-      if(curr_spec.monthly){
-        PFTstart4[0] = month_timestep;
-        temutil::nc( nc_put_vara_double(ncid, cv, PFTstart4, PFTcount4, &cohort.cd.m_veg.lai[0]) );
-      }
-      else if(curr_spec.yearly){
-        PFTstart4[0] = year;
-        temutil::nc( nc_put_vara_double(ncid, cv, PFTstart4, PFTcount4, &cohort.cd.m_veg.lai[0]) );
-      }
-
-    }
-    //Total
-    else if(!curr_spec.pft){
-
-      double lai = 0;
-      if(curr_spec.monthly){
-        start3[0] = month_timestep;
-        for(int ip=0; ip<NUM_PFT; ip++){
-          lai += cohort.cd.m_veg.lai[ip];
+        if(curr_spec.monthly){
+          PFTstart4[0] = month_timestep;
+          temutil::nc( nc_put_vara_double(ncid, cv, PFTstart4, PFTcount4, &cohort.cd.m_veg.lai[0]) );
         }
-      }
-      else if(curr_spec.yearly){
-        start3[0] = year;
-        for(int ip=0; ip<NUM_PFT; ip++){
-          lai += cohort.cd.y_veg.lai[ip];
+        else if(curr_spec.yearly){
+          PFTstart4[0] = year;
+          temutil::nc( nc_put_vara_double(ncid, cv, PFTstart4, PFTcount4, &cohort.cd.m_veg.lai[0]) );
         }
+
       }
-      temutil::nc( nc_put_var1_double(ncid, cv, start3, &lai) );
-    }
-    temutil::nc( nc_close(ncid) );
+      //Total
+      else if(!curr_spec.pft){
+
+        double lai = 0;
+        if(curr_spec.monthly){
+          start3[0] = month_timestep;
+          for(int ip=0; ip<NUM_PFT; ip++){
+            lai += cohort.cd.m_veg.lai[ip];
+          }
+        }
+        else if(curr_spec.yearly){
+          start3[0] = year;
+          for(int ip=0; ip<NUM_PFT; ip++){
+            lai += cohort.cd.y_veg.lai[ip];
+          }
+        }
+        temutil::nc( nc_put_var1_double(ncid, cv, start3, &lai) );
+      }
+      temutil::nc( nc_close(ncid) );
+    }//end critical(outputLAI)
   }//end LAI
   map_itr = netcdf_outputs.end();
 
@@ -3504,85 +3735,88 @@ void Runner::output_netCDF(std::map<std::string, output_spec> &netcdf_outputs, i
     curr_spec = map_itr->second;
     curr_filename = curr_spec.file_path + curr_spec.filename_prefix + file_stage_suffix;
 
-    temutil::nc( nc_open(curr_filename.c_str(), NC_WRITE, &ncid) );
-    temutil::nc( nc_inq_varid(ncid, "LTRFALC", &cv) );
+    #pragma omp critical(outputLTRFALC)
+    {
+      temutil::nc( nc_open(curr_filename.c_str(), NC_WRITE, &ncid) );
+      temutil::nc( nc_inq_varid(ncid, "LTRFALC", &cv) );
 
-    //PFT and compartment
-    if(curr_spec.pft && curr_spec.compartment){
+      //PFT and compartment
+      if(curr_spec.pft && curr_spec.compartment){
 
-      double ltrfalc[NUM_PFT_PART][NUM_PFT];
-      for(int ip=0; ip<NUM_PFT; ip++){
-        for(int ipp=0; ipp<NUM_PFT_PART; ipp++){
+        double ltrfalc[NUM_PFT_PART][NUM_PFT];
+        for(int ip=0; ip<NUM_PFT; ip++){
+          for(int ipp=0; ipp<NUM_PFT_PART; ipp++){
+
+            if(curr_spec.monthly){
+              start5[0] = month_timestep;
+              ltrfalc[ipp][ip] = cohort.bd[ip].m_v2soi.ltrfalc[ipp];
+            }
+            else if(curr_spec.yearly){
+              start5[0] = year;
+              ltrfalc[ipp][ip] = cohort.bd[ip].y_v2soi.ltrfalc[ipp];
+            }
+          }
+        }
+
+        temutil::nc( nc_put_vara_double(ncid, cv, start5, count5, &ltrfalc[0][0]) );
+      }
+      //PFT only
+      else if(curr_spec.pft && !curr_spec.compartment){
+
+        double ltrfalc[NUM_PFT];
+        for(int ip=0; ip<NUM_PFT; ip++){
 
           if(curr_spec.monthly){
-            start5[0] = month_timestep;
-            ltrfalc[ipp][ip] = cohort.bd[ip].m_v2soi.ltrfalc[ipp];
+            PFTstart4[0] = month_timestep;
+            ltrfalc[ip] = cohort.bd[ip].m_v2soi.ltrfalcall;
           }
           else if(curr_spec.yearly){
-            start5[0] = year;
-            ltrfalc[ipp][ip] = cohort.bd[ip].y_v2soi.ltrfalc[ipp];
+            PFTstart4[0] = year;
+            ltrfalc[ip] = cohort.bd[ip].y_v2soi.ltrfalcall;
           }
         }
+
+        temutil::nc( nc_put_vara_double(ncid, cv, PFTstart4, PFTcount4, &ltrfalc[0]) );
       }
+      //Compartment only
+      else if(!curr_spec.pft && curr_spec.compartment){
 
-      temutil::nc( nc_put_vara_double(ncid, cv, start5, count5, &ltrfalc[0][0]) );
-    }
-    //PFT only
-    else if(curr_spec.pft && !curr_spec.compartment){
+        double ltrfalc[NUM_PFT_PART] = {0};
+        for(int ip=0; ip<NUM_PFT; ip++){
+          for(int ipp=0; ipp<NUM_PFT_PART; ipp++){
 
-      double ltrfalc[NUM_PFT];
-      for(int ip=0; ip<NUM_PFT; ip++){
-
-        if(curr_spec.monthly){
-          PFTstart4[0] = month_timestep;
-          ltrfalc[ip] = cohort.bd[ip].m_v2soi.ltrfalcall;
+            if(curr_spec.monthly){
+              CompStart4[0] = month_timestep;
+              ltrfalc[ipp] += cohort.bd[ip].m_v2soi.ltrfalc[ipp];
+            }
+            else if(curr_spec.yearly){
+              CompStart4[0] = year;
+              ltrfalc[ipp] += cohort.bd[ip].y_v2soi.ltrfalc[ipp];
+            }
+          }
         }
-        else if(curr_spec.yearly){
-          PFTstart4[0] = year;
-          ltrfalc[ip] = cohort.bd[ip].y_v2soi.ltrfalcall;
-        }
+
+        temutil::nc( nc_put_vara_double(ncid, cv, CompStart4, CompCount4, &ltrfalc[0]) );
       }
+      //Neither PFT nor compartment - totals
+      else if(!curr_spec.pft && !curr_spec.compartment){
 
-      temutil::nc( nc_put_vara_double(ncid, cv, PFTstart4, PFTcount4, &ltrfalc[0]) );
-    }
-    //Compartment only
-    else if(!curr_spec.pft && curr_spec.compartment){
-
-      double ltrfalc[NUM_PFT_PART] = {0};
-      for(int ip=0; ip<NUM_PFT; ip++){
-        for(int ipp=0; ipp<NUM_PFT_PART; ipp++){
+        double ltrfalc = 0;
+        for(int ip=0; ip<NUM_PFT; ip++){
 
           if(curr_spec.monthly){
-            CompStart4[0] = month_timestep;
-            ltrfalc[ipp] += cohort.bd[ip].m_v2soi.ltrfalc[ipp];
+            start3[0] = month_timestep;
+            ltrfalc += cohort.bd[ip].m_v2soi.ltrfalcall;
           }
           else if(curr_spec.yearly){
-            CompStart4[0] = year;
-            ltrfalc[ipp] += cohort.bd[ip].y_v2soi.ltrfalc[ipp];
+            start3[0] = year;
+            ltrfalc += cohort.bd[ip].y_v2soi.ltrfalcall;
           }
         }
+        temutil::nc( nc_put_var1_double(ncid, cv, start3, &ltrfalc) );
       }
-
-      temutil::nc( nc_put_vara_double(ncid, cv, CompStart4, CompCount4, &ltrfalc[0]) );
-    }
-    //Neither PFT nor compartment - totals
-    else if(!curr_spec.pft && !curr_spec.compartment){
-
-      double ltrfalc = 0;
-      for(int ip=0; ip<NUM_PFT; ip++){
-
-        if(curr_spec.monthly){
-          start3[0] = month_timestep;
-          ltrfalc += cohort.bd[ip].m_v2soi.ltrfalcall;
-        }
-        else if(curr_spec.yearly){
-          start3[0] = year;
-          ltrfalc += cohort.bd[ip].y_v2soi.ltrfalcall;
-        }
-      }
-      temutil::nc( nc_put_var1_double(ncid, cv, start3, &ltrfalc) );
-    }
-    temutil::nc( nc_close(ncid) );
+      temutil::nc( nc_close(ncid) );
+    }//end critical(outputLTRFALC)
   }//end LTRFALC
   map_itr = netcdf_outputs.end();
 
@@ -3594,85 +3828,88 @@ void Runner::output_netCDF(std::map<std::string, output_spec> &netcdf_outputs, i
     curr_spec = map_itr->second;
     curr_filename = curr_spec.file_path + curr_spec.filename_prefix + file_stage_suffix;
 
-    temutil::nc( nc_open(curr_filename.c_str(), NC_WRITE, &ncid) );
-    temutil::nc( nc_inq_varid(ncid, "LTRFALN", &cv) );
+    #pragma omp critical(outputLTRFALN)
+    {
+      temutil::nc( nc_open(curr_filename.c_str(), NC_WRITE, &ncid) );
+      temutil::nc( nc_inq_varid(ncid, "LTRFALN", &cv) );
 
-    //PFT and compartment
-    if(curr_spec.pft && curr_spec.compartment){
+      //PFT and compartment
+      if(curr_spec.pft && curr_spec.compartment){
 
-      double ltrfaln[NUM_PFT_PART][NUM_PFT];
-      for(int ip=0; ip<NUM_PFT; ip++){
-        for(int ipp=0; ipp<NUM_PFT_PART; ipp++){
+        double ltrfaln[NUM_PFT_PART][NUM_PFT];
+        for(int ip=0; ip<NUM_PFT; ip++){
+          for(int ipp=0; ipp<NUM_PFT_PART; ipp++){
+
+            if(curr_spec.monthly){
+              start5[0] = month_timestep;
+              ltrfaln[ipp][ip] = cohort.bd[ip].m_v2soi.ltrfaln[ipp];
+            }
+            else if(curr_spec.yearly){
+              start5[0] = year;
+              ltrfaln[ipp][ip] = cohort.bd[ip].y_v2soi.ltrfaln[ipp];
+            }
+          }
+        }
+
+        temutil::nc( nc_put_vara_double(ncid, cv, start5, count5, &ltrfaln[0][0]) );
+      }
+      //PFT only
+      else if(curr_spec.pft && !curr_spec.compartment){
+
+        double ltrfaln[NUM_PFT];
+        for(int ip=0; ip<NUM_PFT; ip++){
 
           if(curr_spec.monthly){
-            start5[0] = month_timestep;
-            ltrfaln[ipp][ip] = cohort.bd[ip].m_v2soi.ltrfaln[ipp];
+            PFTstart4[0] = month_timestep;
+            ltrfaln[ip] = cohort.bd[ip].m_v2soi.ltrfalnall;
           }
           else if(curr_spec.yearly){
-            start5[0] = year;
-            ltrfaln[ipp][ip] = cohort.bd[ip].y_v2soi.ltrfaln[ipp];
+            PFTstart4[0] = year;
+            ltrfaln[ip] = cohort.bd[ip].y_v2soi.ltrfalnall;
           }
         }
+
+        temutil::nc( nc_put_vara_double(ncid, cv, PFTstart4, PFTcount4, &ltrfaln[0]) );
       }
+      //Compartment only
+      else if(!curr_spec.pft && curr_spec.compartment){
 
-      temutil::nc( nc_put_vara_double(ncid, cv, start5, count5, &ltrfaln[0][0]) );
-    }
-    //PFT only
-    else if(curr_spec.pft && !curr_spec.compartment){
+        double ltrfaln[NUM_PFT_PART] = {0};
+        for(int ip=0; ip<NUM_PFT; ip++){
+          for(int ipp=0; ipp<NUM_PFT_PART; ipp++){
 
-      double ltrfaln[NUM_PFT];
-      for(int ip=0; ip<NUM_PFT; ip++){
-
-        if(curr_spec.monthly){
-          PFTstart4[0] = month_timestep;
-          ltrfaln[ip] = cohort.bd[ip].m_v2soi.ltrfalnall;
+            if(curr_spec.monthly){
+              CompStart4[0] = month_timestep;
+              ltrfaln[ipp] += cohort.bd[ip].m_v2soi.ltrfaln[ipp];
+            }
+            else if(curr_spec.yearly){
+              CompStart4[0] = year;
+              ltrfaln[ipp] += cohort.bd[ip].y_v2soi.ltrfaln[ipp];
+            }
+          }
         }
-        else if(curr_spec.yearly){
-          PFTstart4[0] = year;
-          ltrfaln[ip] = cohort.bd[ip].y_v2soi.ltrfalnall;
-        }
+
+        temutil::nc( nc_put_vara_double(ncid, cv, CompStart4, CompCount4, &ltrfaln[0]) );
       }
+      //Neither PFT nor compartment - totals
+      else if(!curr_spec.pft && !curr_spec.compartment){
 
-      temutil::nc( nc_put_vara_double(ncid, cv, PFTstart4, PFTcount4, &ltrfaln[0]) );
-    }
-    //Compartment only
-    else if(!curr_spec.pft && curr_spec.compartment){
-
-      double ltrfaln[NUM_PFT_PART] = {0};
-      for(int ip=0; ip<NUM_PFT; ip++){
-        for(int ipp=0; ipp<NUM_PFT_PART; ipp++){
+        double ltrfaln = 0;
+        for(int ip=0; ip<NUM_PFT; ip++){
 
           if(curr_spec.monthly){
-            CompStart4[0] = month_timestep;
-            ltrfaln[ipp] += cohort.bd[ip].m_v2soi.ltrfaln[ipp];
+            start3[0] = month_timestep;
+            ltrfaln += cohort.bd[ip].m_v2soi.ltrfalnall;
           }
           else if(curr_spec.yearly){
-            CompStart4[0] = year;
-            ltrfaln[ipp] += cohort.bd[ip].y_v2soi.ltrfaln[ipp];
+            start3[0] = year;
+            ltrfaln += cohort.bd[ip].y_v2soi.ltrfalnall;
           }
         }
+        temutil::nc( nc_put_var1_double(ncid, cv, start3, &ltrfaln) );
       }
-
-      temutil::nc( nc_put_vara_double(ncid, cv, CompStart4, CompCount4, &ltrfaln[0]) );
-    }
-    //Neither PFT nor compartment - totals
-    else if(!curr_spec.pft && !curr_spec.compartment){
-
-      double ltrfaln = 0;
-      for(int ip=0; ip<NUM_PFT; ip++){
-
-        if(curr_spec.monthly){
-          start3[0] = month_timestep;
-          ltrfaln += cohort.bd[ip].m_v2soi.ltrfalnall;
-        }
-        else if(curr_spec.yearly){
-          start3[0] = year;
-          ltrfaln += cohort.bd[ip].y_v2soi.ltrfalnall;
-        }
-      }
-      temutil::nc( nc_put_var1_double(ncid, cv, start3, &ltrfaln) );
-    }
-    temutil::nc( nc_close(ncid) );
+      temutil::nc( nc_close(ncid) );
+    }//end critical(outputLTRFALN)
   }//end LTRFALN
   map_itr = netcdf_outputs.end();
 
@@ -3684,90 +3921,93 @@ void Runner::output_netCDF(std::map<std::string, output_spec> &netcdf_outputs, i
     curr_spec = map_itr->second;
     curr_filename = curr_spec.file_path + curr_spec.filename_prefix + file_stage_suffix;
 
-    temutil::nc( nc_open(curr_filename.c_str(), NC_WRITE, &ncid) );
-    temutil::nc( nc_inq_varid(ncid, "NPP", &cv) );
+    #pragma omp critical(outputNPP)
+    {
+      temutil::nc( nc_open(curr_filename.c_str(), NC_WRITE, &ncid) );
+      temutil::nc( nc_inq_varid(ncid, "NPP", &cv) );
 
-    //PFT and compartment
-    if(curr_spec.pft && curr_spec.compartment){
+      //PFT and compartment
+      if(curr_spec.pft && curr_spec.compartment){
 
-      double npp[NUM_PFT_PART][NUM_PFT];
-      if(curr_spec.monthly){
-        start5[0] = month_timestep;
-        for(int ip=0; ip<NUM_PFT; ip++){
-          for(int ipp=0; ipp<NUM_PFT_PART; ipp++){
-            npp[ipp][ip] = cohort.bd[ip].m_a2v.npp[ipp];
-          }
-        }
-      }
-      else if(curr_spec.yearly){
-        start5[0] = year;
-        for(int ip=0; ip<NUM_PFT; ip++){
-          for(int ipp=0; ipp<NUM_PFT_PART; ipp++){
-            npp[ipp][ip] = cohort.bd[ip].y_a2v.npp[ipp];
-          }
-        }
-      }
-
-      temutil::nc( nc_put_vara_double(ncid, cv, start5, count5, &npp[0][0]) );
-    }
-    //PFT only
-    else if(curr_spec.pft && !curr_spec.compartment){
-
-      double npp[NUM_PFT];
-      if(curr_spec.monthly){
-        PFTstart4[0] = month_timestep;
-        for(int ip=0; ip<NUM_PFT; ip++){
-          npp[ip] = cohort.bd[ip].m_a2v.nppall; 
-        }
-      }
-      else if(curr_spec.yearly){
-        PFTstart4[0] = year;
-        for(int ip=0; ip<NUM_PFT; ip++){
-          npp[ip] = cohort.bd[ip].y_a2v.nppall; 
-        }
-      }
-
-      temutil::nc( nc_put_vara_double(ncid, cv, PFTstart4, PFTcount4, &npp[0]) );
-    }
-    //Compartment only
-    else if(!curr_spec.pft && curr_spec.compartment){
-
-      double npp[NUM_PFT_PART] = {0};
-      if(curr_spec.monthly){
-        CompStart4[0] = month_timestep;
-        for(int ipp=0; ipp<NUM_PFT_PART; ipp++){
+        double npp[NUM_PFT_PART][NUM_PFT];
+        if(curr_spec.monthly){
+          start5[0] = month_timestep;
           for(int ip=0; ip<NUM_PFT; ip++){
-            npp[ipp] += cohort.bd[ip].m_a2v.npp[ipp];
+            for(int ipp=0; ipp<NUM_PFT_PART; ipp++){
+              npp[ipp][ip] = cohort.bd[ip].m_a2v.npp[ipp];
+            }
           }
         }
-      }
-      else if(curr_spec.yearly){
-        CompStart4[0] = year;
-        for(int ipp=0; ipp<NUM_PFT_PART; ipp++){
+        else if(curr_spec.yearly){
+          start5[0] = year;
           for(int ip=0; ip<NUM_PFT; ip++){
-            npp[ipp] += cohort.bd[ip].y_a2v.npp[ipp];
+            for(int ipp=0; ipp<NUM_PFT_PART; ipp++){
+              npp[ipp][ip] = cohort.bd[ip].y_a2v.npp[ipp];
+            }
           }
         }
-      }
 
-      temutil::nc( nc_put_vara_double(ncid, cv, CompStart4, CompCount4, &npp[0]) );
-    }
-    //Neither PFT nor Compartment - total instead
-    else if(!curr_spec.pft && !curr_spec.compartment){
-
-      double npp;
-      if(curr_spec.monthly){
-        start3[0] = month_timestep;
-        npp = cohort.bdall->m_a2v.nppall;
+        temutil::nc( nc_put_vara_double(ncid, cv, start5, count5, &npp[0][0]) );
       }
-      else if(curr_spec.yearly){
-        start3[0] = year;
-        npp = cohort.bdall->y_a2v.nppall;
-      }
+      //PFT only
+      else if(curr_spec.pft && !curr_spec.compartment){
 
-      temutil::nc( nc_put_var1_double(ncid, cv, start3, &npp) );
-    }
-    temutil::nc( nc_close(ncid) );
+        double npp[NUM_PFT];
+        if(curr_spec.monthly){
+          PFTstart4[0] = month_timestep;
+          for(int ip=0; ip<NUM_PFT; ip++){
+            npp[ip] = cohort.bd[ip].m_a2v.nppall; 
+          }
+        }
+        else if(curr_spec.yearly){
+          PFTstart4[0] = year;
+          for(int ip=0; ip<NUM_PFT; ip++){
+            npp[ip] = cohort.bd[ip].y_a2v.nppall; 
+          }
+        }
+
+        temutil::nc( nc_put_vara_double(ncid, cv, PFTstart4, PFTcount4, &npp[0]) );
+      }
+      //Compartment only
+      else if(!curr_spec.pft && curr_spec.compartment){
+
+        double npp[NUM_PFT_PART] = {0};
+        if(curr_spec.monthly){
+          CompStart4[0] = month_timestep;
+          for(int ipp=0; ipp<NUM_PFT_PART; ipp++){
+            for(int ip=0; ip<NUM_PFT; ip++){
+              npp[ipp] += cohort.bd[ip].m_a2v.npp[ipp];
+            }
+          }
+        }
+        else if(curr_spec.yearly){
+          CompStart4[0] = year;
+          for(int ipp=0; ipp<NUM_PFT_PART; ipp++){
+            for(int ip=0; ip<NUM_PFT; ip++){
+              npp[ipp] += cohort.bd[ip].y_a2v.npp[ipp];
+            }
+          }
+        }
+
+        temutil::nc( nc_put_vara_double(ncid, cv, CompStart4, CompCount4, &npp[0]) );
+      }
+      //Neither PFT nor Compartment - total instead
+      else if(!curr_spec.pft && !curr_spec.compartment){
+
+        double npp;
+        if(curr_spec.monthly){
+          start3[0] = month_timestep;
+          npp = cohort.bdall->m_a2v.nppall;
+        }
+        else if(curr_spec.yearly){
+          start3[0] = year;
+          npp = cohort.bdall->y_a2v.nppall;
+        }
+
+        temutil::nc( nc_put_var1_double(ncid, cv, start3, &npp) );
+      }
+      temutil::nc( nc_close(ncid) );
+    }//end critical(outputNPP)
   }//end NPP
   map_itr = netcdf_outputs.end();
 
@@ -3779,55 +4019,58 @@ void Runner::output_netCDF(std::map<std::string, output_spec> &netcdf_outputs, i
     curr_spec = map_itr->second;
     curr_filename = curr_spec.file_path + curr_spec.filename_prefix + file_stage_suffix;
 
-    temutil::nc( nc_open(curr_filename.c_str(), NC_WRITE, &ncid) );
-    temutil::nc( nc_inq_varid(ncid, "NUPTAKEIN", &cv) );
+    #pragma omp critical(outputNUPTAKEIN)
+    {
+      temutil::nc( nc_open(curr_filename.c_str(), NC_WRITE, &ncid) );
+      temutil::nc( nc_inq_varid(ncid, "NUPTAKEIN", &cv) );
 
-    //PFT and compartment
-    if(curr_spec.pft && curr_spec.compartment){
-      /*** STUB ***/
-      //Currently unavailable. N uptake will need to be made accessible
-      // by PFT compartment.
-    }
-    //PFT only
-    else if(curr_spec.pft && !curr_spec.compartment){
-      double innuptake[NUM_PFT];
+      //PFT and compartment
+      if(curr_spec.pft && curr_spec.compartment){
+        /*** STUB ***/
+        //Currently unavailable. N uptake will need to be made accessible
+        // by PFT compartment.
+      }
+      //PFT only
+      else if(curr_spec.pft && !curr_spec.compartment){
+        double innuptake[NUM_PFT];
 
-      if(curr_spec.monthly){
-        PFTstart4[0] = month_timestep;
+        if(curr_spec.monthly){
+          PFTstart4[0] = month_timestep;
 
-        for(int ip=0; ip<NUM_PFT; ip++){
-          innuptake[ip] = cohort.bd[ip].m_soi2v.innuptake;
+          for(int ip=0; ip<NUM_PFT; ip++){
+            innuptake[ip] = cohort.bd[ip].m_soi2v.innuptake;
+          }
         }
-      }
-      else if(curr_spec.yearly){
-        PFTstart4[0] = year;
+        else if(curr_spec.yearly){
+          PFTstart4[0] = year;
 
-        for(int ip=0; ip<NUM_PFT; ip++){
-          innuptake[ip] = cohort.bd[ip].y_soi2v.innuptake;
+          for(int ip=0; ip<NUM_PFT; ip++){
+            innuptake[ip] = cohort.bd[ip].y_soi2v.innuptake;
+          }
         }
+        temutil::nc( nc_put_vara_double(ncid, cv, PFTstart4, PFTcount4, &innuptake[0]) );
       }
-      temutil::nc( nc_put_vara_double(ncid, cv, PFTstart4, PFTcount4, &innuptake[0]) );
-    }
-    //Compartment only
-    else if(!curr_spec.pft && curr_spec.compartment){
-      /*** STUB ***/
-    }
-    //Neither PFT nor compartment
-    else if(!curr_spec.pft && !curr_spec.compartment){
-      double innuptake = 0;
+      //Compartment only
+      else if(!curr_spec.pft && curr_spec.compartment){
+        /*** STUB ***/
+      }
+      //Neither PFT nor compartment
+      else if(!curr_spec.pft && !curr_spec.compartment){
+        double innuptake = 0;
 
-      if(curr_spec.monthly){
-        start3[0] = month_timestep;
-        innuptake = cohort.bdall->m_soi2v.innuptake;
+        if(curr_spec.monthly){
+          start3[0] = month_timestep;
+          innuptake = cohort.bdall->m_soi2v.innuptake;
+        }
+        else if(curr_spec.yearly){
+          start3[0] = year;
+          innuptake = cohort.bdall->y_soi2v.innuptake;
+        }
+        temutil::nc( nc_put_var1_double(ncid, cv, start3, &innuptake) );
       }
-      else if(curr_spec.yearly){
-        start3[0] = year;
-        innuptake = cohort.bdall->y_soi2v.innuptake;
-      }
-      temutil::nc( nc_put_var1_double(ncid, cv, start3, &innuptake) );
-    }
 
-    temutil::nc( nc_close(ncid) );
+      temutil::nc( nc_close(ncid) );
+    }//end critical(outputNUPTAKEIN)
   }//end NUPTAKEIN
   map_itr = netcdf_outputs.end();
 
@@ -3839,55 +4082,58 @@ void Runner::output_netCDF(std::map<std::string, output_spec> &netcdf_outputs, i
     curr_spec = map_itr->second;
     curr_filename = curr_spec.file_path + curr_spec.filename_prefix + file_stage_suffix;
 
-    temutil::nc( nc_open(curr_filename.c_str(), NC_WRITE, &ncid) );
-    temutil::nc( nc_inq_varid(ncid, "NUPTAKELAB", &cv) );
+    #pragma omp critical(outputNUPTAKELAB)
+    {
+      temutil::nc( nc_open(curr_filename.c_str(), NC_WRITE, &ncid) );
+      temutil::nc( nc_inq_varid(ncid, "NUPTAKELAB", &cv) );
 
-    //PFT and compartment
-    if(curr_spec.pft && curr_spec.compartment){
-      /*** STUB ***/
-      //Currently unavailable. Labile N uptake will need to be made
-      // accessible by PFT compartment.
-    }
-    //PFT only
-    else if(curr_spec.pft && !curr_spec.compartment){
-      double labnuptake[NUM_PFT];
+      //PFT and compartment
+      if(curr_spec.pft && curr_spec.compartment){
+        /*** STUB ***/
+        //Currently unavailable. Labile N uptake will need to be made
+        // accessible by PFT compartment.
+      }
+      //PFT only
+      else if(curr_spec.pft && !curr_spec.compartment){
+        double labnuptake[NUM_PFT];
 
-      if(curr_spec.monthly){
-        PFTstart4[0] = month_timestep;
+        if(curr_spec.monthly){
+          PFTstart4[0] = month_timestep;
 
-        for(int ip=0; ip<NUM_PFT; ip++){
-          labnuptake[ip] = cohort.bd[ip].m_soi2v.lnuptake;
+          for(int ip=0; ip<NUM_PFT; ip++){
+            labnuptake[ip] = cohort.bd[ip].m_soi2v.lnuptake;
+          }
         }
-      }
-      else if(curr_spec.yearly){
-        PFTstart4[0] = year;
+        else if(curr_spec.yearly){
+          PFTstart4[0] = year;
 
-        for(int ip=0; ip<NUM_PFT; ip++){
-          labnuptake[ip] = cohort.bd[ip].y_soi2v.lnuptake;
+          for(int ip=0; ip<NUM_PFT; ip++){
+            labnuptake[ip] = cohort.bd[ip].y_soi2v.lnuptake;
+          }
         }
+        temutil::nc( nc_put_vara_double(ncid, cv, PFTstart4, PFTcount4, &labnuptake[0]) );
       }
-      temutil::nc( nc_put_vara_double(ncid, cv, PFTstart4, PFTcount4, &labnuptake[0]) );
-    }
-    //Compartment only
-    else if(!curr_spec.pft && curr_spec.compartment){
-      /*** STUB ***/
-    }
-    //Neither PFT nor compartment
-    else if(!curr_spec.pft && !curr_spec.compartment){
-      double labnuptake = 0;
+      //Compartment only
+      else if(!curr_spec.pft && curr_spec.compartment){
+        /*** STUB ***/
+      }
+      //Neither PFT nor compartment
+      else if(!curr_spec.pft && !curr_spec.compartment){
+        double labnuptake = 0;
 
-      if(curr_spec.monthly){
-        start3[0] = month_timestep;
-        labnuptake = cohort.bdall->m_soi2v.lnuptake;
+        if(curr_spec.monthly){
+          start3[0] = month_timestep;
+          labnuptake = cohort.bdall->m_soi2v.lnuptake;
+        }
+        else if(curr_spec.yearly){
+          start3[0] = year;
+          labnuptake = cohort.bdall->y_soi2v.lnuptake;
+        }
+        temutil::nc( nc_put_var1_double(ncid, cv, start3, &labnuptake) );
       }
-      else if(curr_spec.yearly){
-        start3[0] = year;
-        labnuptake = cohort.bdall->y_soi2v.lnuptake;
-      }
-      temutil::nc( nc_put_var1_double(ncid, cv, start3, &labnuptake) );
-    }
 
-    temutil::nc( nc_close(ncid) );
+      temutil::nc( nc_close(ncid) );
+    }//end critical(outputNUPTAKELAB)
   }//end NUPTAKELAB
   map_itr = netcdf_outputs.end();
 
@@ -3899,81 +4145,84 @@ void Runner::output_netCDF(std::map<std::string, output_spec> &netcdf_outputs, i
     curr_spec = map_itr->second;
     curr_filename = curr_spec.file_path + curr_spec.filename_prefix + file_stage_suffix;
 
-    temutil::nc( nc_open(curr_filename.c_str(), NC_WRITE, &ncid) );
-    temutil::nc( nc_inq_varid(ncid, "NUPTAKEST", &cv) );
+    #pragma omp critical(outputNUPTAKEST)
+    {
+      temutil::nc( nc_open(curr_filename.c_str(), NC_WRITE, &ncid) );
+      temutil::nc( nc_inq_varid(ncid, "NUPTAKEST", &cv) );
 
-    //PFT and compartment
-    if(curr_spec.pft && curr_spec.compartment){
-      double snuptake[NUM_PFT_PART][NUM_PFT];
+      //PFT and compartment
+      if(curr_spec.pft && curr_spec.compartment){
+        double snuptake[NUM_PFT_PART][NUM_PFT];
 
-      for(int ip=0; ip<NUM_PFT; ip++){
+        for(int ip=0; ip<NUM_PFT; ip++){
+          for(int ipp=0; ipp<NUM_PFT_PART; ipp++){
+            if(curr_spec.monthly){
+              start5[0] = month_timestep;
+              snuptake[ipp][ip] = cohort.bd[ip].m_soi2v.snuptake[ipp];
+            }
+            else if(curr_spec.yearly){
+              start5[0] = year;
+              snuptake[ipp][ip] = cohort.bd[ip].y_soi2v.snuptake[ipp];
+            }
+          }
+        }
+        temutil::nc( nc_put_vara_double(ncid, cv, start5, count5, &snuptake[0][0]) );
+      }
+      //PFT only
+      else if(curr_spec.pft && !curr_spec.compartment){
+        double snuptake[NUM_PFT] = {0};
+
+        if(curr_spec.monthly){
+          PFTstart4[0] = month_timestep;
+
+          for(int ip=0; ip<NUM_PFT; ip++){
+            snuptake[ip] = cohort.bd[ip].m_soi2v.snuptakeall;
+          }
+        }
+        else if(curr_spec.yearly){
+          PFTstart4[0] = year;
+
+          for(int ip=0; ip<NUM_PFT; ip++){
+            snuptake[ip] = cohort.bd[ip].y_soi2v.snuptakeall;
+          }
+        }
+        temutil::nc( nc_put_vara_double(ncid, cv, PFTstart4, PFTcount4, &snuptake[0]) );
+      }
+      //Compartment only
+      else if(!curr_spec.pft && curr_spec.compartment){
+        double snuptake[NUM_PFT_PART] = {0};
         for(int ipp=0; ipp<NUM_PFT_PART; ipp++){
-          if(curr_spec.monthly){
-            start5[0] = month_timestep;
-            snuptake[ipp][ip] = cohort.bd[ip].m_soi2v.snuptake[ipp];
-          }
-          else if(curr_spec.yearly){
-            start5[0] = year;
-            snuptake[ipp][ip] = cohort.bd[ip].y_soi2v.snuptake[ipp];
-          }
-        }
-      }
-      temutil::nc( nc_put_vara_double(ncid, cv, start5, count5, &snuptake[0][0]) );
-    }
-    //PFT only
-    else if(curr_spec.pft && !curr_spec.compartment){
-      double snuptake[NUM_PFT] = {0};
-
-      if(curr_spec.monthly){
-        PFTstart4[0] = month_timestep;
-
-        for(int ip=0; ip<NUM_PFT; ip++){
-          snuptake[ip] = cohort.bd[ip].m_soi2v.snuptakeall;
-        }
-      }
-      else if(curr_spec.yearly){
-        PFTstart4[0] = year;
-
-        for(int ip=0; ip<NUM_PFT; ip++){
-          snuptake[ip] = cohort.bd[ip].y_soi2v.snuptakeall;
-        }
-      }
-      temutil::nc( nc_put_vara_double(ncid, cv, PFTstart4, PFTcount4, &snuptake[0]) );
-    }
-    //Compartment only
-    else if(!curr_spec.pft && curr_spec.compartment){
-      double snuptake[NUM_PFT_PART] = {0};
-      for(int ipp=0; ipp<NUM_PFT_PART; ipp++){
-        for(int ip=0; ip<NUM_PFT; ip++){
-          if(curr_spec.monthly){
-            CompStart4[0] = month_timestep;
-            snuptake[ipp] += cohort.bd[ip].m_soi2v.snuptake[ipp]; 
-          }
-          else if(curr_spec.yearly){
-            CompStart4[0] = year;
-            snuptake[ipp] += cohort.bd[ip].y_soi2v.snuptake[ipp]; 
+          for(int ip=0; ip<NUM_PFT; ip++){
+            if(curr_spec.monthly){
+              CompStart4[0] = month_timestep;
+              snuptake[ipp] += cohort.bd[ip].m_soi2v.snuptake[ipp]; 
+            }
+            else if(curr_spec.yearly){
+              CompStart4[0] = year;
+              snuptake[ipp] += cohort.bd[ip].y_soi2v.snuptake[ipp]; 
+            }
           }
         }
+
+        temutil::nc( nc_put_vara_double(ncid, cv, CompStart4, CompCount4, &snuptake[0]) );
+      }
+      //Neither PFT nor compartment
+      else if(!curr_spec.pft && !curr_spec.compartment){
+        double snuptakeall = 0;
+
+        if(curr_spec.monthly){
+          start3[0] = month_timestep;
+          snuptakeall = cohort.bdall->m_soi2v.snuptakeall;
+        }
+        else if(curr_spec.yearly){
+          start3[0] = year;
+          snuptakeall = cohort.bdall->y_soi2v.snuptakeall;
+        }
+        temutil::nc( nc_put_var1_double(ncid, cv, start3, &snuptakeall) );
       }
 
-      temutil::nc( nc_put_vara_double(ncid, cv, CompStart4, CompCount4, &snuptake[0]) );
-    }
-    //Neither PFT nor compartment
-    else if(!curr_spec.pft && !curr_spec.compartment){
-      double snuptakeall = 0;
-
-      if(curr_spec.monthly){
-        start3[0] = month_timestep;
-        snuptakeall = cohort.bdall->m_soi2v.snuptakeall;
-      }
-      else if(curr_spec.yearly){
-        start3[0] = year;
-        snuptakeall = cohort.bdall->y_soi2v.snuptakeall;
-      }
-      temutil::nc( nc_put_var1_double(ncid, cv, start3, &snuptakeall) );
-    }
-
-    temutil::nc( nc_close(ncid) );
+      temutil::nc( nc_close(ncid) );
+    }//end critical(outputNUPTAKEST)
   }//end NUPTAKEST
   map_itr = netcdf_outputs.end();
 
@@ -3985,82 +4234,85 @@ void Runner::output_netCDF(std::map<std::string, output_spec> &netcdf_outputs, i
     curr_spec = map_itr->second;
     curr_filename = curr_spec.file_path + curr_spec.filename_prefix + file_stage_suffix;
 
-    temutil::nc( nc_open(curr_filename.c_str(), NC_WRITE, &ncid) );
-    temutil::nc( nc_inq_varid(ncid, "RG", &cv) );
+    #pragma omp critical(outputRG)
+    {
+      temutil::nc( nc_open(curr_filename.c_str(), NC_WRITE, &ncid) );
+      temutil::nc( nc_inq_varid(ncid, "RG", &cv) );
 
-    //PFT and compartment
-    if(curr_spec.pft && curr_spec.compartment){
+      //PFT and compartment
+      if(curr_spec.pft && curr_spec.compartment){
 
-      double rg[NUM_PFT_PART][NUM_PFT];
-      for(int ip=0; ip<NUM_PFT; ip++){
-        for(int ipp=0; ipp<NUM_PFT_PART; ipp++){
-          if(curr_spec.monthly){
-            start5[0] = month_timestep;
-            rg[ipp][ip] = cohort.bd[ip].m_v2a.rg[ipp];
+        double rg[NUM_PFT_PART][NUM_PFT];
+        for(int ip=0; ip<NUM_PFT; ip++){
+          for(int ipp=0; ipp<NUM_PFT_PART; ipp++){
+            if(curr_spec.monthly){
+              start5[0] = month_timestep;
+              rg[ipp][ip] = cohort.bd[ip].m_v2a.rg[ipp];
+            }
+            else if(curr_spec.yearly){
+              start5[0] = year;
+              rg[ipp][ip] = cohort.bd[ip].y_v2a.rg[ipp];
+            }
           }
-          else if(curr_spec.yearly){
-            start5[0] = year;
-            rg[ipp][ip] = cohort.bd[ip].y_v2a.rg[ipp];
-          }
         }
+
+        temutil::nc( nc_put_vara_double(ncid, cv, start5, count5, &rg[0][0]) ); 
       }
+      //PFT only
+      else if(curr_spec.pft && !curr_spec.compartment){
 
-      temutil::nc( nc_put_vara_double(ncid, cv, start5, count5, &rg[0][0]) ); 
-    }
-    //PFT only
-    else if(curr_spec.pft && !curr_spec.compartment){
-
-      double rg[NUM_PFT];
-      for(int ip=0; ip<NUM_PFT; ip++){
-        if(curr_spec.monthly){
-          PFTstart4[0] = month_timestep;
-          rg[ip] = cohort.bd[ip].m_v2a.rgall;
-        }
-        else if(curr_spec.yearly){
-          PFTstart4[0] = year;
-          rg[ip] = cohort.bd[ip].y_v2a.rgall;
-        }
-      }
-
-      temutil::nc( nc_put_vara_double(ncid, cv, PFTstart4, PFTcount4, &rg[0]) ); 
-    }
-    //Compartment only
-    else if(!curr_spec.pft && curr_spec.compartment){
-
-      double rg[NUM_PFT_PART] = {0};
-      for(int ipp=0; ipp<NUM_PFT_PART; ipp++){
+        double rg[NUM_PFT];
         for(int ip=0; ip<NUM_PFT; ip++){
           if(curr_spec.monthly){
-            CompStart4[0] = month_timestep;
-            rg[ipp] += cohort.bd[ip].m_v2a.rg[ipp];
+            PFTstart4[0] = month_timestep;
+            rg[ip] = cohort.bd[ip].m_v2a.rgall;
           }
           else if(curr_spec.yearly){
-            CompStart4[0] = year;
-            rg[ipp] += cohort.bd[ip].y_v2a.rg[ipp];
+            PFTstart4[0] = year;
+            rg[ip] = cohort.bd[ip].y_v2a.rgall;
           }
         }
+
+        temutil::nc( nc_put_vara_double(ncid, cv, PFTstart4, PFTcount4, &rg[0]) ); 
+      }
+      //Compartment only
+      else if(!curr_spec.pft && curr_spec.compartment){
+
+        double rg[NUM_PFT_PART] = {0};
+        for(int ipp=0; ipp<NUM_PFT_PART; ipp++){
+          for(int ip=0; ip<NUM_PFT; ip++){
+            if(curr_spec.monthly){
+              CompStart4[0] = month_timestep;
+              rg[ipp] += cohort.bd[ip].m_v2a.rg[ipp];
+            }
+            else if(curr_spec.yearly){
+              CompStart4[0] = year;
+              rg[ipp] += cohort.bd[ip].y_v2a.rg[ipp];
+            }
+          }
+        }
+
+        temutil::nc( nc_put_vara_double(ncid, cv, CompStart4, CompCount4, &rg[0]) );
+   
+      }
+      //Neither PFT nor compartment - Total
+      else if(!curr_spec.pft && !curr_spec.compartment){
+
+        double rg;
+        if(curr_spec.monthly){
+          start3[0] = month_timestep;
+          rg = cohort.bdall->m_v2a.rgall;
+        }
+        else if(curr_spec.yearly){
+          start3[0] = year;
+          rg = cohort.bdall->y_v2a.rgall;
+        }
+
+        temutil::nc( nc_put_var1_double(ncid, cv, start3, &rg) );
       }
 
-      temutil::nc( nc_put_vara_double(ncid, cv, CompStart4, CompCount4, &rg[0]) );
- 
-    }
-    //Neither PFT nor compartment - Total
-    else if(!curr_spec.pft && !curr_spec.compartment){
-
-      double rg;
-      if(curr_spec.monthly){
-        start3[0] = month_timestep;
-        rg = cohort.bdall->m_v2a.rgall;
-      }
-      else if(curr_spec.yearly){
-        start3[0] = year;
-        rg = cohort.bdall->y_v2a.rgall;
-      }
-
-      temutil::nc( nc_put_var1_double(ncid, cv, start3, &rg) );
-    }
-
-    temutil::nc( nc_close(ncid) );
+      temutil::nc( nc_close(ncid) );
+    }//end critical(outputRG)
   }//end RG
   map_itr = netcdf_outputs.end();
 
@@ -4072,82 +4324,85 @@ void Runner::output_netCDF(std::map<std::string, output_spec> &netcdf_outputs, i
     curr_spec = map_itr->second;
     curr_filename = curr_spec.file_path + curr_spec.filename_prefix + file_stage_suffix;
 
-    temutil::nc( nc_open(curr_filename.c_str(), NC_WRITE, &ncid) );
-    temutil::nc( nc_inq_varid(ncid, "RM", &cv) );
+    #pragma omp critical(outputRM)
+    {
+      temutil::nc( nc_open(curr_filename.c_str(), NC_WRITE, &ncid) );
+      temutil::nc( nc_inq_varid(ncid, "RM", &cv) );
 
-    //PFT and compartment
-    if(curr_spec.pft && curr_spec.compartment){
+      //PFT and compartment
+      if(curr_spec.pft && curr_spec.compartment){
 
-      double rm[NUM_PFT_PART][NUM_PFT];
-      for(int ip=0; ip<NUM_PFT; ip++){
-        for(int ipp=0; ipp<NUM_PFT_PART; ipp++){
-          if(curr_spec.monthly){
-            start5[0] = month_timestep;
-            rm[ipp][ip] = cohort.bd[ip].m_v2a.rm[ipp];
+        double rm[NUM_PFT_PART][NUM_PFT];
+        for(int ip=0; ip<NUM_PFT; ip++){
+          for(int ipp=0; ipp<NUM_PFT_PART; ipp++){
+            if(curr_spec.monthly){
+              start5[0] = month_timestep;
+              rm[ipp][ip] = cohort.bd[ip].m_v2a.rm[ipp];
+            }
+            else if(curr_spec.yearly){
+              start5[0] = year;
+              rm[ipp][ip] = cohort.bd[ip].y_v2a.rm[ipp];
+            }
           }
-          else if(curr_spec.yearly){
-            start5[0] = year;
-            rm[ipp][ip] = cohort.bd[ip].y_v2a.rm[ipp];
-          }
         }
+
+        temutil::nc( nc_put_vara_double(ncid, cv, start5, count5, &rm[0][0]) ); 
       }
+      //PFT only
+      else if(curr_spec.pft && !curr_spec.compartment){
 
-      temutil::nc( nc_put_vara_double(ncid, cv, start5, count5, &rm[0][0]) ); 
-    }
-    //PFT only
-    else if(curr_spec.pft && !curr_spec.compartment){
-
-      double rm[NUM_PFT];
-      for(int ip=0; ip<NUM_PFT; ip++){
-        if(curr_spec.monthly){
-          PFTstart4[0] = month_timestep;
-          rm[ip] = cohort.bd[ip].m_v2a.rmall;
-        }
-        else if(curr_spec.yearly){
-          PFTstart4[0] = year;
-          rm[ip] = cohort.bd[ip].y_v2a.rmall;
-        }
-      }
-
-      temutil::nc( nc_put_vara_double(ncid, cv, PFTstart4, PFTcount4, &rm[0]) ); 
-    }
-    //Compartment only
-    else if(!curr_spec.pft && curr_spec.compartment){
-
-      double rm[NUM_PFT_PART] = {0};
-      for(int ipp=0; ipp<NUM_PFT_PART; ipp++){
+        double rm[NUM_PFT];
         for(int ip=0; ip<NUM_PFT; ip++){
           if(curr_spec.monthly){
-            CompStart4[0] = month_timestep;
-            rm[ipp] += cohort.bd[ip].m_v2a.rm[ipp];
+            PFTstart4[0] = month_timestep;
+            rm[ip] = cohort.bd[ip].m_v2a.rmall;
           }
           else if(curr_spec.yearly){
-            CompStart4[0] = year;
-            rm[ipp] += cohort.bd[ip].y_v2a.rm[ipp];
+            PFTstart4[0] = year;
+            rm[ip] = cohort.bd[ip].y_v2a.rmall;
           }
         }
+
+        temutil::nc( nc_put_vara_double(ncid, cv, PFTstart4, PFTcount4, &rm[0]) ); 
+      }
+      //Compartment only
+      else if(!curr_spec.pft && curr_spec.compartment){
+
+        double rm[NUM_PFT_PART] = {0};
+        for(int ipp=0; ipp<NUM_PFT_PART; ipp++){
+          for(int ip=0; ip<NUM_PFT; ip++){
+            if(curr_spec.monthly){
+              CompStart4[0] = month_timestep;
+              rm[ipp] += cohort.bd[ip].m_v2a.rm[ipp];
+            }
+            else if(curr_spec.yearly){
+              CompStart4[0] = year;
+              rm[ipp] += cohort.bd[ip].y_v2a.rm[ipp];
+            }
+          }
+        }
+
+        temutil::nc( nc_put_vara_double(ncid, cv, CompStart4, CompCount4, &rm[0]) );
+   
+      }
+      //Neither PFT nor compartment - Total
+      else if(!curr_spec.pft && !curr_spec.compartment){
+
+        double rm;
+        if(curr_spec.monthly){
+          start3[0] = month_timestep;
+          rm = cohort.bdall->m_v2a.rmall;
+        }
+        else if(curr_spec.yearly){
+          start3[0] = year;
+          rm = cohort.bdall->y_v2a.rmall;
+        }
+
+        temutil::nc( nc_put_var1_double(ncid, cv, start3, &rm) );
       }
 
-      temutil::nc( nc_put_vara_double(ncid, cv, CompStart4, CompCount4, &rm[0]) );
- 
-    }
-    //Neither PFT nor compartment - Total
-    else if(!curr_spec.pft && !curr_spec.compartment){
-
-      double rm;
-      if(curr_spec.monthly){
-        start3[0] = month_timestep;
-        rm = cohort.bdall->m_v2a.rmall;
-      }
-      else if(curr_spec.yearly){
-        start3[0] = year;
-        rm = cohort.bdall->y_v2a.rmall;
-      }
-
-      temutil::nc( nc_put_var1_double(ncid, cv, start3, &rm) );
-    }
-
-    temutil::nc( nc_close(ncid) );
+      temutil::nc( nc_close(ncid) );
+    }//end critical(outputRM)
   }//end RM
   map_itr = netcdf_outputs.end();
 
@@ -4159,80 +4414,83 @@ void Runner::output_netCDF(std::map<std::string, output_spec> &netcdf_outputs, i
     curr_spec = map_itr->second;
     curr_filename = curr_spec.file_path + curr_spec.filename_prefix + file_stage_suffix;
 
-    temutil::nc( nc_open(curr_filename.c_str(), NC_WRITE, &ncid) );
-    temutil::nc( nc_inq_varid(ncid, "VEGC", &cv) );
+    #pragma omp critical(outputVEGC)
+    {
+      temutil::nc( nc_open(curr_filename.c_str(), NC_WRITE, &ncid) );
+      temutil::nc( nc_inq_varid(ncid, "VEGC", &cv) );
 
-    //PFT and compartment
-    if(curr_spec.pft && curr_spec.compartment){
+      //PFT and compartment
+      if(curr_spec.pft && curr_spec.compartment){
 
-      double vegc[NUM_PFT_PART][NUM_PFT];
-      for(int ip=0; ip<NUM_PFT; ip++){
-        for(int ipp=0; ipp<NUM_PFT_PART; ipp++){
-          if(curr_spec.monthly){
-            start5[0] = month_timestep;
-            vegc[ipp][ip] = cohort.bd[ip].m_vegs.c[ipp];
+        double vegc[NUM_PFT_PART][NUM_PFT];
+        for(int ip=0; ip<NUM_PFT; ip++){
+          for(int ipp=0; ipp<NUM_PFT_PART; ipp++){
+            if(curr_spec.monthly){
+              start5[0] = month_timestep;
+              vegc[ipp][ip] = cohort.bd[ip].m_vegs.c[ipp];
+            }
+            else if(curr_spec.yearly){
+              start5[0] = year;
+              vegc[ipp][ip] = cohort.bd[ip].y_vegs.c[ipp];
+            }
           }
-          else if(curr_spec.yearly){
-            start5[0] = year;
-            vegc[ipp][ip] = cohort.bd[ip].y_vegs.c[ipp];
-          }
         }
+
+        temutil::nc( nc_put_vara_double(ncid, cv, start5, count5, &vegc[0][0]) );
       }
+      //PFT only
+      else if(curr_spec.pft && !curr_spec.compartment){
 
-      temutil::nc( nc_put_vara_double(ncid, cv, start5, count5, &vegc[0][0]) );
-    }
-    //PFT only
-    else if(curr_spec.pft && !curr_spec.compartment){
-
-      double vegc[NUM_PFT];
-      for(int ip=0; ip<NUM_PFT; ip++){
-        if(curr_spec.monthly){
-          PFTstart4[0] = month_timestep;
-          vegc[ip] = cohort.bd[ip].m_vegs.call;
-        }
-        else if(curr_spec.yearly){
-          PFTstart4[0] = year;
-          vegc[ip] = cohort.bd[ip].y_vegs.call;
-        }
-      }
-
-      temutil::nc( nc_put_vara_double(ncid, cv, PFTstart4, PFTcount4, &vegc[0]) );
-    }
-    //Compartment only
-    else if(!curr_spec.pft && curr_spec.compartment){
-
-      double vegc[NUM_PFT_PART] = {0};
-      for(int ipp=0; ipp<NUM_PFT_PART; ipp++){
+        double vegc[NUM_PFT];
         for(int ip=0; ip<NUM_PFT; ip++){
           if(curr_spec.monthly){
-            CompStart4[0] = month_timestep;
-            vegc[ipp] += cohort.bd[ip].m_vegs.c[ipp];
+            PFTstart4[0] = month_timestep;
+            vegc[ip] = cohort.bd[ip].m_vegs.call;
           }
           else if(curr_spec.yearly){
-            CompStart4[0] = year;
-            vegc[ipp] += cohort.bd[ip].y_vegs.c[ipp];
+            PFTstart4[0] = year;
+            vegc[ip] = cohort.bd[ip].y_vegs.call;
           }
         }
-      }
 
-      temutil::nc( nc_put_vara_double(ncid, cv, CompStart4, CompCount4, &vegc[0]) );
-    }
-    //Neither PFT nor compartment
-    else if(!curr_spec.pft && !curr_spec.compartment){
-
-      double vegc;
-      if(curr_spec.monthly){
-        start3[0] = month_timestep;
-        vegc = cohort.bdall->m_vegs.call;
+        temutil::nc( nc_put_vara_double(ncid, cv, PFTstart4, PFTcount4, &vegc[0]) );
       }
-      else if(curr_spec.yearly){
-        start3[0] = year;
-        vegc = cohort.bdall->y_vegs.call;
-      }
+      //Compartment only
+      else if(!curr_spec.pft && curr_spec.compartment){
 
-      temutil::nc( nc_put_var1_double(ncid, cv, start3, &vegc) );
-    }
-    temutil::nc( nc_close(ncid) );
+        double vegc[NUM_PFT_PART] = {0};
+        for(int ipp=0; ipp<NUM_PFT_PART; ipp++){
+          for(int ip=0; ip<NUM_PFT; ip++){
+            if(curr_spec.monthly){
+              CompStart4[0] = month_timestep;
+              vegc[ipp] += cohort.bd[ip].m_vegs.c[ipp];
+            }
+            else if(curr_spec.yearly){
+              CompStart4[0] = year;
+              vegc[ipp] += cohort.bd[ip].y_vegs.c[ipp];
+            }
+          }
+        }
+
+        temutil::nc( nc_put_vara_double(ncid, cv, CompStart4, CompCount4, &vegc[0]) );
+      }
+      //Neither PFT nor compartment
+      else if(!curr_spec.pft && !curr_spec.compartment){
+
+        double vegc;
+        if(curr_spec.monthly){
+          start3[0] = month_timestep;
+          vegc = cohort.bdall->m_vegs.call;
+        }
+        else if(curr_spec.yearly){
+          start3[0] = year;
+          vegc = cohort.bdall->y_vegs.call;
+        }
+
+        temutil::nc( nc_put_var1_double(ncid, cv, start3, &vegc) );
+      }
+      temutil::nc( nc_close(ncid) );
+    }//end critical(outputVEGC)
   }//end VEGC
   map_itr = netcdf_outputs.end();
 
@@ -4244,80 +4502,83 @@ void Runner::output_netCDF(std::map<std::string, output_spec> &netcdf_outputs, i
     curr_spec = map_itr->second;
     curr_filename = curr_spec.file_path + curr_spec.filename_prefix + file_stage_suffix;
 
-    temutil::nc( nc_open(curr_filename.c_str(), NC_WRITE, &ncid) );
-    temutil::nc( nc_inq_varid(ncid, "VEGN", &cv) );
+    #pragma omp critical(outputVEGN)
+    {
+      temutil::nc( nc_open(curr_filename.c_str(), NC_WRITE, &ncid) );
+      temutil::nc( nc_inq_varid(ncid, "VEGN", &cv) );
 
-    //PFT and compartment
-    if(curr_spec.pft && curr_spec.compartment){
+      //PFT and compartment
+      if(curr_spec.pft && curr_spec.compartment){
 
-      double vegn[NUM_PFT_PART][NUM_PFT];
-      for(int ip=0; ip<NUM_PFT; ip++){
-        for(int ipp=0; ipp<NUM_PFT_PART; ipp++){
-          if(curr_spec.monthly){
-            start5[0] = month_timestep;
-            vegn[ipp][ip] = cohort.bd[ip].m_vegs.strn[ipp];
+        double vegn[NUM_PFT_PART][NUM_PFT];
+        for(int ip=0; ip<NUM_PFT; ip++){
+          for(int ipp=0; ipp<NUM_PFT_PART; ipp++){
+            if(curr_spec.monthly){
+              start5[0] = month_timestep;
+              vegn[ipp][ip] = cohort.bd[ip].m_vegs.strn[ipp];
+            }
+            else if(curr_spec.yearly){
+              start5[0] = year;
+              vegn[ipp][ip] = cohort.bd[ip].y_vegs.strn[ipp];
+            }
           }
-          else if(curr_spec.yearly){
-            start5[0] = year;
-            vegn[ipp][ip] = cohort.bd[ip].y_vegs.strn[ipp];
-          }
         }
+
+        temutil::nc( nc_put_vara_double(ncid, cv, start5, count5, &vegn[0][0]) );
       }
+      //PFT only
+      else if(curr_spec.pft && !curr_spec.compartment){
 
-      temutil::nc( nc_put_vara_double(ncid, cv, start5, count5, &vegn[0][0]) );
-    }
-    //PFT only
-    else if(curr_spec.pft && !curr_spec.compartment){
-
-      double vegn[NUM_PFT];
-      for(int ip=0; ip<NUM_PFT; ip++){
-        if(curr_spec.monthly){
-          PFTstart4[0] = month_timestep;
-          vegn[ip] = cohort.bd[ip].m_vegs.strnall;
-        }
-        else if(curr_spec.yearly){
-          PFTstart4[0] = year;
-          vegn[ip] = cohort.bd[ip].y_vegs.strnall;
-        }
-      }
-
-      temutil::nc( nc_put_vara_double(ncid, cv, PFTstart4, PFTcount4, &vegn[0]) );
-    }
-    //Compartment only
-    else if(!curr_spec.pft && curr_spec.compartment){
-
-      double vegn[NUM_PFT_PART] = {0};
-      for(int ipp=0; ipp<NUM_PFT_PART; ipp++){
+        double vegn[NUM_PFT];
         for(int ip=0; ip<NUM_PFT; ip++){
           if(curr_spec.monthly){
-            CompStart4[0] = month_timestep;
-            vegn[ipp] += cohort.bd[ip].m_vegs.strn[ipp];
+            PFTstart4[0] = month_timestep;
+            vegn[ip] = cohort.bd[ip].m_vegs.strnall;
           }
           else if(curr_spec.yearly){
-            CompStart4[0] = year;
-            vegn[ipp] += cohort.bd[ip].y_vegs.strn[ipp];
+            PFTstart4[0] = year;
+            vegn[ip] = cohort.bd[ip].y_vegs.strnall;
           }
         }
-      }
 
-      temutil::nc( nc_put_vara_double(ncid, cv, CompStart4, CompCount4, &vegn[0]) );
-    }
-    //Neither PFT nor compartment
-    else if(!curr_spec.pft && !curr_spec.compartment){
-
-      double vegn;
-      if(curr_spec.monthly){
-        start3[0] = month_timestep;
-        vegn = cohort.bdall->m_vegs.nall;
+        temutil::nc( nc_put_vara_double(ncid, cv, PFTstart4, PFTcount4, &vegn[0]) );
       }
-      else if(curr_spec.yearly){
-        start3[0] = year;
-        vegn = cohort.bdall->y_vegs.nall;
-      }
+      //Compartment only
+      else if(!curr_spec.pft && curr_spec.compartment){
 
-      temutil::nc( nc_put_var1_double(ncid, cv, start3, &vegn) );
-    }
-    temutil::nc( nc_close(ncid) );
+        double vegn[NUM_PFT_PART] = {0};
+        for(int ipp=0; ipp<NUM_PFT_PART; ipp++){
+          for(int ip=0; ip<NUM_PFT; ip++){
+            if(curr_spec.monthly){
+              CompStart4[0] = month_timestep;
+              vegn[ipp] += cohort.bd[ip].m_vegs.strn[ipp];
+            }
+            else if(curr_spec.yearly){
+              CompStart4[0] = year;
+              vegn[ipp] += cohort.bd[ip].y_vegs.strn[ipp];
+            }
+          }
+        }
+
+        temutil::nc( nc_put_vara_double(ncid, cv, CompStart4, CompCount4, &vegn[0]) );
+      }
+      //Neither PFT nor compartment
+      else if(!curr_spec.pft && !curr_spec.compartment){
+
+        double vegn;
+        if(curr_spec.monthly){
+          start3[0] = month_timestep;
+          vegn = cohort.bdall->m_vegs.nall;
+        }
+        else if(curr_spec.yearly){
+          start3[0] = year;
+          vegn = cohort.bdall->y_vegs.nall;
+        }
+
+        temutil::nc( nc_put_var1_double(ncid, cv, start3, &vegn) );
+      }
+      temutil::nc( nc_close(ncid) );
+    }//end critical(outputVEGN)
   }//end VEGN
   map_itr = netcdf_outputs.end();
 
@@ -4331,69 +4592,72 @@ void Runner::output_netCDF(std::map<std::string, output_spec> &netcdf_outputs, i
     curr_spec = map_itr->second;
     curr_filename = curr_spec.file_path + curr_spec.filename_prefix + file_stage_suffix;
 
-    temutil::nc( nc_open(curr_filename.c_str(), NC_WRITE, &ncid) );
-    temutil::nc( nc_inq_varid(ncid, "EET", &cv) );
+    #pragma omp critical(outputEET)
+    {
+      temutil::nc( nc_open(curr_filename.c_str(), NC_WRITE, &ncid) );
+      temutil::nc( nc_inq_varid(ncid, "EET", &cv) );
 
-    //PFT
-    if(curr_spec.pft){
+      //PFT
+      if(curr_spec.pft){
 
-      if(curr_spec.daily){
-        PFTstart4[0] = day_timestep;
-        PFTcount4[0] = dinm;
+        if(curr_spec.daily){
+          PFTstart4[0] = day_timestep;
+          PFTcount4[0] = dinm;
 
-        double EET[dinm][NUM_PFT];
-        for(int ip=0; ip<NUM_PFT; ip++){
-          for(int id=0; id<dinm; id++){
-            EET[id][ip] = cohort.ed[ip].daily_eet[id];
-          }
-        }
-
-        temutil::nc( nc_put_vara_double(ncid, cv, PFTstart4, PFTcount4, &EET[0][0]) );
-      }
-      else if(curr_spec.monthly){
-        PFTstart4[0] = month_timestep;
-        double EET[NUM_PFT];
-        for(int ip=0; ip<NUM_PFT; ip++){
-          EET[ip] = cohort.ed[ip].m_l2a.eet;
-        }
-
-        temutil::nc( nc_put_vara_double(ncid, cv, PFTstart4, PFTcount4, &EET[0]) );
-      }
-      else if(curr_spec.yearly){
-        PFTstart4[0] = year;
-        double EET[NUM_PFT];
-        for(int ip=0; ip<NUM_PFT; ip++){
-          EET[ip] = cohort.ed[ip].y_l2a.eet;
-        }
-
-        temutil::nc( nc_put_vara_double(ncid, cv, PFTstart4, PFTcount4, &EET[0]) );
-      }
-    }
-    //Not PFT. Total
-    else if(!curr_spec.pft){
-
-      if(curr_spec.daily){
-        start3[0] = day_timestep;
-        double eet[31] = {0};
-        for(int ii=0; ii<31; ii++){
+          double EET[dinm][NUM_PFT];
           for(int ip=0; ip<NUM_PFT; ip++){
-            eet[ii] += cohort.ed[ip].daily_eet[ii];
+            for(int id=0; id<dinm; id++){
+              EET[id][ip] = cohort.ed[ip].daily_eet[id];
+            }
           }
+
+          temutil::nc( nc_put_vara_double(ncid, cv, PFTstart4, PFTcount4, &EET[0][0]) );
         }
-        temutil::nc( nc_put_vara_double(ncid, cv, start3, count3, &eet[0]) );
+        else if(curr_spec.monthly){
+          PFTstart4[0] = month_timestep;
+          double EET[NUM_PFT];
+          for(int ip=0; ip<NUM_PFT; ip++){
+            EET[ip] = cohort.ed[ip].m_l2a.eet;
+          }
+
+          temutil::nc( nc_put_vara_double(ncid, cv, PFTstart4, PFTcount4, &EET[0]) );
+        }
+        else if(curr_spec.yearly){
+          PFTstart4[0] = year;
+          double EET[NUM_PFT];
+          for(int ip=0; ip<NUM_PFT; ip++){
+            EET[ip] = cohort.ed[ip].y_l2a.eet;
+          }
+
+          temutil::nc( nc_put_vara_double(ncid, cv, PFTstart4, PFTcount4, &EET[0]) );
+        }
       }
-      else if(curr_spec.monthly){
-        start3[0] = month_timestep;
-        double eet = cohort.edall->m_l2a.eet;
-        temutil::nc( nc_put_var1_double(ncid, cv, start3, &eet) );
+      //Not PFT. Total
+      else if(!curr_spec.pft){
+
+        if(curr_spec.daily){
+          start3[0] = day_timestep;
+          double eet[31] = {0};
+          for(int ii=0; ii<31; ii++){
+            for(int ip=0; ip<NUM_PFT; ip++){
+              eet[ii] += cohort.ed[ip].daily_eet[ii];
+            }
+          }
+          temutil::nc( nc_put_vara_double(ncid, cv, start3, count3, &eet[0]) );
+        }
+        else if(curr_spec.monthly){
+          start3[0] = month_timestep;
+          double eet = cohort.edall->m_l2a.eet;
+          temutil::nc( nc_put_var1_double(ncid, cv, start3, &eet) );
+        }
+        else if(curr_spec.yearly){
+          start3[0] = year;
+          double eet = cohort.edall->y_l2a.eet;
+          temutil::nc( nc_put_var1_double(ncid, cv, start3, &eet) );
+        }
       }
-      else if(curr_spec.yearly){
-        start3[0] = year;
-        double eet = cohort.edall->y_l2a.eet;
-        temutil::nc( nc_put_var1_double(ncid, cv, start3, &eet) );
-      }
-    }
-   temutil::nc( nc_close(ncid) );
+      temutil::nc( nc_close(ncid) );
+    }//end critical(outputEET)
   }//end EET
   map_itr = netcdf_outputs.end();
 
@@ -4405,70 +4669,73 @@ void Runner::output_netCDF(std::map<std::string, output_spec> &netcdf_outputs, i
     curr_spec = map_itr->second;
     curr_filename = curr_spec.file_path + curr_spec.filename_prefix + file_stage_suffix;
 
-    temutil::nc( nc_open(curr_filename.c_str(), NC_WRITE, &ncid) );
-    temutil::nc( nc_inq_varid(ncid, "PET", &cv) );
+    #pragma omp critical(outputPET)
+    {
+      temutil::nc( nc_open(curr_filename.c_str(), NC_WRITE, &ncid) );
+      temutil::nc( nc_inq_varid(ncid, "PET", &cv) );
 
-    //PFT
-    if(curr_spec.pft){
+      //PFT
+      if(curr_spec.pft){
 
-      if(curr_spec.daily){
-        PFTstart4[0] = day_timestep;
-        PFTcount4[0] = dinm;
+        if(curr_spec.daily){
+          PFTstart4[0] = day_timestep;
+          PFTcount4[0] = dinm;
 
-        double PET[dinm][NUM_PFT];
-        for(int ip=0; ip<NUM_PFT; ip++){
-          for(int id=0; id<dinm; id++){
-            PET[id][ip] = cohort.ed[ip].daily_pet[id];
-          }
-        }
-
-        temutil::nc( nc_put_vara_double(ncid, cv, PFTstart4, PFTcount4, &PET[0][0]) );
-      }
-      else if(curr_spec.monthly){
-        PFTstart4[0] = month_timestep;
-        double PET[NUM_PFT];
-        for(int ip=0; ip<NUM_PFT; ip++){
-          PET[ip] = cohort.ed[ip].m_l2a.pet;
-        }
-
-        temutil::nc( nc_put_vara_double(ncid, cv, PFTstart4, PFTcount4, &PET[0]) );
-      }
-      else if(curr_spec.yearly){
-        PFTstart4[0] = year;
-        double PET[NUM_PFT];
-        for(int ip=0; ip<NUM_PFT; ip++){
-          PET[ip] = cohort.ed[ip].y_l2a.pet;
-        }
-
-        temutil::nc( nc_put_vara_double(ncid, cv, PFTstart4, PFTcount4, &PET[0]) );
-      }
-    }
-    //Not PFT. Total
-    else if(!curr_spec.pft){
-
-      if(curr_spec.daily){
-        start3[0] = day_timestep;
-        double pet[31] = {0};
-        for(int ii=0; ii<31; ii++){
+          double PET[dinm][NUM_PFT];
           for(int ip=0; ip<NUM_PFT; ip++){
-            pet[ii] += cohort.ed[ip].daily_pet[ii];
+            for(int id=0; id<dinm; id++){
+              PET[id][ip] = cohort.ed[ip].daily_pet[id];
+            }
           }
-        }
-        temutil::nc( nc_put_vara_double(ncid, cv, start3, count3, &pet[0]) );
-      }
-      else if(curr_spec.monthly){
-        start3[0] = month_timestep;
-        double pet = cohort.edall->m_l2a.pet;
-        temutil::nc( nc_put_var1_double(ncid, cv, start3, &pet) );
-      }
-      else if(curr_spec.yearly){
-        start3[0] = year;
-        double pet = cohort.edall->y_l2a.pet;
-        temutil::nc( nc_put_var1_double(ncid, cv, start3, &pet) );
-      }
-    }
 
-   temutil::nc( nc_close(ncid) );
+          temutil::nc( nc_put_vara_double(ncid, cv, PFTstart4, PFTcount4, &PET[0][0]) );
+        }
+        else if(curr_spec.monthly){
+          PFTstart4[0] = month_timestep;
+          double PET[NUM_PFT];
+          for(int ip=0; ip<NUM_PFT; ip++){
+            PET[ip] = cohort.ed[ip].m_l2a.pet;
+          }
+
+          temutil::nc( nc_put_vara_double(ncid, cv, PFTstart4, PFTcount4, &PET[0]) );
+        }
+        else if(curr_spec.yearly){
+          PFTstart4[0] = year;
+          double PET[NUM_PFT];
+          for(int ip=0; ip<NUM_PFT; ip++){
+            PET[ip] = cohort.ed[ip].y_l2a.pet;
+          }
+
+          temutil::nc( nc_put_vara_double(ncid, cv, PFTstart4, PFTcount4, &PET[0]) );
+        }
+      }
+      //Not PFT. Total
+      else if(!curr_spec.pft){
+
+        if(curr_spec.daily){
+          start3[0] = day_timestep;
+          double pet[31] = {0};
+          for(int ii=0; ii<31; ii++){
+            for(int ip=0; ip<NUM_PFT; ip++){
+              pet[ii] += cohort.ed[ip].daily_pet[ii];
+            }
+          }
+          temutil::nc( nc_put_vara_double(ncid, cv, start3, count3, &pet[0]) );
+        }
+        else if(curr_spec.monthly){
+          start3[0] = month_timestep;
+          double pet = cohort.edall->m_l2a.pet;
+          temutil::nc( nc_put_var1_double(ncid, cv, start3, &pet) );
+        }
+        else if(curr_spec.yearly){
+          start3[0] = year;
+          double pet = cohort.edall->y_l2a.pet;
+          temutil::nc( nc_put_var1_double(ncid, cv, start3, &pet) );
+        }
+      }
+
+      temutil::nc( nc_close(ncid) );
+    }//end critical(outputPET)
   }//end PET
   map_itr = netcdf_outputs.end();
 

--- a/src/TEM.cpp
+++ b/src/TEM.cpp
@@ -253,17 +253,11 @@ int main(int argc, char* argv[]){
     //      depending on the comparison operator
     //  - The loop must be a basic block: no jump to outside the loop
     //      other than the exit statement.
-    #pragma omp parallel for
+    #pragma omp parallel for collapse(2) schedule(dynamic)
     for(int rowidx=0; rowidx<num_rows; rowidx++){
       for(int colidx=0; colidx<num_cols; colidx++){
-    //for (row = run_mask.begin(); row != run_mask.end() ; ++row) {
-      //for (col = row->begin(); col != row->end(); ++col) {
 
-        //bool mask_value = *col;
         bool mask_value = run_mask[rowidx].at(colidx);
-
-        //int rowidx = row - run_mask.begin();
-        //int colidx = col - row->begin();
 
         if (true == mask_value) {
 

--- a/src/TEMUtilityFunctions.cpp
+++ b/src/TEMUtilityFunctions.cpp
@@ -586,27 +586,36 @@ namespace temutil {
       Assumes that the file has some coordinate dimensions...
   */
   std::pair<float, float> get_latlon(const std::string& filename, int y, int x) {
-    BOOST_LOG_SEV(glg, debug) << "Opening dataset: " << filename;
-    int ncid;
-    temutil::nc( nc_open(filename.c_str(), NC_NOWRITE, &ncid ) );
 
-    int yD, xD;
-    temutil::nc( nc_inq_dimid(ncid, "Y", &yD) );
-    temutil::nc( nc_inq_dimid(ncid, "X", &xD) );
-
-    int latV;
-    int lonV;
-    temutil::nc( nc_inq_varid(ncid, "lat", &latV) );
-    temutil::nc( nc_inq_varid(ncid, "lon", &lonV) );
-
-    size_t start[2];
-    start[0] = y;
-    start[1] = x;
-
-    float lon_value;
+    //Variables needed outside the openmp block
     float lat_value;
-    temutil::nc( nc_get_var1_float(ncid, latV, start, &lat_value));
-    temutil::nc( nc_get_var1_float(ncid, lonV, start, &lon_value));
+    float lon_value;
+
+    #pragma omp critical(load_input)
+    {
+      std::cout<<"begin pragma\n";
+      BOOST_LOG_SEV(glg, debug) << "Opening dataset: " << filename;
+      int ncid;
+      temutil::nc( nc_open(filename.c_str(), NC_NOWRITE, &ncid ) );
+
+      int yD, xD;
+      temutil::nc( nc_inq_dimid(ncid, "Y", &yD) );
+      temutil::nc( nc_inq_dimid(ncid, "X", &xD) );
+      std::cout<<"inquired X and Y\n";
+      int latV;
+      int lonV;
+      temutil::nc( nc_inq_varid(ncid, "lat", &latV) );
+      temutil::nc( nc_inq_varid(ncid, "lon", &lonV) );
+
+      size_t start[2];
+      start[0] = y;
+      start[1] = x;
+
+      temutil::nc( nc_get_var1_float(ncid, latV, start, &lat_value));
+      temutil::nc( nc_get_var1_float(ncid, lonV, start, &lon_value));
+      std::cout<<"ending pragma\n";
+      temutil::nc( nc_close(ncid) );
+    }//End critical(get_latlon)
 
     return std::pair<float, float>(lat_value, lon_value);
   }
@@ -694,31 +703,38 @@ namespace temutil {
 
   /** rough draft for reading a single location, veg classification
   */
-  int get_veg_class(const std::string &filename, int y, int x) {
+  int get_veg_class(const std::string &filename2, int y2, int x2) {
 
-    BOOST_LOG_SEV(glg, debug) << "Opening dataset: " << filename;
-    int ncid;
-    temutil::nc( nc_open(filename.c_str(), NC_NOWRITE, &ncid ) );
-
-    int xD, yD;
-
-    //size_t yD_len, xD_len;
-
-    temutil::nc( nc_inq_dimid(ncid, "Y", &yD) );
-    //temutil::nc( nc_inq_dimlen(ncid, yD, &yD_len) );
-
-    temutil::nc( nc_inq_dimid(ncid, "X", &xD) );
-    //temutil::nc( nc_inq_dimlen(ncid, xD, &xD_len) );
-
-    int veg_classificationV;
-    temutil::nc( nc_inq_varid(ncid, "veg_class", &veg_classificationV) );
-
-    size_t start[2];
-    start[0] = y;
-    start[1] = x;
-
+    //Variable needed outside the omp block
     int veg_class_value;
-    temutil::nc( nc_get_var1_int(ncid, veg_classificationV, start, &veg_class_value)  );
+
+    #pragma omp critical(load_input)
+    {
+      BOOST_LOG_SEV(glg, debug) << "Opening dataset: " << filename2;
+      int ncid2;
+      temutil::nc( nc_open(filename2.c_str(), NC_NOWRITE, &ncid2 ) );
+
+      int xD2, yD2;
+
+      //size_t yD_len, xD_len;
+
+      temutil::nc( nc_inq_dimid(ncid2, "Y", &yD2) );
+      //temutil::nc( nc_inq_dimlen(ncid, yD, &yD_len) );
+
+      temutil::nc( nc_inq_dimid(ncid2, "X", &xD2) );
+      //temutil::nc( nc_inq_dimlen(ncid, xD, &xD_len) );
+
+      int veg_classificationV;
+      temutil::nc( nc_inq_varid(ncid2, "veg_class", &veg_classificationV) );
+
+      size_t start[2];
+      start[0] = y2;
+      start[1] = x2;
+
+      temutil::nc( nc_get_var1_int(ncid2, veg_classificationV, start, &veg_class_value)  );
+
+      temutil::nc( nc_close(ncid2) );
+    }//End critical(get_veg_class)
 
     return veg_class_value;
   }
@@ -728,23 +744,30 @@ namespace temutil {
 
     BOOST_LOG_SEV(glg, debug) << "Opening dataset: " << filename;
 
-    int ncid;
-    temutil::nc( nc_open(filename.c_str(), NC_NOWRITE, &ncid ) );
-
-    int xD, yD;
-
-    temutil::nc( nc_inq_dimid(ncid, "Y", &yD) );
-    temutil::nc( nc_inq_dimid(ncid, "X", &xD) );
-
-    int drainage_classV;
-    temutil::nc( nc_inq_varid(ncid, "drainage_class", &drainage_classV) );
-
-    size_t start[2];
-    start[0] = y;
-    start[1] = x;
-
+    //This variable is needed outside the omp block 
     int drainage_class_value;
-    temutil::nc( nc_get_var1_int(ncid, drainage_classV, start, &drainage_class_value)  );
+
+    #pragma omp critical(load_input)
+    {
+      int ncid;
+      temutil::nc( nc_open(filename.c_str(), NC_NOWRITE, &ncid ) );
+
+      int xD, yD;
+
+      temutil::nc( nc_inq_dimid(ncid, "Y", &yD) );
+      temutil::nc( nc_inq_dimid(ncid, "X", &xD) );
+
+      int drainage_classV;
+      temutil::nc( nc_inq_varid(ncid, "drainage_class", &drainage_classV) );
+
+      size_t start[2];
+      start[0] = y;
+      start[1] = x;
+
+      temutil::nc( nc_get_var1_int(ncid, drainage_classV, start, &drainage_class_value)  );
+
+      temutil::nc( nc_close(ncid) );
+    }//End critical(get_drainage)
 
     return drainage_class_value;
   }

--- a/src/TEMUtilityFunctions.cpp
+++ b/src/TEMUtilityFunctions.cpp
@@ -593,7 +593,6 @@ namespace temutil {
 
     #pragma omp critical(load_input)
     {
-      std::cout<<"begin pragma\n";
       BOOST_LOG_SEV(glg, debug) << "Opening dataset: " << filename;
       int ncid;
       temutil::nc( nc_open(filename.c_str(), NC_NOWRITE, &ncid ) );
@@ -613,7 +612,7 @@ namespace temutil {
 
       temutil::nc( nc_get_var1_float(ncid, latV, start, &lat_value));
       temutil::nc( nc_get_var1_float(ncid, lonV, start, &lon_value));
-      std::cout<<"ending pragma\n";
+
       temutil::nc( nc_close(ncid) );
     }//End critical(get_latlon)
 

--- a/src/TEMUtilityFunctions.cpp
+++ b/src/TEMUtilityFunctions.cpp
@@ -600,7 +600,7 @@ namespace temutil {
       int yD, xD;
       temutil::nc( nc_inq_dimid(ncid, "Y", &yD) );
       temutil::nc( nc_inq_dimid(ncid, "X", &xD) );
-      std::cout<<"inquired X and Y\n";
+
       int latV;
       int lonV;
       temutil::nc( nc_inq_varid(ncid, "lat", &latV) );

--- a/src/disturb/WildFire.cpp
+++ b/src/disturb/WildFire.cpp
@@ -39,22 +39,31 @@ WildFire::~WildFire() {}
 WildFire::WildFire(const std::string& fri_fname,
                    const std::string& exp_fname, const std::string& topo_fname, const int y, const int x) {
 
-  BOOST_LOG_SEV(glg, info) << "Setting up FRI fire data...";
-  this->fri = temutil::get_scalar<int>(fri_fname, "fri", y, x);
-  this->fri_severity = temutil::get_scalar<int>(fri_fname, "fri_severity", y, x);
-  this->fri_jday_of_burn = temutil::get_scalar<int>(fri_fname, "fri_jday_of_burn", y, x);
-  this->fri_area_of_burn = temutil::get_scalar<int>(fri_fname, "fri_area_of_burn", y, x);
+  #pragma omp critical(load_input)
+  {
+    BOOST_LOG_SEV(glg, info) << "Setting up FRI fire data...";
+    this->fri = temutil::get_scalar<int>(fri_fname, "fri", y, x);
+    this->fri_severity = temutil::get_scalar<int>(fri_fname, "fri_severity", y, x);
+    this->fri_jday_of_burn = temutil::get_scalar<int>(fri_fname, "fri_jday_of_burn", y, x);
+    this->fri_area_of_burn = temutil::get_scalar<int>(fri_fname, "fri_area_of_burn", y, x);
+  }//End critical(fri)
 
-  BOOST_LOG_SEV(glg, info) << "Setting up explicit fire data...";
-  this->exp_burn_mask = temutil::get_timeseries<int>(exp_fname, "exp_burn_mask", y, x);
-  this->exp_fire_severity = temutil::get_timeseries<int>(exp_fname, "exp_fire_severity", y, x);
-  this->exp_jday_of_burn = temutil::get_timeseries<int>(exp_fname, "exp_jday_of_burn", y, x);
-  this->exp_area_of_burn = temutil::get_timeseries<int>(exp_fname, "exp_area_of_burn", y, x);
- 
-  BOOST_LOG_SEV(glg, info) << "Setting up topographic data...";
-  this->slope = temutil::get_scalar<int>(topo_fname, "slope", y, x);
-  this->asp = temutil::get_scalar<int>(topo_fname, "aspect", y, x);
-  this->elev = temutil::get_scalar<int>(topo_fname, "elevation", y, x);
+  #pragma omp critical(load_input)
+  {
+    BOOST_LOG_SEV(glg, info) << "Setting up explicit fire data...";
+    this->exp_burn_mask = temutil::get_timeseries<int>(exp_fname, "exp_burn_mask", y, x);
+    this->exp_fire_severity = temutil::get_timeseries<int>(exp_fname, "exp_fire_severity", y, x);
+    this->exp_jday_of_burn = temutil::get_timeseries<int>(exp_fname, "exp_jday_of_burn", y, x);
+    this->exp_area_of_burn = temutil::get_timeseries<int>(exp_fname, "exp_area_of_burn", y, x);
+  }//End critical(exp_fir) 
+
+  #pragma omp critical(load_input)
+  {
+    BOOST_LOG_SEV(glg, info) << "Setting up topographic data...";
+    this->slope = temutil::get_scalar<int>(topo_fname, "slope", y, x);
+    this->asp = temutil::get_scalar<int>(topo_fname, "aspect", y, x);
+    this->elev = temutil::get_scalar<int>(topo_fname, "elevation", y, x);
+  }//End critical(topographic)
 
   BOOST_LOG_SEV(glg, debug) << "Done making WildFire object.";
   BOOST_LOG_SEV(glg, debug) << this->report_fire_inputs();

--- a/src/ecodomain/horizon/MineralInfo.cpp
+++ b/src/ecodomain/horizon/MineralInfo.cpp
@@ -7,20 +7,22 @@ extern src::severity_logger< severity_level > glg;
 MineralInfo::MineralInfo() {}
 
 MineralInfo::MineralInfo(const std::string& fname, const int y, const int x) {
-  
-  BOOST_LOG_SEV(glg, info) << "Loading ModelInfo (soil texture) from file: " << fname;
-  BOOST_LOG_SEV(glg, info) << "Loading for (y, x) point: " << "("<< y <<","<< x <<").";
 
-  float psand = temutil::get_scalar<float>(fname, "pct_sand", y, x);
-  float psilt = temutil::get_scalar<float>(fname, "pct_silt", y, x);
-  float pclay = temutil::get_scalar<float>(fname, "pct_clay", y, x);
-  
-  for (int i = 0; i < MAX_MIN_LAY; ++i) {
-    sand[i] = psand;
-    silt[i] = psilt;
-    clay[i] = pclay;
-  }
+  #pragma omp critical(load_input)
+  {  
+    BOOST_LOG_SEV(glg, info) << "Loading ModelInfo (soil texture) from file: " << fname;
+    BOOST_LOG_SEV(glg, info) << "Loading for (y, x) point: " << "("<< y <<","<< x <<").";
 
+    float psand = temutil::get_scalar<float>(fname, "pct_sand", y, x);
+    float psilt = temutil::get_scalar<float>(fname, "pct_silt", y, x);
+    float pclay = temutil::get_scalar<float>(fname, "pct_clay", y, x);
+    
+    for (int i = 0; i < MAX_MIN_LAY; ++i) {
+      sand[i] = psand;
+      silt[i] = psilt;
+      clay[i] = pclay;
+    }
+  }//End critical(soil_texture)
   setDefaultThick(0.0);
 }
 


### PR DESCRIPTION
Both the sequential and the parallel version were run for 1000EQ, 100SP, and 109TR for four cells [(0,0), (0,1), (1,0), (1,1)]. The netCDF output files for all three stages were shown to be identical using the compare_nc_output.sh script, which utilizes nccmp to diff the data from netCDF files. 