### PR TITLE
Feature general maintenance

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,12 @@
 DATA/*/output/*.nc
 input-staging-area/*
 
+parameters-*/
+
+some-dvmdostem-inputs/*
+auto-post-process/*
+junk/*
+
 calibration-plots/*
 
 # ingore the build directory and compiled binaries
@@ -36,3 +42,6 @@ Debug/*
 
 # Ignore hidden vagrant directory
 .vagrant/*
+
+# assorted temporary stuff
+bundle*

--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,6 @@ Debug/*
 # complied object files...
 *.o
 .sconsign.dblite
+
+# Ignore hidden vagrant directory
+.vagrant/*

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -17,7 +17,11 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     vb.customize ["modifyvm", :id, "--memory", mem, "--cpus", cores, "--ioapic", "on"]
   end
 
-
+  # Set this up for sftp access from notepad++ in Windows 10. Note that we also had to 
+  # find the guest virtualbox ip address (in ipconfig on host) and add it in the notepad++ 
+  # profile settings. (Needed NppFTP plugin for notepad++)
+  config.vm.network "forwarded_port", guest:22, host:2222
+  
   # Necessary for viewing interactive plots
   # (calibration mode, visualiation scripts, etc)
   # Note that on Windows host, the most reliable way we have found to get

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -5,41 +5,6 @@
 # made-to-order virtual machine. In our case, the machine we are ordering 
 # will be setup to run dvm-dos-tem.
 
-puts "Running with Vagrant v#{Vagrant::VERSION}"
-
-# Check to see if there's an SSH agent running with keys.
-puts "Checking if ssh-agent has identities..."
-`ssh-add -l`
-
-if not $?.success?
-  puts "Your SSH Agent does not currently contain any keys (or is stopped.) "\
-  "Please start the agent and add your GitHub SSH key to to the agent. "\
-  "Vagrant will setup you virtual machine so that the ssh keys on your "\
-  "host machine are forwarded for use within the virtual machine guest. "\
-  "This will allow you to seamlessly access private git repos from within "\
-  "the virtual machine guest. If you setup keys on your host with default "\
-  "settings you mabe be able to simply type: $ ssh-add ~/.ssh/id_rsa"
-  exit 1
-end
-
-puts "Checking that keys work for github..."
-puts `ssh -T git@github.com -o StrictHostKeyChecking=no`
-
-$add_github_to_known_hosts = <<SCRIPT
-
-if [[ ! -f ~/.ssh/known_hosts ]]; then
-  mkdir -p ~/.ssh
-  touch ~/.ssh/known_hosts
-fi
-
-echo "Appending github's key to ~/.ssh/known_hosts..."
-ssh-keyscan github.com >> ~/.ssh/known_hosts
-chmod 600 ~/.ssh/known_hosts
-
-SCRIPT
-
-
-
 VAGRANTFILE_API_VERSION = "2" # <--don't change unless you know what you're doing!
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
@@ -47,7 +12,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   
   mem = 756
   cores = 4
-  puts "Rolling your guest VM with #{cores} processors and #{mem}MB of RAM..."
+  puts "Building your guest VM with #{cores} processors and #{mem}MB of RAM..."
   config.vm.provider "virtualbox" do |vb|
     vb.customize ["modifyvm", :id, "--memory", mem, "--cpus", cores, "--ioapic", "on"]
   end
@@ -55,6 +20,8 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
   # Necessary for viewing interactive plots
   # (calibration mode, visualiation scripts, etc)
+  # Note that on Windows host, the most reliable way we have found to get
+  # X11 forwarding is by using MobaXTerm.
   config.ssh.forward_x11 = true  
 
   # For authenticating when cloning private repos, host must have ssh keys for 

--- a/bootstrap-sel-custom.sh
+++ b/bootstrap-sel-custom.sh
@@ -35,16 +35,6 @@ then
 fi
 cd dvm-dos-tem
 git remote rename origin upstream
-git checkout devel
-git pull --ff-only upstream devel:devel
-cd ..
-
-if [ ! -d "$HOME"/ddtv ]
-then
-  git clone git@github.com:tobeycarman/ddtv.git "$HOME"/ddtv
-fi
-cd ddtv
-git remote rename origin upstream
 git checkout master
 git pull --ff-only upstream master:master
 cd ..

--- a/bootstrap-system.sh
+++ b/bootstrap-system.sh
@@ -32,7 +32,9 @@ yum install -y python-matplotlib python-matplotlib-wx netcdf4-python python-ipyt
 # useful for our pre and post processing scripts.
 yum install python-basemap-data python-basemap-data-hires python-basemap
 
+
 # For processing/preparing the "new style" inputs
+yum install -y gdal-python
 yum install -y gdal gdal-devel
 
 # For compiling with Scons

--- a/bootstrap-system.sh
+++ b/bootstrap-system.sh
@@ -28,6 +28,10 @@ yum install -y xauth
 # packages used for plotting
 yum install -y python-matplotlib python-matplotlib-wx netcdf4-python python-ipython python-jinja2
 
+# Stuff for plotting on a basemap with python 
+# useful for our pre and post processing scripts.
+yum install python-basemap-data python-basemap-data-hires python-basemap
+
 # For processing/preparing the "new style" inputs
 yum install -y gdal gdal-devel
 

--- a/include/Climate.h
+++ b/include/Climate.h
@@ -67,7 +67,7 @@ public:
   void monthlycontainers2log();
   void dailycontainers2log();
 
-  void load_proj_climate(std::string&, int, int);
+  void load_proj_climate(const std::string&, int, int);
 
 private:
 

--- a/scripts/gapfill.py
+++ b/scripts/gapfill.py
@@ -165,7 +165,7 @@ for climate_file in CLIMATE_FILES:
       for v in VARS:
 
         print "Generating fill data"
-        filled = gapfill_along_timeseries(myFile[v][:])
+        filled = gapfill_along_timeseries(myFile.variables[v][:])
 
         print myFile.source
         print myFile.ncattrs()

--- a/scripts/runmask-util.py
+++ b/scripts/runmask-util.py
@@ -246,8 +246,8 @@ if __name__ == '__main__':
   parser.add_argument('--all-on', action='store_true', 
       help=textwrap.dedent('''Set all pixels to 1 (run). Inverse of --reset.'''))
 
-  parser.add_argument("--xy", nargs=2, type=int, metavar=('X','Y'),
-      help=textwrap.dedent('''The x, y position of the pixel to turn on.'''))
+  parser.add_argument("--yx", nargs=2, type=int, metavar=('Y','X'),
+      help=textwrap.dedent('''The y, x  (row, col) position of the pixel to turn on.'''))
 
   parser.add_argument("--show", action='store_true',
       help=textwrap.dedent('''Print the mask after modification.'''))
@@ -319,10 +319,10 @@ if __name__ == '__main__':
       print "Setting all pixels in runmask to '0' (OFF)."
       mask.variables['run'][:] = 0
 
-    if args.xy:
-      X,Y = args.xy
-      print "Turning pixel(x,y) to '1', (ON)."
-      mask.variables['run'][X,Y] = 1
+    if args.yx:
+      Y,X = args.yx
+      print "Turning pixel(y,x) ({},{}) to '1', (ON).".format(Y,X)
+      mask.variables['run'][Y,X] = 1
 
     if args.all_on:
       print "Setting all pixels in runmask to '1' (ON)."

--- a/scripts/runmask-util.py
+++ b/scripts/runmask-util.py
@@ -243,6 +243,9 @@ if __name__ == '__main__':
   parser.add_argument('--reset', action='store_true', 
       help=textwrap.dedent('''Set all pixels to zero (don't run).'''))
 
+  parser.add_argument('--all-on', action='store_true', 
+      help=textwrap.dedent('''Set all pixels to 1 (run). Inverse of --reset.'''))
+
   parser.add_argument("--xy", nargs=2, type=int, metavar=('X','Y'),
       help=textwrap.dedent('''The x, y position of the pixel to turn on.'''))
 
@@ -320,6 +323,10 @@ if __name__ == '__main__':
       X,Y = args.xy
       print "Turning pixel(x,y) to '1', (ON)."
       mask.variables['run'][X,Y] = 1
+
+    if args.all_on:
+      print "Setting all pixels in runmask to '1' (ON)."
+      mask.variables['run'][:] = 1
 
   # Show the after state
   if args.show:

--- a/scripts/runmask-util.py
+++ b/scripts/runmask-util.py
@@ -249,6 +249,9 @@ if __name__ == '__main__':
   parser.add_argument("--yx", nargs=2, type=int, metavar=('Y','X'),
       help=textwrap.dedent('''The y, x  (row, col) position of the pixel to turn on.'''))
 
+  parser.add_argument("--yx-off", nargs=2, type=int, metavar=('Y','X'),
+      help=textwrap.dedent('''The y, x  (row, col) position of the pixel to turn OFF.'''))
+
   parser.add_argument("--show", action='store_true',
       help=textwrap.dedent('''Print the mask after modification.'''))
 
@@ -327,6 +330,11 @@ if __name__ == '__main__':
     if args.all_on:
       print "Setting all pixels in runmask to '1' (ON)."
       mask.variables['run'][:] = 1
+
+    if args.yx_off:
+      Y, X = args.yx_off
+      print "Setting pixel (y, x) ({},{}) to '0', (OFF).".format(Y,X)
+      mask.variables['run'][Y,X] = 0
 
   # Show the after state
   if args.show:

--- a/src/Climate.cpp
+++ b/src/Climate.cpp
@@ -468,7 +468,7 @@ void Climate::load_from_file(const std::string& fname, int y, int x) {
 }
 
 /** This loads data from a projected climate data file, overwriting any old climate data*/
-void Climate::load_proj_climate(std::string& fname, int y, int x){
+void Climate::load_proj_climate(const std::string& fname, int y, int x){
   BOOST_LOG_SEV(glg, note) << "Climate, loading projected data";
 
   this->load_from_file(fname, y, x);

--- a/src/ModelData.cpp
+++ b/src/ModelData.cpp
@@ -330,25 +330,25 @@ void ModelData::create_netCDF_output_files(int ysize, int xsize, const std::stri
     } // end looping over tokens (aka columns) in a line
 
     // Only create a file if a timestep is specified for the variable.
-    //  Otherwise, assume the user does not want that variable output.
+    // Otherwise, assume the user does not want that variable output.
     if(new_spec.yearly || new_spec.monthly || new_spec.daily){
 
       // File location information for reconstructing a complete path
-      //  and filename during output.
+      // and filename during output.
       new_spec.file_path = output_base.string();
       new_spec.filename_prefix = name + "_" + timestep;
 
-      //Temporary name for file creation.
+      // Temporary name for file creation.
       std::string creation_filename = name + "_" + timestep + "_" + stage + ".nc";
 
       BOOST_LOG_SEV(glg, debug)<<"Variable: "<<name<<". Timestep: "<<timestep;
 
-      //filename with local path
+      // filename with local path
       boost::filesystem::path output_filepath = output_base / creation_filename;
-      //convert path to string for simplicity in the following function calls
+      // convert path to string for simplicity in the following function calls
       std::string creation_filestr = output_filepath.string();
 
-      //Creating NetCDF file
+      // Creating NetCDF file
       BOOST_LOG_SEV(glg, debug)<<"Creating output NetCDF file "<<creation_filestr;
       temutil::nc( nc_create(creation_filestr.c_str(), NC_CLOBBER, &ncid) );
 
@@ -357,12 +357,12 @@ void ModelData::create_netCDF_output_files(int ysize, int xsize, const std::stri
 
       BOOST_LOG_SEV(glg, debug) << "Adding dimensions...";
 
-      //All variables will have time, y, x 
+      // All variables will have time, y, x
       temutil::nc( nc_def_dim(ncid, "time", NC_UNLIMITED, &timeD) );
       temutil::nc( nc_def_dim(ncid, "y", ysize, &yD) );
       temutil::nc( nc_def_dim(ncid, "x", xsize, &xD) );
 
-      //System-wide variables
+      // System-wide variables
       if(new_spec.dim_count==3){
         vartype3D_dimids[0] = timeD;
         vartype3D_dimids[1] = yD;
@@ -371,7 +371,7 @@ void ModelData::create_netCDF_output_files(int ysize, int xsize, const std::stri
         temutil::nc( nc_def_var(ncid, name.c_str(), NC_DOUBLE, 3, vartype3D_dimids, &Var) );
       }
 
-      //PFT specific dimensions
+      // PFT specific dimensions
       else if(new_spec.pft && !new_spec.compartment){
         temutil::nc( nc_def_dim(ncid, "pft", NUM_PFT, &pftD) );
 
@@ -383,7 +383,7 @@ void ModelData::create_netCDF_output_files(int ysize, int xsize, const std::stri
         temutil::nc( nc_def_var(ncid, name.c_str(), NC_DOUBLE, 4, vartypeVeg4D_dimids, &Var) );
       }
 
-      //PFT compartment only
+      // PFT compartment only
       else if(!new_spec.pft && new_spec.compartment){
         temutil::nc( nc_def_dim(ncid, "pftpart", NUM_PFT_PART, &pftpartD) );
 
@@ -395,7 +395,7 @@ void ModelData::create_netCDF_output_files(int ysize, int xsize, const std::stri
         temutil::nc( nc_def_var(ncid, name.c_str(), NC_DOUBLE, 4, vartypeVeg4D_dimids, &Var) );
       }
 
-      //PFT and PFT compartments
+      // PFT and PFT compartments
       else if(new_spec.pft && new_spec.compartment){ 
         temutil::nc( nc_def_dim(ncid, "pft", NUM_PFT, &pftD) );
         temutil::nc( nc_def_dim(ncid, "pftpart", NUM_PFT_PART, &pftpartD) );
@@ -409,7 +409,7 @@ void ModelData::create_netCDF_output_files(int ysize, int xsize, const std::stri
         temutil::nc( nc_def_var(ncid, name.c_str(), NC_DOUBLE, 5, vartypeVeg5D_dimids, &Var) );
       }
 
-      //Soil specific dimensions
+      // Soil specific dimensions
       else if(new_spec.layer){
         temutil::nc( nc_def_dim(ncid, "layer", MAX_SOI_LAY, &layerD) );
 

--- a/src/Runner.cpp
+++ b/src/Runner.cpp
@@ -53,7 +53,7 @@ void Runner::run_years(int start_year, int end_year, const std::string& stage) {
   BOOST_LOG_NAMED_SCOPE("Y") {
   for (int iy = start_year; iy < end_year; ++iy) {
     BOOST_LOG_SEV(glg, debug) << "(Beginning of year loop) " << cohort.ground.layer_report_string("depth thermal CN");
-    BOOST_LOG_SEV(glg, err) << "Year loop, year: "<<iy;
+    BOOST_LOG_SEV(glg, err) << "y: "<<this->y<<" x: "<<this->x<<" Year: "<<iy;
 
     /* Interpolate all the monthly values...? */
     if( (stage.find("eq") != std::string::npos

--- a/src/TEM.cpp
+++ b/src/TEM.cpp
@@ -88,33 +88,16 @@ void ppv(const std::vector<TYPE> &v){
   std::cout << "\n";
 }
 
-void write_status(const std::string fname, int row, int col, int statusCode) {
+/** Write out a status code to a particular pixel in the run status file.
+*/
+void write_status(const std::string fname, int row, int col, int statusCode);
 
-  int ncid;
-  int statusV;
-
-  temutil::nc( nc_open(fname.c_str(),  NC_WRITE, &ncid) );
-  temutil::nc( nc_inq_varid(ncid, "run_status", &statusV) );
-
-
-  int NDIMS = 2;
-
-  size_t start[NDIMS], count[NDIMS];
-  // Set point to write
-  start[0] = row;
-  start[1] = col;
-  count[0] = 1;
-  count[1] = 1;
-
-  std::cout << "WRITING FOR (row, col): " << row << ", " << col << "\n";
-
-  // Write data
-  temutil::nc( nc_put_vara(ncid, statusV, start, count,  &statusCode) );
-
-  /* Close the netcdf file. */
-  temutil::nc( nc_close(ncid) );
-}
-
+/** Builds an empty netcdf file for recording the run status. 
+ * Ultimately we might want to spit the run status out in a more easily 
+ * consumable way like txt to stdout or json, but for now we can use netcdf. 
+ * Also it makes for a simple netcdf file to experiment with for MPI, 
+ * parallel output
+ */
 void create_empty_run_status_file(const std::string& fname,
     const int ysize, const int xsize);
 
@@ -808,3 +791,28 @@ void create_empty_run_status_file(const std::string& fname,
 
 }
 
+void write_status(const std::string fname, int row, int col, int statusCode) {
+
+  int ncid;
+  int statusV;
+
+  temutil::nc( nc_open(fname.c_str(),  NC_WRITE, &ncid) );
+  temutil::nc( nc_inq_varid(ncid, "run_status", &statusV) );
+
+
+  int NDIMS = 2;
+
+  size_t start[NDIMS], count[NDIMS];
+  // Set point to write
+  start[0] = row;
+  start[1] = col;
+  count[0] = 1;
+  count[1] = 1;
+
+  // Write data
+  BOOST_LOG_SEV(glg, note) << "WRITING FOR OUTPUT STATUS FOR (row, col): " << row << ", " << col << "\n";
+  temutil::nc( nc_put_vara(ncid, statusV, start, count,  &statusCode) );
+
+  /* Close the netcdf file. */
+  temutil::nc( nc_close(ncid) );
+}

--- a/src/TEM.cpp
+++ b/src/TEM.cpp
@@ -310,9 +310,6 @@ int main(int argc, char* argv[]){
 
             BOOST_LOG_SEV(glg, err) << "EXCEPTION!! (row, col): (" << rowidx << ", " << colidx << "): " << e.what();
 
-            // std::string fail_file_name = "fail_log.txt";
-            // boost::filesystem::path fail_log_path = modeldata.output_dir / fail_file_name;
-
             std::ofstream outfile;
             outfile.open((modeldata.output_dir + "fail_log.txt").c_str(), std::ios_base::app); // Append mode
             outfile << "EXCEPTION!! At pixel at (row, col): ("<<rowidx <<", "<<colidx<<") "<< e.what() <<"\n";

--- a/src/TEM.cpp
+++ b/src/TEM.cpp
@@ -167,7 +167,40 @@ int main(int argc, char* argv[]){
       boots::program_options here to manage the arguments from config file
       and the command line.
   */
-  
+
+#ifdef WITHMPI
+    BOOST_LOG_SEV(glg, fatal) << "Built and running with MPI";
+
+    // Intended for passing argc and argv, the arguments to MPI_Init
+    // are currently unnecessary.
+    MPI_Init(NULL, NULL);
+
+    int id = MPI::COMM_WORLD.Get_rank();     // Change this to C interface?? MPI_Comm_World?
+    int ntasks = MPI::COMM_WORLD.Get_size();
+    if (id == 0) {
+
+      BOOST_LOG_SEV(glg, note) << "Clearing output directory...";
+      const boost::filesystem::path out_dir_path(modeldata.output_dir);
+      if (boost::filesystem::exists( out_dir_path )) {
+        boost::filesystem::remove_all( out_dir_path );
+      }
+      boost::filesystem::create_directories(out_dir_path);
+      BOOST_LOG_SEV(glg, debug) << "rank: "<<id<<" Hit MPI_Barrier.";
+      MPI_Barrier(MPI::COMM_WORLD);
+    } else {
+      BOOST_LOG_SEV(glg, debug) << "rank: "<<id<<" Hit MPI_Barrier.";
+      MPI_Barrier(MPI::COMM_WORLD);
+    }
+
+#else
+    BOOST_LOG_SEV(glg, note) << "Clearing output directory...";
+    const boost::filesystem::path out_dir_path(modeldata.output_dir);
+    if (boost::filesystem::exists( out_dir_path )) {
+      boost::filesystem::remove_all( out_dir_path );
+    }
+    boost::filesystem::create_directories(out_dir_path);
+#endif
+
   BOOST_LOG_SEV(glg, note) << "Running PR stage: " << modeldata.pr_yrs << "yrs";
   BOOST_LOG_SEV(glg, note) << "Running EQ stage: " << modeldata.eq_yrs << "yrs";
   BOOST_LOG_SEV(glg, note) << "Running SP stage: " << modeldata.sp_yrs << "yrs";
@@ -310,6 +343,9 @@ int main(int argc, char* argv[]){
 
             BOOST_LOG_SEV(glg, err) << "EXCEPTION!! (row, col): (" << rowidx << ", " << colidx << "): " << e.what();
 
+
+            // IS THIS THREAD SAFE??
+            // IS IT SAFE WITH MPI??
             std::ofstream outfile;
             outfile.open((modeldata.output_dir + "fail_log.txt").c_str(), std::ios_base::app); // Append mode
             outfile << "EXCEPTION!! At pixel at (row, col): ("<<rowidx <<", "<<colidx<<") "<< e.what() <<"\n";

--- a/src/TEM.cpp
+++ b/src/TEM.cpp
@@ -288,6 +288,12 @@ int main(int argc, char* argv[]){
 
         if (true == mask_value) {
 
+          // I think this is safe w/in our OpenMP block because I am
+          // handling the exception here...
+          // Not sure about other OpenMP pragama blocks w/in this one? Any
+          // Exceptions would leak out of the inner pragma and be handled
+          // by this try/catch??
+          try {
           BOOST_LOG_SEV(glg, note) << "Running cell (" << rowidx << ", " << colidx << ")";
 
           //modeldata.initmode = 1; // OBSOLETE?
@@ -572,14 +578,27 @@ int main(int argc, char* argv[]){
               - run_years( TR_BEG <= iy <= TR_END )
               
           */
+        } catch (std::exception& e) {
 
+          BOOST_LOG_SEV(glg, err) << "EXCEPTION!! (row, col): (" << rowidx << ", " << colidx << "): " << e.what();
+
+          // std::string fail_file_name = "fail_log.txt";
+          // boost::filesystem::path fail_log_path = modeldata.output_dir / fail_file_name;
+
+          std::ofstream outfile;
+          outfile.open((modeldata.output_dir + "fail_log.txt").c_str(), std::ios_base::app); // Append mode
+          outfile << "EXCEPTION!! At pixel at (row, col): ("<<rowidx <<", "<<colidx<<") "<< e.what() <<"\n";
+          outfile.close();
+
+          // Write to fail_mask.nc file?? or json? might be good for visualization
+
+        }
         } else {
           BOOST_LOG_SEV(glg, debug) << "Skipping cell (" << rowidx << ", " << colidx << ")";
         }
       }//end col loop
     }//end row loop
   
-    
   } else if (args->get_loop_order() == "time-major") {
     BOOST_LOG_SEV(glg, warn) << "DO NOTHING. NOT IMPLEMENTED YET.";
     // for each year

--- a/src/TEM.cpp
+++ b/src/TEM.cpp
@@ -88,6 +88,33 @@ void ppv(const std::vector<TYPE> &v){
   std::cout << "\n";
 }
 
+void write_status(const std::string fname, int row, int col, int statusCode) {
+
+  int ncid;
+  int statusV;
+
+  temutil::nc( nc_open(fname.c_str(),  NC_WRITE, &ncid) );
+  temutil::nc( nc_inq_varid(ncid, "run_status", &statusV) );
+
+
+  int NDIMS = 2;
+
+  size_t start[NDIMS], count[NDIMS];
+  // Set point to write
+  start[0] = row;
+  start[1] = col;
+  count[0] = 1;
+  count[1] = 1;
+
+  std::cout << "WRITING FOR (row, col): " << row << ", " << col << "\n";
+
+  // Write data
+  temutil::nc( nc_put_vara(ncid, statusV, start, count,  &statusCode) );
+
+  /* Close the netcdf file. */
+  temutil::nc( nc_close(ncid) );
+}
+
 void create_empty_run_status_file(const std::string& fname,
     const int ysize, const int xsize);
 
@@ -250,6 +277,7 @@ int main(int argc, char* argv[]){
   RestartData::create_empty_file(tr_restart_fname, num_rows, num_cols);
   RestartData::create_empty_file(sc_restart_fname, num_rows, num_cols);
 
+
   // Create empty output files now so that later, as the program
   // proceeds, there is somewhere to append output data...
   BOOST_LOG_SEV(glg, info) << "Creating a set of empty NetCDF output files";
@@ -345,11 +373,12 @@ int main(int argc, char* argv[]){
           try {
 
             advance_model(rowidx, colidx, modeldata, args->get_cal_mode(), eq_restart_fname, sp_restart_fname, tr_restart_fname, sc_restart_fname);
-
+            std::cout << "The good write - finished cell!\n";
+            write_status(run_status_fname, rowidx, colidx, 100);            
+            
           } catch (std::exception& e) {
 
             BOOST_LOG_SEV(glg, err) << "EXCEPTION!! (row, col): (" << rowidx << ", " << colidx << "): " << e.what();
-
 
             // IS THIS THREAD SAFE??
             // IS IT SAFE WITH MPI??
@@ -359,6 +388,8 @@ int main(int argc, char* argv[]){
             outfile.close();
 
             // Write to fail_mask.nc file?? or json? might be good for visualization
+            write_status(run_status_fname, rowidx, colidx, -200); // <- what if this throws??
+            BOOST_LOG_SEV(glg, err) << "End of exception handler.";
 
           }
         } else {

--- a/src/TEM.cpp
+++ b/src/TEM.cpp
@@ -256,7 +256,6 @@ int main(int argc, char* argv[]){
   int num_rows = run_mask.size();
   int num_cols = run_mask[0].size();
 
-
   // Make some convenient handles for later...
   std::string run_status_fname = modeldata.output_dir + "run_status.nc";
   std::string eq_restart_fname = modeldata.output_dir + "restart-eq.nc";
@@ -264,19 +263,21 @@ int main(int argc, char* argv[]){
   std::string tr_restart_fname = modeldata.output_dir + "restart-tr.nc";
   std::string sc_restart_fname = modeldata.output_dir + "restart-sc.nc";
 
-  // Create empty restart files for all stages based on size of run mask
+  // Make sure the output directory exists!!
   if (!boost::filesystem::exists(modeldata.output_dir)) {
     BOOST_LOG_SEV(glg, info) << "Creating output directory as specified in "
                              << "config file: ", modeldata.output_dir;
     boost::filesystem::create_directory(modeldata.output_dir);
   }
 
-  create_empty_run_status_file(run_status_fname, num_rows, num_cols);
+  // Create empty restart files for all stages based on size of run mask
   RestartData::create_empty_file(eq_restart_fname, num_rows, num_cols);
   RestartData::create_empty_file(sp_restart_fname, num_rows, num_cols);
   RestartData::create_empty_file(tr_restart_fname, num_rows, num_cols);
   RestartData::create_empty_file(sc_restart_fname, num_rows, num_cols);
 
+  // Create empty run status file
+  create_empty_run_status_file(run_status_fname, num_rows, num_cols);
 
   // Create empty output files now so that later, as the program
   // proceeds, there is somewhere to append output data...

--- a/src/TEM.cpp
+++ b/src/TEM.cpp
@@ -375,7 +375,7 @@ int main(int argc, char* argv[]){
 
             advance_model(rowidx, colidx, modeldata, args->get_cal_mode(), eq_restart_fname, sp_restart_fname, tr_restart_fname, sc_restart_fname);
             std::cout << "The good write - finished cell!\n";
-            write_status(run_status_fname, rowidx, colidx, 100);            
+            write_status(run_status_fname, rowidx, colidx, 100);
             
           } catch (std::exception& e) {
 
@@ -389,12 +389,13 @@ int main(int argc, char* argv[]){
             outfile.close();
 
             // Write to fail_mask.nc file?? or json? might be good for visualization
-            write_status(run_status_fname, rowidx, colidx, -200); // <- what if this throws??
+            write_status(run_status_fname, rowidx, colidx, -100); // <- what if this throws??
             BOOST_LOG_SEV(glg, err) << "End of exception handler.";
 
           }
         } else {
           BOOST_LOG_SEV(glg, debug) << "Skipping cell (" << rowidx << ", " << colidx << ")";
+          write_status(run_status_fname, rowidx, colidx, 0);
         }
       }//end col loop
     }//end row loop

--- a/src/TEM.cpp
+++ b/src/TEM.cpp
@@ -88,6 +88,9 @@ void ppv(const std::vector<TYPE> &v){
   std::cout << "\n";
 }
 
+void create_empty_run_status_file(const std::string& fname,
+    const int ysize, const int xsize);
+
 // The main driving function
 void advance_model(const int rowidx, const int colidx,
                    const ModelData&, const bool calmode,
@@ -222,15 +225,17 @@ int main(int argc, char* argv[]){
   // Open the run mask (spatial mask)
   std::vector< std::vector<int> > run_mask = temutil::read_run_mask(modeldata.runmask_file);
 
+  // Figure out how big the run_mask is
+  int num_rows = run_mask.size();
+  int num_cols = run_mask[0].size();
+
+
   // Make some convenient handles for later...
+  std::string run_status_fname = modeldata.output_dir + "run_status.nc";
   std::string eq_restart_fname = modeldata.output_dir + "restart-eq.nc";
   std::string sp_restart_fname = modeldata.output_dir + "restart-sp.nc";
   std::string tr_restart_fname = modeldata.output_dir + "restart-tr.nc";
   std::string sc_restart_fname = modeldata.output_dir + "restart-sc.nc";
-
-  // Figure out how big the run_mask is
-  int num_rows = run_mask.size();
-  int num_cols = run_mask[0].size();
 
   // Create empty restart files for all stages based on size of run mask
   if (!boost::filesystem::exists(modeldata.output_dir)) {
@@ -238,6 +243,8 @@ int main(int argc, char* argv[]){
                              << "config file: ", modeldata.output_dir;
     boost::filesystem::create_directory(modeldata.output_dir);
   }
+
+  create_empty_run_status_file(run_status_fname, num_rows, num_cols);
   RestartData::create_empty_file(eq_restart_fname, num_rows, num_cols);
   RestartData::create_empty_file(sp_restart_fname, num_rows, num_cols);
   RestartData::create_empty_file(tr_restart_fname, num_rows, num_cols);
@@ -724,4 +731,47 @@ void advance_model(const int rowidx, const int colidx,
 
 
 } // end advance_model
+
+/** Creates (overwrites) an empty run_status file. */
+void create_empty_run_status_file(const std::string& fname,
+    const int ysize, const int xsize) {
+
+  BOOST_LOG_SEV(glg, debug) << "Opening new file with 'NC_CLOBBER'";
+  int ncid;
+  temutil::nc( nc_create(fname.c_str(), NC_CLOBBER, &ncid) );
+
+  // Define handles for dimensions
+  int yD;
+  int xD;
+
+  BOOST_LOG_SEV(glg, debug) << "Creating dimensions...";
+  temutil::nc( nc_def_dim(ncid, "Y", ysize, &yD) );
+  temutil::nc( nc_def_dim(ncid, "X", xsize, &xD) );
+
+  // Setup arrays holding dimids for different "types" of variables
+  // --> will re-arrange these later to define variables with different dims
+  int vartype2D_dimids[2];
+  vartype2D_dimids[0] = yD;
+  vartype2D_dimids[1] = xD;
+
+  // Setup 2D vars, integer
+  // Define handle for variable(s)
+  int run_statusV;
+  
+  // Create variable(s) in nc file
+  temutil::nc( nc_def_var(ncid, "run_status", NC_INT, 2, vartype2D_dimids, &run_statusV) );
+
+  // SET FILL VALUE?
+
+  /* Create Attributes?? */
+
+  /* End Define Mode (not scrictly necessary for netcdf 4) */
+  BOOST_LOG_SEV(glg, debug) << "Leaving 'define mode'...";
+  temutil::nc( nc_enddef(ncid) );
+
+  /* Close file. */
+  BOOST_LOG_SEV(glg, debug) << "Closing new file...";
+  temutil::nc( nc_close(ncid) );
+
+}
 

--- a/src/TEMUtilityFunctions.cpp
+++ b/src/TEMUtilityFunctions.cpp
@@ -369,8 +369,14 @@ namespace temutil {
   void handle_error(int status) {
     if (status != NC_NOERR) {
       fprintf(stderr, "%s\n", nc_strerror(status));
-      BOOST_LOG_SEV(glg, fatal) << nc_strerror(status);
-      exit(-1);
+      BOOST_LOG_SEV(glg, err) << nc_strerror(status);
+
+      std::string msg = "Exception from netcdf: ";
+      msg = msg + nc_strerror(status);
+
+      throw std::runtime_error(msg);
+
+      //exit(-1);
     }
   }
   

--- a/src/data/RestartData.cpp
+++ b/src/data/RestartData.cpp
@@ -440,10 +440,12 @@ void RestartData::write_pixel_to_ncfile(const std::string& fname, const int rowi
 
 }
 
-/** Checks a given variable against an extreme negative value. FIX: should be more flexible*/
+/** Checks a given variable against an extreme negative value. 
+ *  FIX: should be more flexible
+ */
 template<typename T> void check_bounds(std::string var_name, T value){
   if(value<-4000){
-    BOOST_LOG_SEV(glg, err) << var_name << " is out of bounds: " << value;
+    BOOST_LOG_SEV(glg, warn) << var_name << " is out of bounds: " << value;
   }
 }
 

--- a/src/ecodomain/Ground.cpp
+++ b/src/ecodomain/Ground.cpp
@@ -2041,7 +2041,10 @@ void Ground::updateOslThickness5Carbon(Layer* fstsoil) {
 }
 
 
-/** Convert from gC/m^2 to layer thickness (meters) based on Yi et al, 2009. */
+/** Convert from gC/m^2 to layer thickness (meters) based on Yi et al, 2009. 
+ *
+ * Throws std::runtime_error if thickness goes negative.
+*/
 double Ground::thicknessFromCarbon(const double carbon, const double coefA, const double coefB) {
   //assert ((coefB >= 1) && "Yi et al. 2009 says the b coefficient should be a fitted parameter constrained to >= 1!");
   if (!(coefB >= 1)) BOOST_LOG_SEV(glg, err) << "Yi et al. 2009 says the b coefficient should be a fitted parameter constrained to >= 1!";
@@ -2051,11 +2054,17 @@ double Ground::thicknessFromCarbon(const double carbon, const double coefA, cons
   T = pow( carbon/10000.0/coefA, 1/coefB); // convert gC/m^2 to gC/cm^2
   T = T / 100.0;                           // convert thickness from cm to m
 
-  assert ((T >= 0) && "It doesn't make sense to have a negative thickness!");
+  if( !(T >= 0) ) {
+    throw std::runtime_error("It doesn't make sense to have a negative thickness!");
+  }
+
   return T;
 }
 
-/** Convert from layer thickness (meters) to gC/m^2 based on Yi et al, 2009. */
+/** Convert from layer thickness (meters) to gC/m^2 based on Yi et al, 2009. 
+ * 
+ * Throws std::runtime_error if C goes negative
+*/
 double Ground::carbonFromThickness(const double thickness, const double coefA, const double coefB) {
   //assert ((coefB >= 1) && "Yi et al. 2009 says the b coefficient should be a fitted parameter constrained to >= 1!");
   if (!(coefB >= 1)) BOOST_LOG_SEV(glg, err) << "Yi et al. 2009 says the b coefficient should be a fitted parameter constrained to >= 1!";
@@ -2065,7 +2074,10 @@ double Ground::carbonFromThickness(const double thickness, const double coefA, c
   C = coefA * pow(thickness*100.0, coefB); // convert from m to cm
   C = C * 10000.0;                         // convert from gC/cm^2 to gC/m^2
 
-  assert ((C >= 0) && "It doesn't make sense to have a negative amount of Carbon!");
+  if( !(C >= 0) ) {
+    throw std::runtime_error("It doesn't make sense to have a negative amount of Carbon!");
+  }
+
   return C;
 }
 

--- a/src/ecodomain/Ground.cpp
+++ b/src/ecodomain/Ground.cpp
@@ -2047,7 +2047,7 @@ void Ground::updateOslThickness5Carbon(Layer* fstsoil) {
 */
 double Ground::thicknessFromCarbon(const double carbon, const double coefA, const double coefB) {
   //assert ((coefB >= 1) && "Yi et al. 2009 says the b coefficient should be a fitted parameter constrained to >= 1!");
-  if (!(coefB >= 1)) BOOST_LOG_SEV(glg, err) << "Yi et al. 2009 says the b coefficient should be a fitted parameter constrained to >= 1!";
+  if (!(coefB >= 1)) BOOST_LOG_SEV(glg, warn) << "Yi et al. 2009 says the b coefficient should be a fitted parameter constrained to >= 1!";
 
   // T = (C/a)^(1/b)
   double T;
@@ -2067,7 +2067,7 @@ double Ground::thicknessFromCarbon(const double carbon, const double coefA, cons
 */
 double Ground::carbonFromThickness(const double thickness, const double coefA, const double coefB) {
   //assert ((coefB >= 1) && "Yi et al. 2009 says the b coefficient should be a fitted parameter constrained to >= 1!");
-  if (!(coefB >= 1)) BOOST_LOG_SEV(glg, err) << "Yi et al. 2009 says the b coefficient should be a fitted parameter constrained to >= 1!";
+  if (!(coefB >= 1)) BOOST_LOG_SEV(glg, warn) << "Yi et al. 2009 says the b coefficient should be a fitted parameter constrained to >= 1!";
 
   // C = aT^b
   double C;

--- a/src/ecodomain/Ground.cpp
+++ b/src/ecodomain/Ground.cpp
@@ -1361,17 +1361,19 @@ COMBINEBEGIN:
 
 void Ground::redivideDeepLayers() {
   ////////// IF there exists 'deep' layer(s) ////////////////
-  if(fstdeepl!=NULL) {
-    Layer * currl =fstdeepl;
+  if(fstdeepl != NULL) {
+    Layer * currl = fstdeepl;
     // Adjusting the OS horion's layer division/combination
     SoilLayer* upsl ;
     SoilLayer* lwsl;
-    //combine all deep layers into ONE for re-structuring
-COMBINEBEGIN:
-    currl =fstdeepl;
+
+    // combine all deep layers into ONE for re-structuring
+
+    COMBINEBEGIN:
+    currl = fstdeepl;
 
     while(currl!=NULL) {
-      if(currl->indl<lstdeepl->indl) {
+      if(currl->indl < lstdeepl->indl) {
         upsl = dynamic_cast<SoilLayer*>(currl);
         lwsl = dynamic_cast<SoilLayer*>(currl->nextl);
         combineTwoSoilLayersL2U(lwsl,upsl); //combine this layer and next layer

--- a/src/lookup/CohortLookup.cpp
+++ b/src/lookup/CohortLookup.cpp
@@ -405,7 +405,8 @@ void CohortLookup::assignBgc4Vegetation(string & dircmt) {
 
   if (!OK) {
     BOOST_LOG_SEV(glg, fatal) << "Problem with cmt_bgcvegetation.txt!!";
-    exit(-1);
+    throw std::runtime_error("Problem with initial parameter files!");
+
   }
 
 }

--- a/src/runmodule/Cohort.cpp
+++ b/src/runmodule/Cohort.cpp
@@ -118,7 +118,7 @@ Cohort::~Cohort() {
 };
 
 /** Provides necessary data to Climate for loading projected climate data*/
-void Cohort::load_proj_climate(std::string& proj_climate_file){
+void Cohort::load_proj_climate(const std::string& proj_climate_file){
 
   climate.load_proj_climate(proj_climate_file, y, x);
 }

--- a/src/runmodule/Cohort.h
+++ b/src/runmodule/Cohort.h
@@ -111,7 +111,7 @@ public :
   void set_state_from_restartdata();
   void set_restartdata_from_state();
 
-  void load_proj_climate(std::string&);//Provides data to Climate for loading proj data
+  void load_proj_climate(const std::string&);//Provides data to Climate for loading proj data
 
 private:
 


### PR DESCRIPTION
This is a collection of a bunch of stuff:

 - updates to boostrap files and Vagrant file for building VM
 - updates to log messages - change log levels, add pixel coords to log outputs
 - add try-catch code so that a run can continue after a pixel fails (for nearly any reason)
     * writes to netcdf file and text file. Details of what content is written to each file is likely to change in the future as we refine things
 - adds step that clears out the output directory at the beginning of each run - prevents the possibility of misinterpreting old outputs leftover from previous run as part of the current run
 - change command line interface of `runmask-util.py` slightly to fit the rest of the codebase
 - add some features to `runmask-util.py`
 - fix bug with running `create_region_input.py` on atlas
 - fix bug with gapfill.py script