### PR TITLE
Fix pecan integration issues

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ CFLAGS=-c -ansi -g -gdwarf-2 -fPIC -DBOOST_ALL_DYN_LINK -Werror # -W -Wall -Werr
 LIBS=-lnetcdf -lboost_system -lboost_filesystem \
 -lboost_program_options -lboost_thread -lboost_log -ljsoncpp -lpthread -lreadline
 
-USEMPI = true
+USEMPI = false
 USEOMP = false
 
 ifeq ($(USEMPI),true)

--- a/Makefile
+++ b/Makefile
@@ -3,9 +3,6 @@
 # Add compiler flag for enabling floating point exceptions:
 # -DBSD_FPE for BSD (OSX)
 # -DGNU_FPE for various Linux
-SITE_SPECIFIC_INCLUDES=-I/home/UA/tcarman2/.local/easybuild/software/jsoncpp/1.8.1-foss-2016a/include/jsoncpp/ -I/home/UA/tcarman2/.local/easybuild/build/netCDF/4.4.0/foss-2016a/netcdf-c-4.4.0/include/
-
-SITE_SPECIFIC_LIBS="-L/home/UA/tcarman2/.local/easybuild/software/Boost/1.55.0-foss-2016a-Python-2.7.11/lib/"
 
 CC=g++
 CFLAGS=-c -ansi -g -gdwarf-2 -fPIC -DBOOST_ALL_DYN_LINK -Werror # -W -Wall -Werror -Wno-system-headers

--- a/env-setup-scripts/setup-env-for-atlas.sh
+++ b/env-setup-scripts/setup-env-for-atlas.sh
@@ -12,24 +12,24 @@
 # LD_LIBRARY_PATH, as the linker does not seem smart enough to look the extra 
 # level of depth...
 
+# NOTE: (Nov 2017) Using EasyBuild, we no longer need to update LD_LIBRARY_PATH
+# or manually adjust the jsoncpp path in the Makefile. We might want a separate
+# environment setup script for Ruth's atlas environment?
+
+echo "Loading modules..."
+module purge
+module load jsoncpp/1.8.1-foss-2016a netCDF/4.4.0-foss-2016a Boost/1.55.0-foss-2016a-Python-2.7.11
+module load netcdf4-python/1.2.2-foss-2016a-Python-2.7.11
+
 echo "Setting up site specific inlcudes..."
-export SITE_SPECIFIC_INCLUDES="-I/home/UA/tcarman2/boost_1_55_0/ -I/home/UA/tcarman2/custom-software/jsoncpp/include"
+export SITE_SPECIFIC_INCLUDES="-I/home/UA/tcarman2/.local/easybuild/software/jsoncpp/1.8.1-foss-2016a/include/jsoncpp/ -I/home/UA/tcarman2/.local/easybuild/build/netCDF/4.4.0/foss-2016a/netcdf-c-4.4.0/include/"
 
 echo "Setting up site specific libs..."
-export SITE_SPECIFIC_LIBS="-L/home/UA/tcarman2/boost_1_55_0/stage/lib -L/home/UA/tcarman2/custom-software/jsoncpp/libs/linux-gcc-4.4.7"
-
-echo "Setting the path for loading libraries..."
-export LD_LIBRARY_PATH="/home/UA/rarutter/downloads/hdf5-1.8.19/hdf5/lib:/home/UA/tcarman2/custom-software/jsoncpp/libs/linux-gcc-4.4.7:/home/UA/tcarman2/boost_1_55_0/stage/lib:$LD_LIBRARY_PATH"
-
-echo "Fixing jsoncpp library name in Makefile..."
-sed -e 's/\<ljsoncpp\>/ljson_linux-gcc-4.4.7_libmt/g' Makefile > Makefile.tmp && mv Makefile.tmp Makefile
+export SITE_SPECIFIC_LIBS="-L/home/UA/tcarman2/.local/easybuild/software/Boost/1.55.0-foss-2016a-Python-2.7.11/lib/"
 
 echo "NOTE: This file will NOT work if it is run as a script!"
 echo "      Instead use the 'source' command like this:"
 echo "      $ source env-setup-scripts/setup-env-for-atlas.sh"
 echo ""
-echo "NOTE: Please remember not to commit the modified Makefile!!"
-echo "      You can revert the change with this command:"
-echo "      $ git checkout -- Makefile"
 
 

--- a/src/TEM.cpp
+++ b/src/TEM.cpp
@@ -580,7 +580,7 @@ void advance_model(const int rowidx, const int colidx,
     runner.cohort.md->set_avlnflg(true);
     runner.cohort.md->set_baseline(true);
 
-    runner.cohort.md->set_dsbmodule(true);
+    runner.cohort.md->set_dsbmodule(false);
 
     // This variable ensures that OpenMP threads do not modify
     // the shared modeldata.eq_yrs value.
@@ -638,6 +638,15 @@ void advance_model(const int rowidx, const int colidx,
       runner.calcontroller_ptr->handle_stage_start();
     }
 
+    runner.cohort.md->set_envmodule(true);
+    runner.cohort.md->set_bgcmodule(true);
+    runner.cohort.md->set_nfeed(true);
+    runner.cohort.md->set_avlnflg(true);
+    runner.cohort.md->set_baseline(true);
+    runner.cohort.md->set_dsbmodule(false);
+    runner.cohort.md->set_dslmodule(true);
+    runner.cohort.md->set_dvmmodule(true);
+
     runner.cohort.climate.monthlycontainers2log();
 
     BOOST_LOG_SEV(glg, debug) << "Loading RestartData from: " << eq_restart_fname;
@@ -683,6 +692,15 @@ void advance_model(const int rowidx, const int colidx,
       runner.calcontroller_ptr->handle_stage_start();
     }
 
+    runner.cohort.md->set_envmodule(true);
+    runner.cohort.md->set_bgcmodule(true);
+    runner.cohort.md->set_nfeed(true);
+    runner.cohort.md->set_avlnflg(true);
+    runner.cohort.md->set_baseline(true);
+    runner.cohort.md->set_dsbmodule(false);
+    runner.cohort.md->set_dslmodule(true);
+    runner.cohort.md->set_dvmmodule(true);
+
     // update the cohort's restart data object
     BOOST_LOG_SEV(glg, debug) << "Loading RestartData from: " << sp_restart_fname;
     runner.cohort.restartdata.update_from_ncfile(sp_restart_fname, rowidx, colidx);
@@ -723,6 +741,15 @@ void advance_model(const int rowidx, const int colidx,
     if (runner.calcontroller_ptr) {
       runner.calcontroller_ptr->handle_stage_start();
     }
+
+    runner.cohort.md->set_envmodule(true);
+    runner.cohort.md->set_bgcmodule(true);
+    runner.cohort.md->set_nfeed(true);
+    runner.cohort.md->set_avlnflg(true);
+    runner.cohort.md->set_baseline(true);
+    runner.cohort.md->set_dsbmodule(false);
+    runner.cohort.md->set_dslmodule(true);
+    runner.cohort.md->set_dvmmodule(true);
 
     // update the cohort's restart data object
     BOOST_LOG_SEV(glg, debug) << "Loading RestartData from: " << tr_restart_fname;


### PR DESCRIPTION
Turns MPI build in Makefile off by default, fixes Makefile to remove site specific setup stuff (moves to dedicated environment setup script), turns dsb module off for all stages.