### PR TITLE
Implement command line flag that overrides the output cleanup.

### DIFF
--- a/include/ArgHandler.h
+++ b/include/ArgHandler.h
@@ -31,6 +31,7 @@ class ArgHandler {
   int last_n_json_files;
 
   std::string max_output_volume;
+  bool no_output_cleanup;
 
   std::string pid_tag;
 
@@ -71,7 +72,8 @@ public:
 	inline const std::string get_ctrl_file(){return ctrl_file;};
 
   inline const std::string get_max_output_volume(){return max_output_volume;};
-  
+  inline const bool get_no_output_cleanup(){return no_output_cleanup;};
+
   inline const std::string get_log_level(){return log_level;};
   inline const std::string get_log_scope(){return log_scope;};
 

--- a/src/ArgHandler.cpp
+++ b/src/ArgHandler.cpp
@@ -34,6 +34,12 @@ void ArgHandler::parse(int argc, char** argv) {
      "the special value '-1' to indicate no cap on output volume. Use this at "
      "your own risk - you may end up filling your hard-drive!")
 
+    ("no-output-cleanup", boost::program_options::bool_switch(&no_output_cleanup),
+     "Do not clean the output directory at the beginging of a run. This might "
+     "be useful when running dvmdostem under the control of an outside program "
+     "such as PEcAn that makes assumptions about the presence of an output "
+     "directory and may perform its own cleanup.")
+
     ("inter-stage-pause", boost::program_options::bool_switch(&inter_stage_pause),
      "With this flag, (and when in calibration mode), the model will pause and "
      "wait for user input at the end of each run-stage.")

--- a/src/TEM.cpp
+++ b/src/TEM.cpp
@@ -191,27 +191,33 @@ int main(int argc, char* argv[]){
     int id = MPI::COMM_WORLD.Get_rank();     // Change this to C interface?? MPI_Comm_World?
     int ntasks = MPI::COMM_WORLD.Get_size();
     if (id == 0) {
-
+      if (args->get_no_output_cleanup()) {
+        BOOST_LOG_SEV(glg, warn) << "Not cleaning output directory! Files from previous run may remain!";
+      } else {
+        BOOST_LOG_SEV(glg, note) << "Clearing output directory...";
+        const boost::filesystem::path out_dir_path(modeldata.output_dir);
+        if (boost::filesystem::exists( out_dir_path )) {
+          boost::filesystem::remove_all( out_dir_path );
+        }
+        boost::filesystem::create_directories(out_dir_path);
+        BOOST_LOG_SEV(glg, debug) << "rank: "<<id<<" Hit MPI_Barrier.";
+        MPI_Barrier(MPI::COMM_WORLD);
+      } else {
+        BOOST_LOG_SEV(glg, debug) << "rank: "<<id<<" Hit MPI_Barrier.";
+        MPI_Barrier(MPI::COMM_WORLD);
+      }
+    }
+#else
+    if (args->get_no_output_cleanup()) {
+      BOOST_LOG_SEV(glg, warn) << "Not cleaning output directory! Files from previous run may remain!";
+    } else {
       BOOST_LOG_SEV(glg, note) << "Clearing output directory...";
       const boost::filesystem::path out_dir_path(modeldata.output_dir);
       if (boost::filesystem::exists( out_dir_path )) {
         boost::filesystem::remove_all( out_dir_path );
       }
       boost::filesystem::create_directories(out_dir_path);
-      BOOST_LOG_SEV(glg, debug) << "rank: "<<id<<" Hit MPI_Barrier.";
-      MPI_Barrier(MPI::COMM_WORLD);
-    } else {
-      BOOST_LOG_SEV(glg, debug) << "rank: "<<id<<" Hit MPI_Barrier.";
-      MPI_Barrier(MPI::COMM_WORLD);
     }
-
-#else
-    BOOST_LOG_SEV(glg, note) << "Clearing output directory...";
-    const boost::filesystem::path out_dir_path(modeldata.output_dir);
-    if (boost::filesystem::exists( out_dir_path )) {
-      boost::filesystem::remove_all( out_dir_path );
-    }
-    boost::filesystem::create_directories(out_dir_path);
 #endif
 
   BOOST_LOG_SEV(glg, note) << "Running PR stage: " << modeldata.pr_yrs << "yrs";


### PR DESCRIPTION
This is necessary for running under PEcAn, as pecan makes some
assumptions about the existence of the output directory  (specifically
the PEcAn generated logfile.txt) and undertakes its own cleanup steps.