### PR TITLE
Adding some easyconfigs for building all the right stuff for parallelIO. (cherry-picked)

### DIFF
--- a/easyconfigs/HDF5-1.8.16-foss-2016a.eb
+++ b/easyconfigs/HDF5-1.8.16-foss-2016a.eb
@@ -1,0 +1,26 @@
+name = 'HDF5'
+version = '1.8.16'
+
+homepage = 'http://www.hdfgroup.org/HDF5/'
+description = """HDF5 is a unique technology suite that makes possible the management of
+ extremely large and complex data collections."""
+
+toolchain = {'name': 'foss', 'version': '2016a'}
+toolchainopts = {'optarch': True, 'pic': True, 'usempi': True}
+
+source_urls = ['http://www.hdfgroup.org/ftp/HDF5/releases/hdf5-1.8/hdf5-%(version)s/src']
+sources = [SOURCELOWER_TAR_GZ]
+
+patches = [
+    'HDF5-1.8.15_configure_intel.patch',
+    'configure_libtool.patch',
+]
+
+buildopts = 'CXXFLAGS="$CXXFLAGS -DMPICH_IGNORE_CXX_SEEK"'
+
+dependencies = [
+    ('zlib', '1.2.8'),
+    ('Szip', '2.1.1'),
+]
+
+moduleclass = 'data'

--- a/easyconfigs/Szip-2.1.1-foss-2016a.eb
+++ b/easyconfigs/Szip-2.1.1-foss-2016a.eb
@@ -1,0 +1,23 @@
+easyblock = 'ConfigureMake'
+
+name = 'Szip'
+version = '2.1.1'
+
+homepage = 'http://www.hdfgroup.org/doc_resource/SZIP/'
+description = "Szip compression software, providing lossless compression of scientific data"
+
+toolchain = {'name': 'foss', 'version': '2016a'}
+toolchainopts = {'optarch': True, 'pic': True}
+
+source_urls = ['http://www.hdfgroup.org/ftp/lib-external/szip/%(version)s/src']
+sources = [SOURCELOWER_TAR_GZ]
+
+configopts = "--with-pic"
+
+sanity_check_paths = {
+    'files': ["lib/libsz.a", "lib/libsz.%s" % SHLIB_EXT] +
+             ["include/%s" % x for x in ["ricehdf.h", "szip_adpt.h", "szlib.h"]],
+    'dirs': [],
+}
+
+moduleclass = 'tools'

--- a/easyconfigs/netCDF-4.4.0-foss-2016a.eb
+++ b/easyconfigs/netCDF-4.4.0-foss-2016a.eb
@@ -1,0 +1,39 @@
+name = 'netCDF'
+version = '4.4.0'
+
+homepage = 'http://www.unidata.ucar.edu/software/netcdf/'
+description = """NetCDF (network Common Data Form) is a set of software libraries 
+ and machine-independent data formats that support the creation, access, and sharing of array-oriented 
+ scientific data."""
+
+toolchain = {'name': 'foss', 'version': '2016a'}
+toolchainopts = {'pic': True, 'usempi': True}
+
+sources = ['v%(version)s.tar.gz']
+source_urls = [
+    'https://github.com/Unidata/netcdf-c/archive/'
+]
+
+dependencies = [
+    ('HDF5', '1.8.16'),
+    ('cURL', '7.47.0'),
+    ('Szip', '2.1.1'),
+    ('PnetCDF','1.8.1'),
+]
+
+builddependencies = [
+    ('CMake', '3.4.3'),
+    ('Doxygen', '1.8.11'),
+]
+
+# make sure both static and shared libs are built
+configopts = [
+    "-DENABLE_PNETCDF=ON",
+    "-DENABLE_PARALLEL_TESTS=ON",
+    "-DENABLE_LOGGING=ON",
+    "-DENABLE_PARALLEL=ON",
+    "-DBUILD_SHARED_LIBS=OFF ",
+    "-DBUILD_SHARED_LIBS=ON ",
+]
+
+moduleclass = 'data'

--- a/easyconfigs/netcdf4-python-1.2.2-foss-2016a.eb
+++ b/easyconfigs/netcdf4-python-1.2.2-foss-2016a.eb
@@ -1,0 +1,24 @@
+name = 'netcdf4-python'
+version = '1.2.2'
+versionsuffix = '-Python-%(pyver)s'
+
+homepage = 'https://unidata.github.io/netcdf4-python/'
+description = """Python/numpy interface to netCDF."""
+
+toolchain = {'name': 'foss', 'version': '2016a'}
+toolchainopts = {'usempi': True}
+
+source_urls = ['https://github.com/Unidata/netcdf4-python/archive/']
+sources = ['v%(version)srel.tar.gz']
+
+patches = ['netcdf4-python-1.1.8-avoid-diskless-test.patch']
+
+dependencies = [
+    ('Python', '2.7.11'),
+    ('numpy', '1.8.2', versionsuffix),
+    ('HDF5', '1.8.16'),
+    ('netCDF', '4.4.0'),
+    ('cURL', '7.47.0'),
+]
+
+moduleclass = 'data'


### PR DESCRIPTION
This is a single commit cherry-picked from the end of @tobeycarman's old implement_MPI_2 branch.

From his commits:
This might not be everything, but should be close. I copied these
files from my ~/ directory on atlas into the repo, as it seems
like we might want to track these files for the future. Eventually
we might be able to get these easyconfig files merged to upstream
in the EasyBuild repo, but I am not sure how that works yet.

My edits from the stock files were qutie minor if I recally. I think
I mainly was adjusting some funky version numbering.

The one missing piece I can't remember how I did or find my easyconfig
file is for jsoncpp.