### PR TITLE
Update to C++11

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@
 # -DGNU_FPE for various Linux
 
 CC=g++
-CFLAGS=-c -ansi -g -gdwarf-2 -fPIC -DBOOST_ALL_DYN_LINK -Werror # -W -Wall -Werror -Wno-system-headers
+CFLAGS=-c -ansi -g -gdwarf-2 -std=c++11 -fPIC -DBOOST_ALL_DYN_LINK -Werror # -W -Wall -Werror -Wno-system-headers
 LIBS=-lnetcdf -lboost_system -lboost_filesystem \
 -lboost_program_options -lboost_thread -lboost_log -ljsoncpp -lpthread -lreadline
 

--- a/SConstruct
+++ b/SConstruct
@@ -119,7 +119,7 @@ elif platform_name == 'Darwin':
   platform_include_path = ['/usr/local/include']
   platform_library_path = ['/usr/local/lib']
 
-  compiler_flags = '-Werror -fpermissive -ansi -g -fPIC -DBOOST_ALL_DYN_LINK -DBSD_FPE'
+  compiler_flags = '-Werror -fpermissive -ansi -g -fPIC -std=c++11 -DBOOST_ALL_DYN_LINK -DBSD_FPE'
 
   # This is not really a Darwin-specific thing so much as the fact that
   # for Tobey, when he installed boost, he inadvertantly specified that

--- a/env-setup-scripts/setup-env-for-atlas.sh
+++ b/env-setup-scripts/setup-env-for-atlas.sh
@@ -16,6 +16,10 @@
 # or manually adjust the jsoncpp path in the Makefile. We might want a separate
 # environment setup script for Ruth's atlas environment?
 
+# NOTE: (Jan 2018) Changing to C++11. The EasyBuild provided libs seem to have 
+# been compiled without -std=c++11 so we need this adjust CFLAGS to have a 
+# special variable for BOOST.
+
 echo "Loading modules..."
 module purge
 module load jsoncpp/1.8.1-foss-2016a netCDF/4.4.0-foss-2016a Boost/1.55.0-foss-2016a-Python-2.7.11
@@ -27,9 +31,15 @@ export SITE_SPECIFIC_INCLUDES="-I/home/UA/tcarman2/.local/easybuild/software/jso
 echo "Setting up site specific libs..."
 export SITE_SPECIFIC_LIBS="-L/home/UA/tcarman2/.local/easybuild/software/Boost/1.55.0-foss-2016a-Python-2.7.11/lib/"
 
+echo "Adding special CFLAG variable for Boost, C++11 in Makefile..."
+sed -e 's/-DBOOST_ALL_DYN_LINK -Werror/-DBOOST_ALL_DYN_LINK -DBOOST_NO_CXX11_SCOPED_ENUMS -Werror/' Makefile > Makefile.tmp && mv Makefile.tmp Makefile
+
 echo "NOTE: This file will NOT work if it is run as a script!"
 echo "      Instead use the 'source' command like this:"
 echo "      $ source env-setup-scripts/setup-env-for-atlas.sh"
 echo ""
 
+echo "NOTE: Please remember not to commit the modified Makefile!!"
+echo "      You can revert the change with this command:"
+echo "      $ git checkout -- Makefile"
 

--- a/env-setup-scripts/setup-env-for-pecanVM.sh
+++ b/env-setup-scripts/setup-env-for-pecanVM.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+# Setting up the environment for the PEcAn VM 1.5.1
+
+# NOTE: I had to install jsoncpp, I think I did it using 
+# apt-get and I may have had to install libjsoncpp-dev too.
+
+# Not sure why the include path needs setting...
+
+echo "Setting up site specific inlcudes..."
+export SITE_SPECIFIC_INCLUDES="-I/usr/include/jsoncpp"
+
+echo "NOTE: This file will NOT work if it is run as a script!"
+echo "      Instead use the 'source' command like this:"
+echo "      $ source env-setup-scripts/setup-env-for-atlas.sh"
+echo ""
+

--- a/src/CalController.cpp
+++ b/src/CalController.cpp
@@ -28,71 +28,71 @@ CalController::CalController(Cohort* cht_p):
   io_service(new boost::asio::io_service),
   pause_sigs(*io_service, SIGINT, SIGTERM),
   cohort_ptr(cht_p) {
-  cmd_map = boost::assign::map_list_of
-            ("q", CalCommand("quit the calibrator",
-                             boost::bind(&CalController::quit, this)) )
-            ("c",
+  cmd_map = {
+            {"q", CalCommand("quit the calibrator",
+                             boost::bind(&CalController::quit, this)) },
+            {"c",
               CalCommand("continue simulation",
                           boost::bind(&CalController::continue_simulation,
-                                      this)) )
-            ("r",
+                                      this)) },
+            {"r",
               CalCommand("reload calparbgc file",
                           boost::bind(&CalController::reload_calparbgc_file,
-                                      this)) )
-            ("reload all",
+                                      this)) },
+            {"reload all",
               CalCommand("reload all cmt files",
                           boost::bind(&CalController::reload_all_cmt_files,
-                                      this)) )
-            ("h",
+                                      this)) },
+            {"h",
               CalCommand("show short menu",
-                          boost::bind(&CalController::show_short_menu, this)) )
-            ("help",
+                          boost::bind(&CalController::show_short_menu, this)) },
+            {"help",
               CalCommand("show full menu",
-                          boost::bind(&CalController::show_full_menu, this)) )
+                          boost::bind(&CalController::show_full_menu, this)) },
 
-            ("print calparbgc",
+            {"print calparbgc",
               CalCommand("prints out the calparbgc parameters ",
-                         boost::bind(&CalController::print_calparbgc, this)) )
-            ("print module settings",
+                         boost::bind(&CalController::print_calparbgc, this)) },
+            {"print module settings",
               CalCommand("print module settings (on/off)",
-                         boost::bind(&CalController::print_modules_settings, this)) )
+                         boost::bind(&CalController::print_modules_settings, this)) },
 
-            ("print directives",
+            {"print directives",
               CalCommand("show data from the run_configuration data structure",
-                         boost::bind(&CalController::print_directive_settings, this)) )
+                         boost::bind(&CalController::print_directive_settings, this)) },
 
-            ("quitat",
+            {"quitat",
               CalCommand("quits and exits at simulation year specified",
-                         boost::bind(&CalController::quit_at, this, _1)) )
-            ("pauseat",
+                         boost::bind(&CalController::quit_at, this, _1)) },
+            {"pauseat",
               CalCommand("pauses at simulation year specified",
-                         boost::bind(&CalController::pause_at, this, _1)) )
+                         boost::bind(&CalController::pause_at, this, _1)) },
 
-            ("env",
+            {"env",
               CalCommand("changes env module state",
-                         boost::bind(&CalController::env_cmd, this, _1)) )
-            ("bgc",
+                         boost::bind(&CalController::env_cmd, this, _1)) },
+            {"bgc",
               CalCommand("changes bgc module state",
-                         boost::bind(&CalController::bgc_cmd, this, _1)) )
-            ("avln",
+                         boost::bind(&CalController::bgc_cmd, this, _1)) },
+            {"avln",
               CalCommand("changes available Nitrogen setting",
-                         boost::bind(&CalController::avln_cmd, this, _1)) )
-            ("dsb",
+                         boost::bind(&CalController::avln_cmd, this, _1)) },
+            {"dsb",
               CalCommand("changes dsb module state",
-                         boost::bind(&CalController::dsb_cmd, this, _1)) )
-            ("dsl",
+                         boost::bind(&CalController::dsb_cmd, this, _1)) },
+            {"dsl",
               CalCommand("changes dsl module state",
-                         boost::bind(&CalController::dsl_cmd, this, _1)) )
-            ("dvm",
+                         boost::bind(&CalController::dsl_cmd, this, _1)) },
+            {"dvm",
               CalCommand("changes dvm module state",
-                         boost::bind(&CalController::dvm_cmd, this, _1)) )
-            ("nfeed",
+                         boost::bind(&CalController::dvm_cmd, this, _1)) },
+            {"nfeed",
               CalCommand("changes nitrogen feedback setting",
-                          boost::bind(&CalController::nfeed_cmd, this, _1)) )
-            ("baseline",
+                          boost::bind(&CalController::nfeed_cmd, this, _1)) },
+            {"baseline",
               CalCommand("changes baseline setting",
-                          boost::bind(&CalController::baseline_cmd, this, _1)) )
-            ;
+                          boost::bind(&CalController::baseline_cmd, this, _1)) },
+            };
 
   BOOST_LOG_SEV(glg, debug) << "Set async wait on signals to PAUSE handler.";
   pause_sigs.async_wait( boost::bind(&CalController::pause_handler, this,

--- a/src/OutputEstimate.cpp
+++ b/src/OutputEstimate.cpp
@@ -18,14 +18,15 @@ extern src::severity_logger< severity_level > glg;
 
 OutputEstimate::OutputEstimate(const ModelData& md, bool calmode) {
 
-  stage_output_estimates = boost::assign::list_of
+  stage_output_estimates = { 
       // Table of coefficients for bytes per year of run-time for
       // each stage and different types of json output (archive, daily, etc).
-      (StageOutputEstimate("pr", md.pr_yrs, 22000,  41000,  200000,  20000))
-      (StageOutputEstimate("eq", md.eq_yrs, 56000,  41000,  240000,  24000))
-      (StageOutputEstimate("sp", md.sp_yrs, 15000,  36000,  199000,  16000))
-      (StageOutputEstimate("tr", md.tr_yrs, 15000,  36000,  199000,  16000))
-      (StageOutputEstimate("sc", md.sc_yrs, 15000,  36000,  199000,  16000));
+      {StageOutputEstimate("pr", md.pr_yrs, 22000,  41000,  200000,  20000)},
+      {StageOutputEstimate("eq", md.eq_yrs, 56000,  41000,  240000,  24000)},
+      {StageOutputEstimate("sp", md.sp_yrs, 15000,  36000,  199000,  16000)},
+      {StageOutputEstimate("tr", md.tr_yrs, 15000,  36000,  199000,  16000)},
+      {StageOutputEstimate("sc", md.sc_yrs, 15000,  36000,  199000,  16000)},
+  };
 
   // Open the run mask (spatial mask) and count all the non-zero cells.
   std::vector< std::vector<int> > run_mask = temutil::read_run_mask(md.runmask_file);


### PR DESCRIPTION
Code changes:
 - Change from boost::asign_list_of() to initilalizer lists

Build changes:
 - add std=c++11 to CFLAGS
 - on atlas, in tobey's account which was setup with EasyBuild, we
   have to add a special BOOST flag because it appears that some of
   the supporting libs were compiled without the -std=c++11 flag.
   This should probably be fixed in the future by re-compiling everything.