### PR TITLE
Fronts plots

### DIFF
--- a/scripts/output_utils.py
+++ b/scripts/output_utils.py
@@ -655,11 +655,11 @@ def plot_fronts(args):
   x = np.arange(0, fdepth.shape[0])
 
   for fnt_idx in range(0,10):
-    front_thaw = ax0.scatter(x, np.ma.masked_where(ftype[:,fnt_idx,Y,X] < 0, fdepth[:,fnt_idx,Y,X]), color='orange', marker='o')
-    front_thaw_line = ax0.plot(np.ma.masked_where(ftype[:,fnt_idx,Y,X] < 0, fdepth[:,fnt_idx,Y,X]), label='thaw front {}'.format(fnt_idx), color='orange', alpha=0.5)
+    front_thaw = ax0.scatter(x, np.ma.masked_where(ftype[:,fnt_idx,Y,X] > 0, fdepth[:,fnt_idx,Y,X]), color='orange', marker='o')
+    front_thaw_line = ax0.plot(np.ma.masked_where(ftype[:,fnt_idx,Y,X] > 0, fdepth[:,fnt_idx,Y,X]), label='thaw front {}'.format(fnt_idx), color='orange', alpha=0.5)
 
-    front_freeze = ax0.scatter(x ,np.ma.masked_where(ftype[:,fnt_idx,Y,X] > 0, fdepth[:,fnt_idx,Y,X]), color='blue', marker='o')
-    front_freeze_line = ax0.plot(np.ma.masked_where(ftype[:,fnt_idx,Y,X] > 0, fdepth[:,fnt_idx,Y,X]), label='freeze front {}'.format(fnt_idx), color='blue', alpha=0.5)
+    front_freeze = ax0.scatter(x ,np.ma.masked_where(ftype[:,fnt_idx,Y,X] < 0, fdepth[:,fnt_idx,Y,X]), color='blue', marker='o')
+    front_freeze_line = ax0.plot(np.ma.masked_where(ftype[:,fnt_idx,Y,X] < 0, fdepth[:,fnt_idx,Y,X]), label='freeze front {}'.format(fnt_idx), color='blue', alpha=0.5)
 
   if args.show_layers:
     layerdepth, layerdepth_units = pull_data_wrapper(args, variable="LAYERDEPTH", required_dims=['time','layer','y','x'])

--- a/scripts/output_utils.py
+++ b/scripts/output_utils.py
@@ -604,6 +604,23 @@ def plot_soil_layers():
   plt.barh(bottoms, widths, heights, color=colors)
 
 def pull_data_wrapper(args, variable=None, required_dims=None):
+  '''
+  Extracts data from an netcdf file.
+
+  `args` must be a dict with settings for outfolder, timeres, and stage.
+  `variable` must be a string with the variable name that is expected to be in
+  the netcdf file. The file is expected to be names like this:
+  "VARIABLE_TIMERES_STAGE.nc" and is expected to be present in the
+  args.outfolder.
+
+  If required_dims is passed, then the dimensions of the variable to extract
+  are checked against the list and a RuntimeError is thrown if there is a
+  a problem.
+
+  Returns a tuple (data, units), where data is a numpy array or masked array
+  and units is a string that is extracted from the attributs of the netcdf file.
+
+  '''
 
   od = args.outfolder
   timeres = (args.timeres).lower()

--- a/scripts/output_utils.py
+++ b/scripts/output_utils.py
@@ -659,7 +659,13 @@ def plot_fronts(args):
     front_freeze = ax0.scatter(np.arange(0,1308),np.ma.masked_where(ftype[:,fnt_idx,Y,X] > 0, fdepth[:,fnt_idx,Y,X]), color='blue', marker='o')
     front_freeze_line = ax0.plot(np.ma.masked_where(ftype[:,fnt_idx,Y,X] > 0, fdepth[:,fnt_idx,Y,X]), label='freeze front {}'.format(fnt_idx), color='blue', alpha=0.5)
 
+  if args.show_layers:
+    layerdepth, layerdepth_units = pull_data_wrapper(args, variable="LAYERDEPTH", required_dims=['time','layer','y','x'])
+    for lidx in range(0,layerdepth.shape[1]):
+      layerline = ax0.plot(layerdepth[:,lidx,Y,X], color='gray', alpha=0.5, linewidth=0.5)
 
+  # This is super cluttered in the default view if there are many layers or if
+  # the time axis is long, but looks good when you zoom in.
   ax0.xaxis.set_major_locator(matplotlib.ticker.MultipleLocator(12))
   ax0.xaxis.set_minor_locator(matplotlib.ticker.MultipleLocator(6))
   ax0.invert_yaxis()
@@ -942,9 +948,15 @@ if __name__ == '__main__':
 
   fronts_parser = subparsers.add_parser('fronts',
     help=textwrap.dedent('''\
-      Make a plot of the fronts.
+      Make a plot of the fronts. Y axis depth with 0 at the surface, X axis is
+      time (tested with monthly data).
       '''))
-  fronts_parser.add_argument('outfolder', help="Path to a folder containing a set of dvmdostem outputs")
+  fronts_parser.add_argument('--show-layers', action='store_true', help=textwrap.dedent('''\
+    Plot the layers. Assumes that file for LAYERDEPTH is available in the
+    outfolder.'''))
+  fronts_parser.add_argument('outfolder', help=textwrap.dedent('''\
+    "Path to a folder containing a set of dvmdostem outputs, presumably with
+    files for FRONTSDEPTH and FRONTSTYPE'''))
 
   # sc for 'site compare'
   # ./output_util.py --stage tr --yx 0 0 --timeres monthly site-compare --save-name some/path/to/somefile.pdf /path/to/inputA /path/to/inputB /pathto.inpuC

--- a/scripts/output_utils.py
+++ b/scripts/output_utils.py
@@ -663,8 +663,26 @@ def plot_fronts(args):
 
   if args.show_layers:
     layerdepth, layerdepth_units = pull_data_wrapper(args, variable="LAYERDEPTH", required_dims=['time','layer','y','x'])
+    layer_lines = []
     for lidx in range(0,layerdepth.shape[1]):
-      layerline = ax0.plot(layerdepth[:,lidx,Y,X], color='gray', alpha=0.5, linewidth=0.5)
+      layerline = ax0.plot(layerdepth[:,lidx,Y,X], color='gray', alpha=0.5, linewidth=0.5, marker='o', markersize=.75)
+      layer_lines.append(layerline)
+
+  if args.layer_colors:
+    ltype, ltype_units = pull_data_wrapper(args, "LAYERTYPE")
+    for il, l in enumerate(layer_lines):
+      if il == 0:
+        pass
+      else:
+        currl = l[0]
+        prevl = layer_lines[il-1][0]
+
+        # Make sure to grab the previous layer (il-1) for the layer type condition!
+        ax0.fill_between(x, currl.get_ydata(), prevl.get_ydata(), ltype[:,il-1,Y,X] == 0, color='xkcd:green', alpha=.5)
+        ax0.fill_between(x, currl.get_ydata(), prevl.get_ydata(), ltype[:,il-1,Y,X] == 1, color='xkcd:sand', alpha=.5)
+        ax0.fill_between(x, currl.get_ydata(), prevl.get_ydata(), ltype[:,il-1,Y,X] == 2, color='xkcd:coffee', alpha=.5)
+        ax0.fill_between(x, currl.get_ydata(), prevl.get_ydata(), ltype[:,il-1,Y,X] == 3, color='xkcd:silver', alpha=.5)
+
 
   # This is super cluttered in the default view if there are many layers or if
   # the time axis is long, but looks good when you zoom in.
@@ -953,9 +971,13 @@ if __name__ == '__main__':
       Make a plot of the fronts. Y axis depth with 0 at the surface, X axis is
       time (tested with monthly data).
       '''))
-  fronts_parser.add_argument('--show-layers', action='store_true', help=textwrap.dedent('''\
-    Plot the layers. Assumes that file for LAYERDEPTH is available in the
-    outfolder.'''))
+  fronts_parser.add_argument('--show-layers', action='store_true',
+    help=textwrap.dedent('''Plot the layers. Assumes that file for LAYERDEPTH 
+      is available in the outfolder.'''))
+  fronts_parser.add_argument('--layer-colors', action='store_true',
+    help=textwrap.dedent('''Try to color the layers based on the LAYERTYPE.
+      Green for moss, sand for shallow soil, dark brown for deep soil, and gray
+      for mineral.'''))
   fronts_parser.add_argument('outfolder', help=textwrap.dedent('''\
     "Path to a folder containing a set of dvmdostem outputs, presumably with
     files for FRONTSDEPTH and FRONTSTYPE'''))

--- a/scripts/output_utils.py
+++ b/scripts/output_utils.py
@@ -652,11 +652,13 @@ def plot_fronts(args):
   ax0.set_xlabel("Time")
   ax0.set_title("{}".format(od))
 
+  x = np.arange(0, fdepth.shape[0])
+
   for fnt_idx in range(0,10):
-    front_thaw = ax0.scatter(np.arange(0,1308),np.ma.masked_where(ftype[:,fnt_idx,Y,X] < 0, fdepth[:,fnt_idx,Y,X]), color='orange', marker='o')
+    front_thaw = ax0.scatter(x, np.ma.masked_where(ftype[:,fnt_idx,Y,X] < 0, fdepth[:,fnt_idx,Y,X]), color='orange', marker='o')
     front_thaw_line = ax0.plot(np.ma.masked_where(ftype[:,fnt_idx,Y,X] < 0, fdepth[:,fnt_idx,Y,X]), label='thaw front {}'.format(fnt_idx), color='orange', alpha=0.5)
 
-    front_freeze = ax0.scatter(np.arange(0,1308),np.ma.masked_where(ftype[:,fnt_idx,Y,X] > 0, fdepth[:,fnt_idx,Y,X]), color='blue', marker='o')
+    front_freeze = ax0.scatter(x ,np.ma.masked_where(ftype[:,fnt_idx,Y,X] > 0, fdepth[:,fnt_idx,Y,X]), color='blue', marker='o')
     front_freeze_line = ax0.plot(np.ma.masked_where(ftype[:,fnt_idx,Y,X] > 0, fdepth[:,fnt_idx,Y,X]), label='freeze front {}'.format(fnt_idx), color='blue', alpha=0.5)
 
   if args.show_layers:


### PR DESCRIPTION
Adds more abilities to the `scripts/output_utils.py` plotting tools. Specifically, adds:

 - ability to plot fronts
 - ability to plot layer depths with fronts
 - ability to plot layer type with depths and fronts

If your files have a lot of data in them (i.e. long time range), the initial plot will be too busy to be useful, but the interactive zoom tools let you view just a subset, and then things are usable.

Here is an example using the data that @rarutter sent me last week from an extensive fronts debugging session. 

Initial view (too messy, but gets you oriented):
```
$ ./scripts/output_utils.py --yx 0 0 --stage tr --timeres monthly fronts /home/vagrant/better_fronts
```
![screen shot 2018-08-20 at 2 27 20 pm](https://user-images.githubusercontent.com/838735/44370192-99a2f780-a485-11e8-944a-2db80b673a74.png)

Zoomed way in, also with layers and layer colors display enabled (see args on command line):
```
$ ./scripts/output_utils.py --yx 0 0 --stage tr --timeres monthly fronts /home/vagrant/better_fronts --show-layers --layer-colors
```
![screen shot 2018-08-20 at 2 29 12 pm](https://user-images.githubusercontent.com/838735/44370176-8bed7200-a485-11e8-838b-d0418c95d8db.png)
