### PR TITLE
Add code and flag to prevent output directory cleanup at the beginning of a run.

### DIFF
--- a/include/ArgHandler.h
+++ b/include/ArgHandler.h
@@ -31,6 +31,7 @@ class ArgHandler {
   int last_n_json_files;
 
   std::string max_output_volume;
+  bool no_output_cleanup;
 
   std::string pid_tag;
 
@@ -71,7 +72,8 @@ public:
 	inline const std::string get_ctrl_file(){return ctrl_file;};
 
   inline const std::string get_max_output_volume(){return max_output_volume;};
-  
+  inline const bool get_no_output_cleanup(){return no_output_cleanup;};
+
   inline const std::string get_log_level(){return log_level;};
   inline const std::string get_log_scope(){return log_scope;};
 

--- a/src/ArgHandler.cpp
+++ b/src/ArgHandler.cpp
@@ -34,6 +34,12 @@ void ArgHandler::parse(int argc, char** argv) {
      "the special value '-1' to indicate no cap on output volume. Use this at "
      "your own risk - you may end up filling your hard-drive!")
 
+    ("no-output-cleanup", boost::program_options::bool_switch(&no_output_cleanup),
+     "Do not clean the output directory at the beginging of a run. This might "
+     "be useful when running dvmdostem under the control of an outside program "
+     "such as PEcAn that makes assumptions about the presence of an output "
+     "directory and may perform its own cleanup.")
+
     ("inter-stage-pause", boost::program_options::bool_switch(&inter_stage_pause),
      "With this flag, (and when in calibration mode), the model will pause and "
      "wait for user input at the end of each run-stage.")

--- a/src/TEM.cpp
+++ b/src/TEM.cpp
@@ -237,8 +237,14 @@ int main(int argc, char* argv[]){
     BOOST_LOG_SEV(glg, info) << "Checking for output directory: "<<modeldata.output_dir;
     boost::filesystem::path out_dir_path(modeldata.output_dir);
     if( boost::filesystem::exists(out_dir_path) ){
-      BOOST_LOG_SEV(glg, info) << "Output directory exists. Deleting...";
-      boost::filesystem::remove_all(out_dir_path);
+      if (args->get_no_output_cleanup()) {
+        BOOST_LOG_SEV(glg, warn) << "WARNING!! Not cleaning up output directory! "
+                                 << "Old and potentially confusing files may be "
+                                 << "present from previous runs!!";
+      } else {
+        BOOST_LOG_SEV(glg, info) << "Output directory exists. Deleting...";
+        boost::filesystem::remove_all(out_dir_path);
+      }
     }
     BOOST_LOG_SEV(glg, info) << "Creating output directory: "<<modeldata.output_dir;
     boost::filesystem::create_directories(out_dir_path);
@@ -861,7 +867,7 @@ void write_status(const std::string fname, int row, int col, int statusCode) {
 
 #ifdef WITHMPI
 
-  //These are for logging identification only.
+  // These are for logging identification only.
   int id = MPI::COMM_WORLD.Get_rank();
   int ntasks = MPI::COMM_WORLD.Get_size();
 


### PR DESCRIPTION
Useful for integration with PEcAn. PEcAn requires the presence of the output directory and does its own cleanup steps.