### PR TITLE
369 fix snowfall

### DIFF
--- a/src/Runner.cpp
+++ b/src/Runner.cpp
@@ -2124,7 +2124,7 @@ void Runner::output_netCDF(std::map<std::string, OutputSpec> &netcdf_outputs, in
       }
       else if(curr_spec.monthly){
         start3[0] = month_timestep;
-        double snowthick;
+        double snowthick=0.0;
         Layer* currL = cohort.ground.toplayer;
         while(currL->isSnow){
           snowthick += currL->dz;
@@ -2135,7 +2135,7 @@ void Runner::output_netCDF(std::map<std::string, OutputSpec> &netcdf_outputs, in
       }
       else if(curr_spec.yearly){
         start3[0] = year;
-        double snowthick;
+        double snowthick=0.0;
         Layer* currL = cohort.ground.toplayer;
         while(currL->isSnow){
           snowthick += currL->dz;

--- a/src/Snow_Env.cpp
+++ b/src/Snow_Env.cpp
@@ -186,6 +186,7 @@ double  Snow_Env::meltSnowLayersAfterT(Layer* toplayer) {
 // assign double-linked snow horizon data to 'ed'
 void Snow_Env::updateSnowEd(Layer *toplayer) {
   ed->d_snws.swesum = 0.;
+  ed->d_snws.snowthick = 0.;
   Layer* currl=toplayer;
   int snowind = 0;
 
@@ -263,6 +264,7 @@ void Snow_Env::set_state_from_restartdata(const RestartData & rdata) {
   Layer* currl = ground->toplayer;
   int snind = -1;
   ed->d_snws.swesum = 0;
+  ed->d_snws.snowthick = 0;
 
   while(currl!=NULL) {
     if(currl->isSnow) {

--- a/src/Snow_Env.cpp
+++ b/src/Snow_Env.cpp
@@ -91,7 +91,8 @@ void Snow_Env::updateDailySurfFlux( Layer* toplayer, const double & tdrv) {
         double layicermv = fmin(sublim, currl->ice);
         actsub += layicermv;
         sublim -= layicermv;
-        currl->ice -= layicermv;
+        //layicermv used to be subtracted from currl->ice here, but
+        // that duplicates the removal in Ground::constructSnowLayers()
       } else {
         break;
       }

--- a/src/Vegetation_Env.cpp
+++ b/src/Vegetation_Env.cpp
@@ -228,8 +228,8 @@ void Vegetation_Env::updateWaterBalance(const double & daylhr, double leaf_area_
     ed->d_v2a.sublim =0.;
     ed->d_v2g.rdrip = 0;
     ed->d_v2g.sdrip = 0;
-    ed->d_v2g.rthfl = rnfl;
-    ed->d_v2g.sthfl = snfl ;
+    ed->d_v2g.rthfl = 0;
+    ed->d_v2g.sthfl = 0;
     ed->d_vegs.snow  =0.;
     ed->d_vegs.rwater=0.;
   }


### PR DESCRIPTION

![snowthick_fix](https://user-images.githubusercontent.com/6707880/39653636-432a473c-4f9e-11e8-86fa-a12d241dcc06.jpg)

[SNOWTHICK_fix.pdf](https://github.com/ua-snap/dvm-dos-tem/files/1975933/SNOWTHICK_fix.pdf)
This shows daily SNOWTHICK from dostem and dvmdostem once the fixes are applied to ddt. The differences in the first year are because dostem starts EQ with thickness of zero, while dvmdostem retains the values from PR.