### PR TITLE
Feature spatial ref for mapping inputs

### DIFF
--- a/scripts/create_region_input.py
+++ b/scripts/create_region_input.py
@@ -192,6 +192,11 @@ def create_template_topo_file(fname, sizey=10, sizex=10):
 
   Y = ncfile.createDimension('Y', sizey)
   X = ncfile.createDimension('X', sizex)
+
+  # Spatial Ref. variables
+  lat = ncfile.createVariable('lat', np.float32, ('Y', 'X',))
+  lon = ncfile.createVariable('lon', np.float32, ('Y', 'X',))
+
   slope = ncfile.createVariable('slope', np.double, ('Y', 'X',))
   aspect = ncfile.createVariable('aspect', np.double, ('Y', 'X',))
   elevation = ncfile.createVariable('elevation', np.double, ('Y', 'X',))
@@ -207,6 +212,11 @@ def create_template_drainage_file(fname, sizey=10, sizex=10):
 
   Y = ncfile.createDimension('Y', sizey)
   X = ncfile.createDimension('X', sizex)
+
+  # Spatial Ref. variables
+  lat = ncfile.createVariable('lat', np.float32, ('Y', 'X',))
+  lon = ncfile.createVariable('lon', np.float32, ('Y', 'X',))
+
   drainage_class = ncfile.createVariable('drainage_class', np.int, ('Y', 'X',))
 
   ncfile.source = source_attr_string()
@@ -326,6 +336,10 @@ def create_template_fri_fire_file(fname, sizey=10, sizex=10, rand=None):
 
   # Do we need time dimension??
 
+  # Spatial Ref. variables
+  lat = ncfile.createVariable('lat', np.float32, ('Y', 'X',))
+  lon = ncfile.createVariable('lon', np.float32, ('Y', 'X',))
+
   fri = ncfile.createVariable('fri', np.int32, ('Y','X',))
   sev = ncfile.createVariable('fri_severity', np.int32, ('Y','X'))
   dob = ncfile.createVariable('fri_jday_of_burn', np.int32, ('Y','X'))
@@ -347,6 +361,10 @@ def create_template_explicit_fire_file(fname, sizey=10, sizex=10, rand=None):
   Y = ncfile.createDimension('Y', sizey)
   X = ncfile.createDimension('X', sizex)
   time = ncfile.createDimension('time', None)
+
+  # Spatial Ref. variables
+  lat = ncfile.createVariable('lat', np.float32, ('Y', 'X',))
+  lon = ncfile.createVariable('lon', np.float32, ('Y', 'X',))
 
   exp_bm = ncfile.createVariable('exp_burn_mask', np.int32, ('time', 'Y', 'X',))
   exp_dob = ncfile.createVariable('exp_jday_of_burn', np.int32, ('time', 'Y', 'X',))
@@ -388,6 +406,11 @@ def create_template_soil_texture_nc_file(fname, sizey=10, sizex=10):
 
   Y = ncfile.createDimension('Y', sizey)
   X = ncfile.createDimension('X', sizex)
+
+  # Spatial Ref. variables
+  lat = ncfile.createVariable('lat', np.float32, ('Y', 'X',))
+  lon = ncfile.createVariable('lon', np.float32, ('Y', 'X',))
+
   pct_sand = ncfile.createVariable('pct_sand', np.float32, ('Y','X'))
   pct_silt = ncfile.createVariable('pct_silt', np.float32, ('Y','X'))
   pct_clay = ncfile.createVariable('pct_clay', np.float32, ('Y','X'))
@@ -464,6 +487,7 @@ def fill_topo_file(inSlope, inAspect, inElev, xo, yo, xs, ys, out_dir, of_name):
 
   for inFile, tmpFile in zip([inSlope, inAspect, inElev], [tmpSlope, tmpAspect, tmpElev]):
     subprocess.call(['gdal_translate', '-of', 'netcdf',
+                     '-co', 'WRITE_LONLAT=YES',
                       '-srcwin', str(xo), str(yo), str(xs), str(ys),
                       inFile, tmpFile])
 
@@ -473,6 +497,10 @@ def fill_topo_file(inSlope, inAspect, inElev, xo, yo, xs, ys, out_dir, of_name):
         V = new_topodataset.variables[ncvar]
         V[:] = TF.variables['Band1'][:]
 
+  with netCDF4.Dataset(of_name, mode='a') as new_topodataset:
+    with netCDF4.Dataset(tmpSlope, 'r') as TF:
+        new_topodataset.variables['lat'][:] = TF.variables['lat'][:]
+        new_topodataset.variables['lon'][:] = TF.variables['lon'][:]
 
 def fill_veg_file(if_name, xo, yo, xs, ys, out_dir, of_name):
   '''Read subset of data from .tif into netcdf file for dvmdostem. '''
@@ -654,18 +682,21 @@ def fill_soil_texture_file(if_sand_name, if_silt_name, if_clay_name, xo, yo, xs,
       print "Filling with real data..."
 
       print "Subsetting TIF to netCDF"
-      subprocess.check_call(['gdal_translate','-of','netCDF','-srcwin',
-                             str(xo), str(yo), str(xs), str(ys),
+      subprocess.check_call(['gdal_translate','-of','netCDF',
+                             '-co', 'WRITE_LONLAT=YES',
+                             '-srcwin', str(xo), str(yo), str(xs), str(ys),
                              if_sand_name,
                              '/tmp/create_region_input_script_sand_texture.nc'])
 
-      subprocess.check_call(['gdal_translate','-of','netCDF','-srcwin',
-                             str(xo), str(yo), str(xs), str(ys),
+      subprocess.check_call(['gdal_translate','-of','netCDF',
+                             '-co', 'WRITE_LONLAT=YES',
+                             '-srcwin', str(xo), str(yo), str(xs), str(ys),
                              if_silt_name,
                              '/tmp/create_region_input_script_silt_texture.nc'])
 
-      subprocess.check_call(['gdal_translate','-of','netCDF','-srcwin',
-                             str(xo), str(yo), str(xs), str(ys),
+      subprocess.check_call(['gdal_translate','-of','netCDF',
+                             '-co', 'WRITE_LONLAT=YES',
+                             '-srcwin', str(xo), str(yo), str(xs), str(ys),
                              if_clay_name,
                              '/tmp/create_region_input_script_clay_texture.nc'])
 
@@ -676,6 +707,14 @@ def fill_soil_texture_file(if_sand_name, if_silt_name, if_clay_name, xo, yo, xs,
         p_silt[:] = f.variables['Band1'][:]
       with netCDF4.Dataset('/tmp/create_region_input_script_clay_texture.nc', mode='r') as f:
         p_clay[:] = f.variables['Band1'][:]
+
+    # While we went to the trouble of writing lat/lon to all the temporary
+    # files, we are only going to use one of those files to get the 
+    # data into the final file...
+
+    with netCDF4.Dataset('/tmp/create_region_input_script_sand_texture.nc', mode='r') as f:
+      soil_tex.variables['lat'][:] = f.variables['lat'][:]
+      soil_tex.variables['lon'][:] = f.variables['lon'][:]
 
     soil_tex.source =  source_attr_string(xo=xo, yo=yo)
 
@@ -699,8 +738,9 @@ def fill_drainage_file(if_name, xo, yo, xs, ys, out_dir, of_name, rand=False):
       print "Filling with real data"
 
       print "Subsetting TIF to netCDF..."
-      check_call(['gdal_translate', '-of', 'netCDF', '-srcwin',
-                  str(xo), str(yo), str(xs), str(ys),
+      check_call(['gdal_translate', '-of', 'netCDF',
+                  '-co', 'WRITE_LONLAT=YES',
+                  '-srcwin', str(xo), str(yo), str(xs), str(ys),
                   if_name,
                   '/tmp/script-temp_drainage_subset.nc'])
 
@@ -714,6 +754,10 @@ def fill_drainage_file(if_name, xo, yo, xs, ys, out_dir, of_name, rand=False):
 
         print "Writing subset data to new file"
         drain[:] = data
+
+        print "Writing lat/lon data to new file..."
+        drainage_class.variables['lat'][:] = temp_drainage.variables['lat'][:]
+        drainage_class.variables['lon'][:] = temp_drainage.variables['lon'][:]
 
       drainage_class.source = source_attr_string(xo=xo, yo=yo)
 
@@ -746,6 +790,8 @@ def fill_fri_fire_file(if_name, xo, yo, xs, ys, out_dir, of_name):
     sev = np.array([cmt2fireprops[i]['sev'] for i in vd.flatten()]).reshape(vd.shape)
     jdob = np.array([cmt2fireprops[i]['jdob'] for i in vd.flatten()]).reshape(vd.shape)
     aob = np.array([cmt2fireprops[i]['aob'] for i in vd.flatten()]).reshape(vd.shape)
+    latv = vegFile.variables['lat'][:]
+    lonv = vegFile.variables['lon'][:]
 
   with netCDF4.Dataset(of_name, mode='a') as nfd:
     print "==> write data to new FRI based fire file..."
@@ -753,6 +799,10 @@ def fill_fri_fire_file(if_name, xo, yo, xs, ys, out_dir, of_name):
     nfd.variables['fri_severity'][:,:] = sev
     nfd.variables['fri_jday_of_burn'][:,:] = jdob
     nfd.variables['fri_area_of_burn'][:,:] = aob
+
+    print "Writing lat/lon from veg file..."
+    nfd.variables['lat'][:] = latv
+    nfd.variables['lon'][:] = lonv
 
     print "==> write global :source attribute to FRI fire file..."
     nfd.source = source_attr_string(xo=xo, yo=yo)
@@ -768,13 +818,18 @@ def fill_explicit_fire_file(if_name, yrs, xo, yo, xs, ys, out_dir, of_name):
   never_burn = ([9],[9])
   print "--> Never burn pixels: {}".format(zip(*never_burn))
 
-  # guess_vegfile = os.path.join(os.path.split(of_name)[0], 'vegetation.nc')
-  # print "--> NOTE: Attempting to read: {:}".format(guess_vegfile)
+  guess_vegfile = os.path.join(os.path.split(of_name)[0], 'vegetation.nc')
+  print "--> NOTE: Attempting to read: {:} for lat/lon info...".format(guess_vegfile)
   # print "    and set fire properties based on community type..."
   # with netCDF4.Dataset(guess_vegfile ,'r') as vegFile:
   #   vd = vegFile.variables['veg_class'][:]
 
   with netCDF4.Dataset(of_name, mode='a') as nfd:
+
+    print "Writing lat/lon from veg file..."
+    with netCDF4.Dataset(guess_vegfile ,'r') as vegFile:
+      nfd.variables['lat'][:] = vegFile.variables['lat'][:]
+      nfd.variables['lon'][:] = vegFile.variables['lon'][:]
 
     for yr in range(0, yrs):
 

--- a/scripts/create_region_input.py
+++ b/scripts/create_region_input.py
@@ -1005,8 +1005,9 @@ if __name__ == '__main__':
     print('Target lat, lon:', target['lat'], target['lon'])
     print('Delta with target lat, lon:', target['lat'] - latvar[iy,ix], target['lon'] - lonvar[iy,ix])
     print('lat, lon of closest match:', latvar[iy,ix], lonvar[iy,ix])
-    print('indices of closest match iy, ix (from LOWER left):', iy, ix)
-    print('indices of closest match iy, ix (from UPPER left):', len(ncfile.dimensions['y'])-iy, ix)
+    print('indices of closest match iy, ix (FROM LOWER left):', iy, ix)
+    print('indices of closest match iy, ix (FROM UPPER left):', len(ncfile.dimensions['y'])-iy, ix)
+    print('** NOTE: Use coords FROM UPPER LEFT to build/crop a new dataset with that pixel at the LOWER LEFT corner of the dataset!')
     ncfile.close()
     exit()
 

--- a/scripts/view_inputs.py
+++ b/scripts/view_inputs.py
@@ -1,0 +1,162 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+# T. Carman March 2017
+
+import sys
+import os
+import re
+import argparse
+import textwrap
+import numpy as np
+import matplotlib.pyplot as plt
+import netCDF4 as nc
+import matplotlib.ticker
+
+from mpl_toolkits.basemap import Basemap
+
+
+def dms2dd(degrees, minutes, seconds, direction):
+  dd = float(degrees) + float(minutes)/60 + float(seconds)/(60*60)
+  if direction == 'S' or direction == 'W':
+    dd *= -1.0
+  return dd
+
+def parse_dms(dms):
+  #parts = re.split('[°\'"]+', dms)
+  parts = dms.strip().split(' ')
+  print parts
+  return parts
+
+
+def discrete_cmap(N, base_cmap=None):
+    """Create an N-bin discrete colormap from the specified input map
+    From: Jake VanderPlas
+    License: BSD-style
+    https://gist.github.com/jakevdp/91077b0cae40f8f8244a
+    """
+
+    # Note that if base_cmap is a string or None, you can simply do
+    #    return plt.cm.get_cmap(base_cmap, N)
+    # The following works for string, None, or a colormap instance:
+
+    base = plt.cm.get_cmap(base_cmap)
+    color_list = base(np.linspace(0, 1, N))
+    cmap_name = base.name + str(N)
+    return base.from_list(cmap_name, color_list, N)
+
+
+if __name__ == '__main__':
+
+  parser = argparse.ArgumentParser(
+    formatter_class=argparse.RawDescriptionHelpFormatter,
+    description=textwrap.dedent('''
+      Script for viewing dvmdostem input files.
+    ''')
+  )
+  parser.add_argument('file', nargs='?', 
+      #type=argparse.FileType('r'),
+      metavar=('FILE'), 
+      help=textwrap.dedent('''The input file to display.'''))
+
+  parser.add_argument('--dms2dd', nargs=4, metavar=("DD", "MM", "SS", "D"),
+      # default=,
+      # const=,
+      help=textwrap.dedent('''Convert degrees minutes seconds to decimal degrees.'''))
+
+
+  args = parser.parse_args()
+  #print sys.argv
+  #print len(sys.argv)
+  #print args
+
+  if args.dms2dd:
+    coords = args.dms2dd
+    dd = dms2dd(coords[0],coords[1],coords[2],coords[3])
+    print (dd)
+    sys.exit(-1)
+
+  # if args.file == None:
+  #   print "ERROR: You must provide a file argument!"
+  #   sys.exit(-1)
+
+  d = nc.Dataset(args.file)
+
+  lats = d.variables['lat'][:]
+  lons = d.variables['lon'][:]
+  lons2 = 180+(180-(-1*lons))
+
+  fig, (ax0, ax1) = plt.subplots(ncols=2)
+
+  ax0.set_title("General Overview")
+  m = Basemap(lat_0=65, lon_0=-151, width=1600*1000, height=1400*1000, 
+              projection='aeqd', resolution=None, ax=ax0)
+  m.bluemarble()
+  x, y = m(lons2, lats)
+  points = m.scatter(x, y, marker='o', color='r')
+
+
+  if 'veg_class' in d.variables.keys():
+    CMTNAMES = [ 
+      "Bare Ground Rock Water",
+      "Black Spruce",
+      "White Spruce",
+      "Boreal Deciduous",
+      "Shrub Tundra",
+      "Tussock Tundra",
+      "Wet Sedge Tundra",
+      "Heath Tundra",
+      "Maritime Forest",
+    ]
+
+    N = len(CMTNAMES)
+
+    file_max = d.variables['veg_class'][:,:].max()
+    file_min = d.variables['veg_class'][:,:].min()
+    data2show = d.variables['veg_class']
+    color_map = discrete_cmap(N, 'Set1')
+
+  if 'tair' in d.variables.keys():
+    data2show = d.variables['tair'][0]
+    color_map = plt.cm.get_cmap('Reds')
+
+
+
+  ax1.set_title("Area of Interest")
+  print data2show.shape
+  img = ax1.imshow(data2show[:,:], 
+                   origin='lower', interpolation='none', 
+                   cmap=color_map)
+  img.set_clim(-0.5, N-0.5)
+
+  if 'veg_class' in d.variables.keys():
+    cbar = fig.colorbar(img, ax=ax1)
+    cbar.set_ticks(range(len(CMTNAMES)))
+    cbar.set_ticklabels(CMTNAMES)
+
+  if 'tair' in d.variables.keys():
+    pass
+
+
+  fig.suptitle('??')
+
+  fig.tight_layout()
+
+  plt.show(block=True)
+
+
+
+# Offset info
+# ===========
+
+# ncview - (0,0) is lower left
+# ----------------------------
+# i --> x --> lon
+# j --> y --> lat
+
+# matplotlib - (0,0) is upper left
+# --------------------------------
+# Even when using plt.imshow(.., origin-'lower', ...) it seems to take slices
+# from the upper left.
+
+


### PR DESCRIPTION
Modify create_region_input.py script to add spatial reference info to (almost) all input files.

Held off on actually updating all our sample input datasets, but re-generating the inputs in the future will result in  files with the spatial reference info, which will be handy for mapping and data provenance.