### PR TITLE
Cleanup parameter files

### DIFF
--- a/parameters/cmt_bgcsoil.txt
+++ b/parameters/cmt_bgcsoil.txt
@@ -21,7 +21,7 @@
 363               // initsoln:
 0.76              // initavln:
 //===========================================================
-// CMT01 // Black Spruce Forest
+// CMT01 // Black Spruce Forest // ###THESE ARE JUNK VALUES!!!###
 2.0               // rhq10:
 0.0               // moistmin:
 0.5               // moistopt:

--- a/parameters/cmt_bgcsoil.txt
+++ b/parameters/cmt_bgcsoil.txt
@@ -1,5 +1,7 @@
+// dmvdostem parameter file
+// soil microbial activity (BGC) parameters and default initial conditions
 //===========================================================
-// CMT00 // Default TEM Community  - soil microbial activity (BGC) parameters and default initial conditions
+// CMT00 // BARE GROUND OPEN WATER SNOW AND ICE
 2.0               // rhq10:
 0.0               // moistmin:
 0.5               // moistopt:
@@ -19,7 +21,7 @@
 363               // initsoln:
 0.76              // initavln:
 //===========================================================
-// CMT01 // CMT1 TEM Community  - soil microbial activity (BGC) parameters and default initial conditions
+// CMT01 // Black Spruce Forest
 2.0               // rhq10:
 0.0               // moistmin:
 0.5               // moistopt:
@@ -39,7 +41,7 @@
 363               // initsoln:
 0.76              // initavln:
 //===========================================================
-// CMT02 // CMT2 TEM Community  - soil microbial activity (BGC) parameters and default initial conditions
+// CMT02 // White Spruce Forest
 2.0               // rhq10:
 0.0               // moistmin:
 0.5               // moistopt:
@@ -59,7 +61,7 @@
 363               // initsoln:
 0.76              // initavln:
 //===========================================================
-// CMT03 // CMT3 TEM Community  - soil microbial activity (BGC) parameters and default initial conditions
+// CMT03 // Boreal Deciduous Forest
 2.0               // rhq10:
 0.0               // moistmin:
 0.5               // moistopt:
@@ -79,7 +81,7 @@
 363               // initsoln:
 0.76              // initavln:
 //===========================================================
-// CMT04 // Shrub Tundra  - soil microbial activity (BGC) parameters and default initial conditions
+// CMT04 // Shrub Tundra
 2.0               // rhq10:
 0.0               // moistmin:
 0.5               // moistopt:
@@ -99,7 +101,7 @@
 1843              // initsoln:
 3.93              // initavln:  was 0.68
 //===========================================================
-// CMT05 // Tussock Tundra (updated 1/15/2016 JDC) - Soil microbial activity (BGC) parameters and default initial conditions.
+// CMT05 // Tussock Tundra // (updated 1/15/2016 JDC)
 2.0               // rhq10:
 0.0               // moistmin:
 0.5               // moistopt:
@@ -119,7 +121,7 @@
 2200              // initsoln:
 8.9               // initavln:
 //===========================================================
-// CMT06 // Wet Sedge Tundra - soil microbial activity (BGC) parameters and default initial conditions
+// CMT06 // Wet Sedge Tundra
 2.0               // rhq10:
 0.0               // moistmin:
 0.5               // moistopt:
@@ -139,7 +141,7 @@
 2698              // initsoln:
 0.48              // initavln:
 //===========================================================
-// CMT07 // Heath Tundra - soil microbial activity (BGC) parameters and default initial conditions
+// CMT07 // Heath Tundra
 2.0               // rhq10:
 0.0               // moistmin:
 0.5               // moistopt:
@@ -159,7 +161,7 @@
 1405               // initsoln:
 0.17              // initavln:
 //===========================================================
-// CMT12 // Lowland Boreal Wet Shrubland - soil microbial activity (BGC) parameters and default initial conditions
+// CMT12 // Lowland Boreal Wet Shrubland
 2.0               // rhq10:
 0.0               // moistmin:
 0.5               // moistopt:
@@ -179,7 +181,7 @@
 2177.91           // initsoln:
 0.8               // initavln:
 //===========================================================
-// CMT20 // EML Shrub Tundra - 
+// CMT20 // EML Shrub Tundra
 2.0               // rhq10:
 0.0               // moistmin:
 0.5               // moistopt:
@@ -199,7 +201,7 @@
 1904.10           // initsoln: was 1904.10
 4.0               // initavln:
 //===========================================================
-// CMT21 // EML Tussock Tundra -
+// CMT21 // EML Tussock Tundra
 2.0               // rhq10:
 0.0               // moistmin:
 0.5               // moistopt:

--- a/parameters/cmt_bgcvegetation.txt
+++ b/parameters/cmt_bgcvegetation.txt
@@ -257,7 +257,7 @@
 0.0          0.0          0.0          0.0          0.0          0.0          0.0          0.0          0.0          0.0          // initdeadn:
 //===========================================================
 // CMT07 // Heath Tundra 
-//Decid.     E.green      Forbs        Lichens      Grasses      Moss       Misc.       Misc.         Misc.        Misc.          // names: comments                  
+//Decid      EGreen       Forbs        Lichens      Grasses      Moss       PFT6         PFT7         PFT8         PFT9           // pftnames:
 400.0        400.0        400.0        400.0        400.0        400.0      0.0          0.0          0.0          0.0            // kc:
 75           75           75           75           75           75         0.0          0.0          0.0          0.0            // ki:
 -8.0         -8.0        -1.0         -8.0         -8.0         -1.0        0.0          0.0          0.0          0.0            // tmin:

--- a/parameters/cmt_bgcvegetation.txt
+++ b/parameters/cmt_bgcvegetation.txt
@@ -365,7 +365,7 @@
 0.0          0.0          0.0          0.0          0.0          0.0         0.0         0.0          0.0          0.0            // initdeadn:
 //===========================================================
 // CMT21 // EML Tussock Tundra
-//Betnan     Carex        Ericoid      Erivag       Feather     Lichen      OtherMoss    Rubcha     Sphagnum       Misc.           // names: comments
+//Betnan     Carex        Ericoid      Erivag       Feather     Lichen      OtherMoss    Rubcha     Sphagnum       PFT9           // pftnames:
 400.0        400.0        400.0        400.0        400.0        400.0       400.0       400.0       400.0         0.0            // kc:
 75           75           75           75           75           75          75          75          75            0.0            // ki:
 -8.0         -8.0        -8.0         -8.0         -8.0         -8.0        -8.0        -8.0        -8.0           0.0            // tmin:

--- a/parameters/cmt_bgcvegetation.txt
+++ b/parameters/cmt_bgcvegetation.txt
@@ -1,5 +1,8 @@
+// dvmdostem parameter file
+// Initial values for BGC plant physiological parameters
+// Maximum of 10 PFTs
 //===========================================================
-// CMT00 // Bare/Open Water/Snow and Ice?  ##JUNK VALUES!!!### - (max. 10 PFTs) (BGC) Plant physiological parameters and default initial conditions
+// CMT00 // Bare/Open Water/Snow and Ice?  // ##JUNK VALUES!!!###
 //PFT0       PFT1         PFT2         PFT3         PFT4         PFT5         PFT6         PFT7         PFT8         PFT9         // names: comments                  
 400.0        400.0        400.0        400.0        400.0        400.0        400.0        400.0        400.0        400.0        // kc:
 75           75           75           75           75           75           75           75           75           75           // ki:
@@ -35,7 +38,7 @@
 0.0          0.0          0.0          0.0          0.0          0.0          0.0          0.0          0.0          0.0          // initdeadc:
 0.0          0.0          0.0          0.0          0.0          0.0          0.0          0.0          0.0          0.0          // initdeadn:
 //===========================================================
-// CMT01 // Black Spruce Forest ###JUNK VALUES!!!###- (max. 10 PFTs) (BGC) Plant physiological parameters and default initial conditions
+// CMT01 // Black Spruce Forest // ###JUNK VALUES!!!###
 //PFT0       PFT1         PFT2         PFT3         PFT4         PFT5         PFT6         PFT7         PFT8         PFT9         // names: comments                  
 400.0        400.0        400.0        400.0        400.0        400.0        400.0        400.0        400.0        400.0        // kc:
 75           75           75           75           75           75           75           75           75           75           // ki:
@@ -71,7 +74,7 @@
 0.0          0.0          0.0          0.0          0.0          0.0          0.0          0.0          0.0          0.0          // initdeadc:
 0.0          0.0          0.0          0.0          0.0          0.0          0.0          0.0          0.0          0.0          // initdeadn:
 //===========================================================
-// CMT02 // White Spruce Forest ###JUNK VALUES!!!### - (max. 10 PFTs) (BGC) Plant physiological parameters and default initial conditions
+// CMT02 // White Spruce Forest // ###JUNK VALUES!!!###
 //PFT0       PFT1         PFT2         PFT3         PFT4         PFT5         PFT6         PFT7         PFT8         PFT9         // names: comments                  
 400.0        400.0        400.0        400.0        400.0        400.0        400.0        400.0        400.0        400.0        // kc:
 75           75           75           75           75           75           75           75           75           75           // ki:
@@ -107,7 +110,7 @@
 0.0          0.0          0.0          0.0          0.0          0.0          0.0          0.0          0.0          0.0          // initdeadc:
 0.0          0.0          0.0          0.0          0.0          0.0          0.0          0.0          0.0          0.0          // initdeadn:
 //===========================================================
-// CMT03 // Boreal Deciduous Forest ###JUNK VALUES!!!### - (max. 10 PFTs) (BGC) Plant physiological parameters and default initial conditions
+// CMT03 // Boreal Deciduous Forest // ###JUNK VALUES!!!###
 //PFT0       PFT1         PFT2         PFT3         PFT4         PFT5         PFT6         PFT7         PFT8         PFT9         // names: comments                  
 400.0        400.0        400.0        400.0        400.0        400.0        400.0        400.0        400.0        400.0        // kc:
 75           75           75           75           75           75           75           75           75           75           // ki:
@@ -143,7 +146,7 @@
 0.0          0.0          0.0          0.0          0.0          0.0          0.0          0.0          0.0          0.0          // initdeadc:
 0.0          0.0          0.0          0.0          0.0          0.0          0.0          0.0          0.0          0.0          // initdeadn:
 //===========================================================
-// CMT04 // Shrub Tundra - (max. 10 PFTs over 1 soil column) (BGC) Plant physiological parameters and default initial conditions
+// CMT04 // Shrub Tundra
 //Salix      Betula       Decid.       E.green      Sedges       Forbs        Grasses      Lichens      Feather      Misc1.       // names: comments                  
 400.0        400.0        400.0        400.0        400.0        400.0        400.0        400.0        400.0        0.0          // kc:
 75           75           75           75           75           75           75           75           75           0.0          // ki:
@@ -179,7 +182,7 @@
 0.0          0.0          0.0          0.0          0.0          0.0          0.0          0.0          0.0          0.0          // initdeadc:
 0.0          0.0          0.0          0.0          0.0          0.0          0.0          0.0          0.0          0.0          // initdeadn:
 //==========================================================
-// CMT05 // Tussock Tundra (updated 1/15/2016 JDC) - (max. 10 PFTs) Plant physiological parameters and default initial conditions
+// CMT05 // Tussock Tundra // (updated 1/15/2016 JDC)
 //Betula     Decid.       E.green      Sedges       Forbs        Lichens      Feather.     Sphag.       Misc1.       Misc2.       // names: comments                  
 400.0        400.0        400.0        400.0        400.0        400.0        400.0        400.0        0.0          0.0          // kc:
 75           75           75           75           75           75           75           75           0.0          0.0          // ki:
@@ -215,7 +218,7 @@
 0.0          0.0          0.0          0.0          0.0          0.0          0.0          0.0          0.0          0.0          // initdeadc:
 0.0          0.0          0.0          0.0          0.0          0.0          0.0          0.0          0.0          0.0          // initdeadn:
 //===========================================================
-// CMT06 // Wet Sedge Tundra - (max. 10 PFTs over 1 soil column) Plant physiological parameters and default initial conditions
+// CMT06 // Wet Sedge Tundra 
 //Decid.     Sedges       Grasses      Forbs        Lichens      Feather      Sphag.       PFT7         PFT8         PFT9         // names: comments                  
 400.0        400.0        400.0        400.0        400.0        400.0        400.0        0.0          0.0          0.0          // kc:
 75           75           75           75           75           75           75           0.0          0.0          0.0          // ki:
@@ -251,7 +254,7 @@
 0.0          0.0          0.0          0.0          0.0          0.0          0.0          0.0          0.0          0.0          // initdeadc:
 0.0          0.0          0.0          0.0          0.0          0.0          0.0          0.0          0.0          0.0          // initdeadn:
 //===========================================================
-// CMT07 // Heath Tundra - (max. 10 PFTs over 1 soil column) (BGC) Plant physiological parameters and default initial conditions
+// CMT07 // Heath Tundra 
 //Decid.     E.green      Forbs        Lichens      Grasses      Moss       Misc.       Misc.         Misc.        Misc.          // names: comments                  
 400.0        400.0        400.0        400.0        400.0        400.0      0.0          0.0          0.0          0.0            // kc:
 75           75           75           75           75           75         0.0          0.0          0.0          0.0            // ki:
@@ -287,7 +290,7 @@
 0.0          0.0          0.0          0.0          0.0          0.0        0.0          0.0          0.0          0.0            // initdeadc:
 0.0          0.0          0.0          0.0          0.0          0.0        0.0          0.0          0.0          0.0            // initdeadn:
 //===========================================================
-// CMT12 // Lowland Boreal Wet Shrubland - (max. 10 PFTs over 1 soil column) (BGC) Plant physiological parameters and default initial conditions
+// CMT12 // Lowland Boreal Wet Shrubland 
 //DecShrub   EvrShrub     DecTree     EvrTree       Forbs        Gram         Feather      Lichen       Equisetum    Misc.        // names: comments 
 400.0        400.0        400.0        400.0        400.0        400.0        400.0        400.0        400.0        0.0          // kc:
 75           75           75           75           75           75           75           75           75           0.0          // ki:
@@ -323,7 +326,7 @@
 0.0          0.0          0.0          0.0          0.0          0.0          0.0          0.0          0.0          0.0          // initdeadc:
 0.0          0.0          0.0          0.0          0.0          0.0          0.0          0.0          0.0          0.0          // initdeadn:
 //===========================================================
-// CMT20 // EML Shrub Tundra - 
+// CMT20 // EML Shrub Tundra
 //Betnan     Carex       Ericoid      Feather       Lichen      OthMoss     Rubcha       Misc1        Misc2        Misc3          // names: comments
 400.0        400.0        400.0        400.0        400.0        400.0       400.0       0.0          0.0          0.0            // kc:
 75           75           75           75           75           75          75          0.0          0.0          0.0            // ki:
@@ -359,7 +362,7 @@
 0.0          0.0          0.0          0.0          0.0          0.0         0.0         0.0          0.0          0.0            // initdeadc:
 0.0          0.0          0.0          0.0          0.0          0.0         0.0         0.0          0.0          0.0            // initdeadn:
 //===========================================================
-// CMT21 // EML Tussock Tundra -
+// CMT21 // EML Tussock Tundra
 //Betnan     Carex        Ericoid      Erivag       Feather     Lichen      OtherMoss    Rubcha     Sphagnum       Misc.           // names: comments
 400.0        400.0        400.0        400.0        400.0        400.0       400.0       400.0       400.0         0.0            // kc:
 75           75           75           75           75           75          75          75          75            0.0            // ki:

--- a/parameters/cmt_bgcvegetation.txt
+++ b/parameters/cmt_bgcvegetation.txt
@@ -149,7 +149,7 @@
 0.0          0.0          0.0          0.0          0.0          0.0          0.0          0.0          0.0          0.0          // initdeadn:
 //===========================================================
 // CMT04 // Shrub Tundra
-//Salix      Betula       Decid.       E.green      Sedges       Forbs        Grasses      Lichens      Feather      Misc1.       // names: comments                  
+//Salix      Betula       Decid        EGreen       Sedges       Forbs        Grasses      Lichens      Feather      PFT9         // pftnames:
 400.0        400.0        400.0        400.0        400.0        400.0        400.0        400.0        400.0        0.0          // kc:
 75           75           75           75           75           75           75           75           75           0.0          // ki:
 -8.0         -8.0        -8.0         -8.0         -8.0         -8.0         -8.0         -8.0         -8.0          0.0          // tmin:

--- a/parameters/cmt_bgcvegetation.txt
+++ b/parameters/cmt_bgcvegetation.txt
@@ -221,7 +221,7 @@
 0.0          0.0          0.0          0.0          0.0          0.0          0.0          0.0          0.0          0.0          // initdeadn:
 //===========================================================
 // CMT06 // Wet Sedge Tundra 
-//Decid.     Sedges       Grasses      Forbs        Lichens      Feather      Sphag.       PFT7         PFT8         PFT9         // names: comments                  
+//Decid      Sedges       Grasses      Forbs        Lichens      Feather      Sphag        PFT7         PFT8         PFT9         // pftnames
 400.0        400.0        400.0        400.0        400.0        400.0        400.0        0.0          0.0          0.0          // kc:
 75           75           75           75           75           75           75           0.0          0.0          0.0          // ki:
 -5.0         -5.0        -5.0         -5.0         -5.0         -5.0         -5.0          0.0          0.0          0.0          // tmin:

--- a/parameters/cmt_bgcvegetation.txt
+++ b/parameters/cmt_bgcvegetation.txt
@@ -185,7 +185,7 @@
 0.0          0.0          0.0          0.0          0.0          0.0          0.0          0.0          0.0          0.0          // initdeadn:
 //==========================================================
 // CMT05 // Tussock Tundra // (updated 1/15/2016 JDC)
-//Betula     Decid.       E.green      Sedges       Forbs        Lichens      Feather.     Sphag.       Misc1.       Misc2.       // names: comments                  
+//Betula     Decid        EGreen       Sedges       Forbs        Lichens      Feather      Sphag        PFT8         PFT9         // pftnames:
 400.0        400.0        400.0        400.0        400.0        400.0        400.0        400.0        0.0          0.0          // kc:
 75           75           75           75           75           75           75           75           0.0          0.0          // ki:
 -5.0         -5.0        -5.0         -5.0         -5.0         -5.0         -5.0         -5.0          0.0          0.0          // tmin:

--- a/parameters/cmt_bgcvegetation.txt
+++ b/parameters/cmt_bgcvegetation.txt
@@ -293,7 +293,7 @@
 0.0          0.0          0.0          0.0          0.0          0.0        0.0          0.0          0.0          0.0            // initdeadn:
 //===========================================================
 // CMT12 // Lowland Boreal Wet Shrubland 
-//DecShrub   EvrShrub     DecTree     EvrTree       Forbs        Gram         Feather      Lichen       Equisetum    Misc.        // names: comments 
+//DecShrub   EvrShrub     DecTree      EvrTree      Forbs        Gram         Feather      Lichen       Equisetum    PFT9         // pftnames:
 400.0        400.0        400.0        400.0        400.0        400.0        400.0        400.0        400.0        0.0          // kc:
 75           75           75           75           75           75           75           75           75           0.0          // ki:
 -8.0         -8.0        -8.0         -8.0         -8.0         -8.0         -8.0         -8.0         -8.0          0.0          // tmin:

--- a/parameters/cmt_bgcvegetation.txt
+++ b/parameters/cmt_bgcvegetation.txt
@@ -1,6 +1,8 @@
 // dvmdostem parameter file
 // Initial values for BGC plant physiological parameters
 // Maximum of 10 PFTs
+// PFT names should be CamelCase and must not have a period in them!
+//
 //===========================================================
 // CMT00 // Bare/Open Water/Snow and Ice?  // ##JUNK VALUES!!!###
 //PFT0       PFT1         PFT2         PFT3         PFT4         PFT5         PFT6         PFT7         PFT8         PFT9         // names: comments                  
@@ -39,7 +41,7 @@
 0.0          0.0          0.0          0.0          0.0          0.0          0.0          0.0          0.0          0.0          // initdeadn:
 //===========================================================
 // CMT01 // Black Spruce Forest // ###JUNK VALUES!!!###
-//PFT0       PFT1         PFT2         PFT3         PFT4         PFT5         PFT6         PFT7         PFT8         PFT9         // names: comments                  
+//BlackSpr   Decid        DecidShrub   EGreen       Sphag      Feather        Moss         Lichen        Forbs       Sedge        // pftnames:
 400.0        400.0        400.0        400.0        400.0        400.0        400.0        400.0        400.0        400.0        // kc:
 75           75           75           75           75           75           75           75           75           75           // ki:
 -8.0         -8.0        -8.0         -8.0         -8.0         -8.0         -8.0         -8.0         -8.0         -8.0          // tmin:

--- a/parameters/cmt_calparbgc.txt
+++ b/parameters/cmt_calparbgc.txt
@@ -158,7 +158,7 @@
 0.00025       // kdcsomcr:
 //===========================================================
 // CMT07 // Heath Tundra //
-//Decid.     E.green      Forbs        Lichens      Grasses      Moss       Misc.       Misc.      Misc.        Misc.        // names: comments
+//Decid     EGreen        Forbs        Lichens      Grasses      Moss       PFT6        PFT7       PFT8         PFT9         // pftnames:
 26.40       89.70        23.0        113.1          4.8         38.1        0.0         0.0        0.0          0.0          // cmax:
  4.50       10.72         4.50         2.120        2.29         1.00       0.0         0.0        0.0          0.0          // nmax:
  0.065       0.048        0.075        0.0120       0.000001     0.079      0.0         0.0        0.0          0.0          // cfall(0): leave

--- a/parameters/cmt_calparbgc.txt
+++ b/parameters/cmt_calparbgc.txt
@@ -114,7 +114,7 @@
 0.00007  // kdcsomcr:
 //===========================================================
 // CMT05 // Tussock Tundra // Updated by E.E. calibration, April, May 2017
-//    Betula       Decid.      E.green       Sedges        Forbs      Lichens     Feather.       Sphag.       Misc1.       Misc2.
+//    Betula        Decid       EGreen       Sedges        Forbs      Lichens      Feather        Sphag         PFT8         PFT9 // pftnames:
   400.000000   250.000000   800.000000  2000.000000   120.000000   300.000000   350.000000   200.000000     0.000000     0.000000 // cmax: 
     7.000000     8.200000     9.000000    27.600000     4.500000     3.000000     3.000000     3.000000     0.000000     0.000000 // nmax: 
     0.009970     0.109998     0.090001     0.059997     0.010000     0.065000     0.099000     0.065000     0.000000     0.000000 // cfall(0): 

--- a/parameters/cmt_calparbgc.txt
+++ b/parameters/cmt_calparbgc.txt
@@ -92,7 +92,7 @@
 0.0000108       // kdcsomcr:
 //===========================================================
 // CMT04 // Shrub Tundra // 
-//Salix      Betula      Decid.       E.green      Sedges       Forbs       Grasses     Lichens     Feather   Misc1.     // names: comments
+//Salix      Betula       Decid        EGreen       Sedges       Forbs      Grasses      Lichens      Feather    PFT9    // pftnames:
 380.00       750.00     110.00        25.00        30.00        77.00       127.00       41.00       64.00       0.0     // cmax:
  6.00         7.00        8.20         9.00         7.60         4.50        30.00        3.000       3.00       0.0     // nmax:
  0.19         0.02        0.0011       0.0005       0.006        0.00300     0.00150      0.04000     0.01700    0.0     // cfall(0): leave

--- a/parameters/cmt_calparbgc.txt
+++ b/parameters/cmt_calparbgc.txt
@@ -136,7 +136,7 @@
 0.000005     // kdcsomcr
 //===========================================================
 // CMT06 // Wet Sedge Tundra //
-//Decid.     Sedges       Grasses      Forbs        Lichens      Feather      Sphag.       PFT7     PFT8      PFT9        // names: comments
+//Decid      Sedges       Grasses      Forbs        Lichens      Feather      Sphag        PFT7     PFT8      PFT9        // pftnames
 36.80        585.6       140.8         68.5         10.0         48.00        19.3          0.0      0.0       0.0        // cmax:
  4.10         14.01        8.29         9.20         4.32         3.00         3.32         0.0      0.0       0.0        // nmax:
  0.190        0.00001      0.000005     0.0037       0.096        0.038        0.000008     0.0      0.0       0.0        // cfall(0): leave

--- a/parameters/cmt_calparbgc.txt
+++ b/parameters/cmt_calparbgc.txt
@@ -1,5 +1,6 @@
 // dvmdostem parameter file for BGC calibrated parameters
 // Maximum of 10 PFTs over one soil column.
+// PFT names should be CamelCase and must not have a period in them!
 //
 //===========================================================
 // CMT00 // BARE GROUND OPEN WATER SNOW AND ICE // ##THESE ARE JUNK VALUES###
@@ -25,7 +26,7 @@
 0.0000108       // kdcsomcr:
 //===========================================================
 // CMT01 // Black Spruce Forest // ###THESE ARE JUNK VALUES!!!###
-//BlkSpr.    Decid.     Decid.Shrub   E.green      Sphag.      Feather       Moss         Lichen        Forbs       Sedge
+//BlackSpr   Decid        DecidShrub   EGreen       Sphag      Feather        Moss         Lichen        Forbs       Sedge        // pftnames:
 2200         2200.0       1250.0         83.0       50.0         27.0         28.0         260.0         250.0       0.0          // cmax:
 3.3          3.3          2.5          0.80         1.4          1.5          2.2          1.1          2.1          0.0          // nmax:
 0.018        0.018        0.03        0.110        0.083        0.083        0.083        0.001        0.018         0.0          // cfall(0): leave

--- a/parameters/cmt_calparbgc.txt
+++ b/parameters/cmt_calparbgc.txt
@@ -224,7 +224,7 @@
 0.00025    // kdcsomcr:
 //===========================================================
 // CMT21 // EML Tussock Tundra
-//Betnan   Carex       Ericoid    Erivag       Feather   Lichen     OtherMoss  Rubcha     Sphagnum    Misc.    // names: comments
+//Betnan   Carex       Ericoid    Erivag       Feather   Lichen     OtherMoss  Rubcha     Sphagnum    PFT9     // pftnames:
 180.00    680.00     1320.00    1505.00        0.81     103.0      928.0      345.0       21.0        0.0      // cmax:
  7.20      15.00       28.20      40.00        0.50       3.00      10.0        5.0        2.5        0.0      // nmax:
  0.25       0.37        0.0500     0.0010      0.017      0.020      0.040      0.52       0.009      0.0      // cfall(0): leaf

--- a/parameters/cmt_calparbgc.txt
+++ b/parameters/cmt_calparbgc.txt
@@ -1,5 +1,8 @@
+// dvmdostem parameter file for BGC calibrated parameters
+// Maximum of 10 PFTs over one soil column.
+//
 //===========================================================
-// CMT00 // SHOULD THIS BE BARE GROUND/OPEN WATER/SNOW AND ICE??? ##THESE ARE JUNK VALUES### - (max. 10 PFTs over 1 soil column) (BGC) plant calibrated parameters
+// CMT00 // BARE GROUND OPEN WATER SNOW AND ICE // ##THESE ARE JUNK VALUES###
 //PFT0      PFT1        PFT2         PFT3         PFT4         PFT5         PFT6         PFT7         PFT8         PFT9         // names: comments
 939.0       1255.0        50.0         83.0         50.0         27.0         28.0         26.0         25.0         0.0          // cmax:
 3.1          2.5          2.5          0.80         1.4          1.5          2.2          1.1          2.1          0.0          // nmax:
@@ -21,7 +24,7 @@
 0.0020805       // kdcsompr:
 0.0000108       // kdcsomcr:
 //===========================================================
-// CMT01 // Black Spruce Forest ###THESE ARE JUNK VALUES!!!###- (max. 10 PFTs over 1 soil column) (BGC) plant calibrated parameters
+// CMT01 // Black Spruce Forest // ###THESE ARE JUNK VALUES!!!###
 //BlkSpr.    Decid.     Decid.Shrub   E.green      Sphag.      Feather       Moss         Lichen        Forbs       Sedge
 2200         2200.0       1250.0         83.0       50.0         27.0         28.0         260.0         250.0       0.0          // cmax:
 3.3          3.3          2.5          0.80         1.4          1.5          2.2          1.1          2.1          0.0          // nmax:
@@ -43,7 +46,7 @@
 0.0020805       // kdcsompr:
 0.0000108       // kdcsomcr:
 //===========================================================
-// CMT02 // White Spruce Forest ###THESE ARE JUNK VALUES!!!###- (max. 10 PFTs over 1 soil column) (BGC) plant calibrated parameters
+// CMT02 // White Spruce Forest // ###THESE ARE JUNK VALUES!!!###
 //PFT0       PFT1        PFT2         PFT3         PFT4         PFT5         PFT6         PFT7         PFT8         PFT9         // names: comments
 939.0        255.0        50.0         83.0         50.0         27.0         28.0         26.0         25.0         0.0          // cmax:
 3.1          2.5          2.5          0.80         1.4          1.5          2.2          1.1          2.1          0.0          // nmax:
@@ -65,7 +68,7 @@
 0.0020805       // kdcsompr:
 0.0000108       // kdcsomcr:
 //===========================================================
-//CMT03 // Boreal Deciduous Forest ###THESE ARE JUNK VALUES!!!###- (max. 10 PFTs over 1 soil column) (BGC) plant calibrated parameters
+//CMT03 // Boreal Deciduous Forest // ###THESE ARE JUNK VALUES!!!###
 //PFT0       PFT1        PFT2         PFT3         PFT4         PFT5         PFT6         PFT7         PFT8         PFT9         // names: comments
 939.0        255.0        50.0         83.0         50.0         27.0         28.0         26.0         25.0         0.0          // cmax:
 3.1          2.5          2.5          0.80         1.4          1.5          2.2          1.1          2.1          0.0          // nmax:
@@ -87,7 +90,7 @@
 0.0020805       // kdcsompr:
 0.0000108       // kdcsomcr:
 //===========================================================
-// CMT04 // Shrub Tundra - (max. 10 PFTs over 1 soil column) (BGC) plant calibrated parameters
+// CMT04 // Shrub Tundra // 
 //Salix      Betula      Decid.       E.green      Sedges       Forbs       Grasses     Lichens     Feather   Misc1.     // names: comments
 380.00       750.00     110.00        25.00        30.00        77.00       127.00       41.00       64.00       0.0     // cmax:
  6.00         7.00        8.20         9.00         7.60         4.50        30.00        3.000       3.00       0.0     // nmax:
@@ -109,7 +112,7 @@
 0.02     // kdcsompr:
 0.00007  // kdcsomcr:
 //===========================================================
-// CMT05 // Tussock Tundra - Updated by E.E. calibration, April, May 2017
+// CMT05 // Tussock Tundra // Updated by E.E. calibration, April, May 2017
 //    Betula       Decid.      E.green       Sedges        Forbs      Lichens     Feather.       Sphag.       Misc1.       Misc2.
   400.000000   250.000000   800.000000  2000.000000   120.000000   300.000000   350.000000   200.000000     0.000000     0.000000 // cmax: 
     7.000000     8.200000     9.000000    27.600000     4.500000     3.000000     3.000000     3.000000     0.000000     0.000000 // nmax: 
@@ -131,7 +134,7 @@
 0.009000     // kdcsompr
 0.000005     // kdcsomcr
 //===========================================================
-// CMT06 // Wet Sedge Tundra - (max. 10 PFTs over 1 soil column) (BGC) plant calibrated parameters
+// CMT06 // Wet Sedge Tundra //
 //Decid.     Sedges       Grasses      Forbs        Lichens      Feather      Sphag.       PFT7     PFT8      PFT9        // names: comments
 36.80        585.6       140.8         68.5         10.0         48.00        19.3          0.0      0.0       0.0        // cmax:
  4.10         14.01        8.29         9.20         4.32         3.00         3.32         0.0      0.0       0.0        // nmax:
@@ -153,7 +156,7 @@
 0.030       // kdcsompr:
 0.00025       // kdcsomcr:
 //===========================================================
-// CMT07 // Heath Tundra - (max. 10 PFTs over 1 soil column) (BGC) plant calibrated parameters
+// CMT07 // Heath Tundra //
 //Decid.     E.green      Forbs        Lichens      Grasses      Moss       Misc.       Misc.      Misc.        Misc.        // names: comments
 26.40       89.70        23.0        113.1          4.8         38.1        0.0         0.0        0.0          0.0          // cmax:
  4.50       10.72         4.50         2.120        2.29         1.00       0.0         0.0        0.0          0.0          // nmax:
@@ -175,7 +178,7 @@
 0.0062      // kdcsompr:
 0.0000005   // kdcsomcr:
 //===========================================================
-// CMT12 // Lowland Boreal Wet Shrubland - (max. 10 PFTs over 1 soil column) (BGC) plant calibrated parameters
+// CMT12 // Lowland Boreal Wet Shrubland //
 //DecShrub   EvrShrub      DecTree      EvrTree     Forbs        Gram       Feather     Lichen     Equisetum    Misc.        // names: comments 
 370.00       120.00      700.00      1470.00       285.0       2300.0      135.0        19.0       75.0          0.0          // cmax:
 10.20         9.00         8.20        10.00         3.00        27.00       3.0         3.0        4.0          0.0          // nmax:
@@ -197,7 +200,7 @@
 0.0085      // kdcsompr:
 0.000025    // kdcsomcr:
 //===========================================================
-// CMT20 // EML Shrub Tundra - 
+// CMT20 // EML Shrub Tundra //
 //Betnan     Carex       Ericoid      Feather       Lichen      OthMoss   Rubcha     Misc1    Misc2   Misc3      // names: comments
 2470.00    300.00      1710.00       510.00       108.0        88.0      285.0        0.0      0.0     0.0       // cmax:
 70.20       20.00        30.20        23.00         3.00       10.00      13.0        0.0      0.0     0.0       // nmax:
@@ -219,7 +222,7 @@
 0.91      // kdcsompr:
 0.00025    // kdcsomcr:
 //===========================================================
-// CMT21 // EML Tussock Tundra -
+// CMT21 // EML Tussock Tundra
 //Betnan   Carex       Ericoid    Erivag       Feather   Lichen     OtherMoss  Rubcha     Sphagnum    Misc.    // names: comments
 180.00    680.00     1320.00    1505.00        0.81     103.0      928.0      345.0       21.0        0.0      // cmax:
  7.20      15.00       28.20      40.00        0.50       3.00      10.0        5.0        2.5        0.0      // nmax:

--- a/parameters/cmt_calparbgc.txt
+++ b/parameters/cmt_calparbgc.txt
@@ -180,7 +180,7 @@
 0.0000005   // kdcsomcr:
 //===========================================================
 // CMT12 // Lowland Boreal Wet Shrubland //
-//DecShrub   EvrShrub      DecTree      EvrTree     Forbs        Gram       Feather     Lichen     Equisetum    Misc.        // names: comments 
+//DecShrub   EvrShrub     DecTree      EvrTree       Forbs        Gram      Feather     Lichen    Equisetum      PFT9         // pftnames:
 370.00       120.00      700.00      1470.00       285.0       2300.0      135.0        19.0       75.0          0.0          // cmax:
 10.20         9.00         8.20        10.00         3.00        27.00       3.0         3.0        4.0          0.0          // nmax:
  0.0950       0.0006       0.0500       0.0009       0.0027       0.0009     0.0278     0.0788    0.0020       0.0          // cfall(0): leaf

--- a/parameters/cmt_dimground.txt
+++ b/parameters/cmt_dimground.txt
@@ -21,7 +21,7 @@
 0.04025            // coefminea:
 0.0532             // coefmineb:
 //===========================================================
-// CMT01 // Black Spruce Forest
+// CMT01 // Black Spruce Forest // ### THESE ARE JUNK VALUES!!! ###
 // Snow characteristics
 350                // snwdenmax:  max. snow density (kg/m3)
 120                // snwdennew:  new (min.) snow density (kg/m3)

--- a/parameters/cmt_dimground.txt
+++ b/parameters/cmt_dimground.txt
@@ -1,5 +1,7 @@
+// dvmdostem parameter file
+// ground structure and dimensions
 //===========================================================
-// CMT00 // Default TEM Community - ground structure/dimension
+// CMT00 // BARE GROUND OPEN WATER ICE AND SNOW
 // Snow characteristics
 350                // snwdenmax:  max. snow density (kg/m3)
 120                // snwdennew:  new (min.) snow density (kg/m3)
@@ -19,7 +21,7 @@
 0.04025            // coefminea:
 0.0532             // coefmineb:
 //===========================================================
-// CMT01 // CMT1 TEM Community - ground structure/dimension
+// CMT01 // Black Spruce Forest
 // Snow characteristics
 350                // snwdenmax:  max. snow density (kg/m3)
 120                // snwdennew:  new (min.) snow density (kg/m3)
@@ -39,7 +41,7 @@
 0.04025            // coefminea:
 0.0532             // coefmineb:
 //===========================================================
-// CMT02 // CMT2 TEM Community - ground structure/dimension
+// CMT02 // White Spruce Forest
 // Snow characteristics
 350                // snwdenmax:  max. snow density (kg/m3)
 120                // snwdennew:  new (min.) snow density (kg/m3)
@@ -59,7 +61,7 @@
 0.04025            // coefminea:
 0.0532             // coefmineb:
 //===========================================================
-// CMT03 // CMT3 TEM Community - ground structure/dimension
+// CMT03 // Boreal Deciduous Forest
 // Snow characteristics
 350                // snwdenmax:  max. snow density (kg/m3)
 120                // snwdennew:  new (min.) snow density (kg/m3)
@@ -79,7 +81,7 @@
 0.03939            // coefminea:
 0.78               // coefmineb:
 //===========================================================
-// CMT04 // Shrub Tundra - ground structure/dimension (NOTE: Was listed as Tussock Tundra. 11/2015)
+// CMT04 // Shrub Tundra
 // Snow characteristics
 350                // snwdenmax:  max. snow density (kg/m3)
 120                // snwdennew:  new (min.) snow density (kg/m3)
@@ -99,7 +101,7 @@
 0.0966              // coefminea:
 0.7851              // coefmineb:
 //===========================================================
-// CMT05 // Tussock Tundra (updated 1/15/2016 JDC)- ground structure/dimension 
+// CMT05 // Tussock Tundra // (updated 1/15/2016 JDC)
 // Snow characteristics
 350                // snwdenmax:  max. snow density (kg/m3)
 120                // snwdennew:  new (min.) snow density (kg/m3)
@@ -119,7 +121,7 @@
 0.0966             // coefminea:
 0.8239             // coefmineb:
 //===========================================================
-// CMT06 // Wet Sedge Tundra - ground structure/dimension
+// CMT06 // Wet Sedge Tundra
 // Snow characteristics
 350                // snwdenmax:  max. snow density (kg/m3)
 120                // snwdennew:  new (min.) snow density (kg/m3)
@@ -139,7 +141,7 @@
 0.0966              // coefminea:
 0.8239              // coefmineb:
 //===========================================================
-// CMT07 // Heath Tundra - ground structure/dimension
+// CMT07 // Heath Tundra
 // Snow characteristics
 350                // snwdenmax:  max. snow density (kg/m3)
 120                // snwdennew:  new (min.) snow density (kg/m3)
@@ -159,7 +161,7 @@
 0.0966              // coefminea:
 0.781               // coefmineb:
 //===========================================================
-// CMT12 // Lowland Boreal Wet Shrubland - more comment?
+// CMT12 // Lowland Boreal Wet Shrubland 
 // Snow characteristics
 350                // snwdenmax:  max. snow density (kg/m3)
 120                // snwdennew:  new (min.) snow density (kg/m3)
@@ -179,7 +181,7 @@
 0.0996             // coefminea:
 0.6931             // coefmineb:
 //===========================================================
-// CMT20 // EML Shrub Tundra - 
+// CMT20 // EML Shrub Tundra
 // Snow characteristics
 350                // snwdenmax:  max. snow density (kg/m3)
 120                // snwdennew:  new (min.) snow density (kg/m3)
@@ -199,7 +201,7 @@
 0.0996             // coefminea:
 0.7810             // coefmineb:
 //===========================================================
-// CMT21 // EML Tussock Tundra -
+// CMT21 // EML Tussock Tundra
 // Snow characteristics
 350                // snwdenmax:  max. snow density (kg/m3)
 120                // snwdennew:  new (min.) snow density (kg/m3)

--- a/parameters/cmt_dimvegetation.txt
+++ b/parameters/cmt_dimvegetation.txt
@@ -1,5 +1,8 @@
+// dvmdostem parameter file
+// Plant structure and dimensions
+// Max 10 PFTs
 //===========================================================
-// CMT00 // Default TEM Community - (max. 10 PFTs) Plant structure/dimension
+// CMT00 // BARE GROUND OPEN WATER SNOW AND ICE
 //PFT0      PFT1        PFT2         PFT3         PFT4         PFT5         PFT6         PFT7         PFT8         PFT9         // names: comments                  
 1.00        1.00        0.00         0.00         0.00         0.00         0.00         0.00         0.00         0.           // vegfrac: vegetation coverage on land - 0 indicates that PFT does't exist
 1           1           1            1            0            0            0            0            0            0            // ifwoody: woody plants (1) or not (0)
@@ -42,7 +45,7 @@
 1.1         0.0         0.0          0.8          0.5          1.0          1.5          1.9          0.0          0            // envlai[10]: monthly LAI for a year, used for static input of LAI 
 1.0         0.0         0.0          0.7          0.8          0.5          1.5          2.1          1.1          0            // envlai[11]: monthly LAI for a year, used for static input of LAI
 //===========================================================
-// CMT01 // CMT1 TEM Community - (max. 10 PFTs) Plant structure/dimension
+// CMT01 // Black Spruce Forest
 //PFT0      PFT1        PFT2         PFT3         PFT4         PFT5         PFT6         PFT7         PFT8         PFT9         // names: comments                  
 1.00        1.00        1.00         1.00         1.00         1.00         1.00         1.00         1.00         0.           // vegfrac: vegetation coverage on land - 0 indicates that PFT does't exist
 1           1           1            1            0            0            0            0            0            0            // ifwoody: woody plants (1) or not (0)
@@ -85,7 +88,7 @@
 1.1         1.5         0.0          0.8          0.5          1.0          1.5          1.9          0.0          0            // envlai[10]: monthly LAI for a year, used for static input of LAI 
 1.0         1.5         0.0          0.7          0.8          0.5          1.5          2.1          1.1          0            // envlai[11]: monthly LAI for a year, used for static input of LAI
 //===========================================================
-// CMT02 // CMT2 TEM Community - (max. 10 PFTs) Plant structure/dimension
+// CMT02 // White Spruce Forest
 //PFT0      PFT1        PFT2         PFT3         PFT4         PFT5         PFT6         PFT7         PFT8         PFT9         // names: comments                  
 1.00        1.00        1.00         1.00         1.00         1.00         1.00         1.00         1.00         0.           // vegfrac: vegetation coverage on land - 0 indicates that PFT does't exist
 1           1           1            1            0            0            0            0            0            0            // ifwoody: woody plants (1) or not (0)
@@ -128,7 +131,7 @@
 1.1         0.0         0.0          0.8          0.5          1.0          1.5          1.9          0.0          0            // envlai[10]: monthly LAI for a year, used for static input of LAI 
 1.0         0.0         0.0          0.7          0.8          0.5          1.5          2.1          1.1          0            // envlai[11]: monthly LAI for a year, used for static input of LAI
 //===========================================================
-// CMT03 // CMT3 TEM Community - (max. 10 PFTs) Plant structure/dimension
+// CMT03 // Boreal Deciduous Forest
 //PFT0      PFT1        PFT2         PFT3         PFT4         PFT5         PFT6         PFT7         PFT8         PFT9         // names: comments                  
 1.00        1.00        1.00         1.00         1.00         1.00         1.00         1.00         1.00         0.           // vegfrac: vegetation coverage on land - 0 indicates that PFT does't exist
 1           1           1            1            0            0            0            0            0            0            // ifwoody: woody plants (1) or not (0)
@@ -171,7 +174,7 @@
 1.1         0.0         0.0          0.8          0.5          1.0          1.5          1.9          0.0          0            // envlai[10]: monthly LAI for a year, used for static input of LAI 
 1.0         0.0         0.0          0.7          0.8          0.5          1.5          2.1          1.1          0            // envlai[11]: monthly LAI for a year, used for static input of LAI
 //===========================================================
-// CMT04 // Shrub Tundra - (max. 10 PFTs over 1 soil column) Plant structure/dimension
+// CMT04 // Shrub Tundra
 //Salix     Betula      Decid.       E.green      Sedges       Forbs        Grasses      Lichens      Feather      Misc1.       // names: comments                  
 1.00        1.00        1.00         1.00         1.00         1.00         1.00         1.00         1.00         0.           // vegfrac: vegetation coverage on land - 0 indicates that PFT does't exist
 1           1           1            1            0            0            0            0            0            0            // ifwoody: woody plants (1) or not (0)
@@ -214,7 +217,7 @@
 1.1         0.0         0.0          0.8          0.5          1.0          1.5          1.9          0.0          0            // envlai[10]: monthly LAI for a year, used for static input of LAI 
 1.0         0.0         0.0          0.7          0.8          0.5          1.5          2.1          1.1          0            // envlai[11]: monthly LAI for a year, used for static input of LAI
 //===========================================================
-// CMT05 // Tussock Tundra (updated 1/15/2016 JDC) - (max. 10 PFTs) (BGC) Plant structure/dimension
+// CMT05 // Tussock Tundra // (updated 1/15/2016 JDC)
 //Betula    Decid.      E.green      Sedges       Forbs        Lichens      Feather.     Sphag.       Misc1.       Misc2.       // names: comments                  
 0.01        0.01        0.01         0.01         0.01         0.01         0.01         0.01         0.           0.           // vegfrac: vegetation coverage on land - 0 indicates that PFT does't exist
 1           1           1            0            0            0            0            0            0            0            // ifwoody: woody plants (1) or not (0)
@@ -257,7 +260,7 @@
 0.0         0.0         0.8          0.0          1.0          2.00         2.00         2.00          0            0           // envlai[10]:
 0.0         0.0         0.7          0.0          0.5          2.00         2.00         2.00          0            0           // envlai[11]:
 //===========================================================
-// CMT06 // Wet Sedge Tundra - (max. 10 PFTs over 1 soil column) Plant structure/dimension
+// CMT06 // Wet Sedge Tundra
 //Decid.    Sedges      Grasses      Forbs        Lichens      Feather      Sphag.       PFT7         PFT8         PFT9         // names: comments                  
 1.00        1.00        1.00         1.00         1.00         1.00         1.00         0.00         0.00         0.00         // vegfrac: vegetation coverage on land - 0 indicates that PFT does't exist
 1           1           1            1            0            0            0            0            0            0            // ifwoody: woody plants (1) or not (0)
@@ -300,7 +303,7 @@
 1.1         0.0         0.0          0.8          1.5          1.5          1.5          0.00         0.00         0.00         // envlai[10]: monthly LAI for a year, used for static input of LAI 
 1.0         0.0         0.0          0.7          1.5          1.5          1.5          0.00         0.00         0.00         // envlai[11]: monthly LAI for a year, used for static input of LAI
 //===========================================================
-// CMT07 // Heath Tundra - (max. 10 PFTs over 1 soil column) (BGC) Plant structure/dimension
+// CMT07 // Heath Tundra
 //Decid.    E.green     Forbs        Lichens      Grasses      Moss         Misc.       Misc.         Misc.        Misc.        // names: comments                  
 1.00        1.00        1.00         1.00         1.00         1.00         0.00         0.00         0.00         0.00         // vegfrac: vegetation coverage on land - 0 indicates that PFT does't exist
 1           1           1            1            0            0            0            0            0            0            // ifwoody: woody plants (1) or not (0)
@@ -343,7 +346,7 @@
 1.1         0.0         0.0          0.8          0.5          1.0          0.00         0.00         0.00         0.00         // envlai[10]: monthly LAI for a year, used for static input of LAI 
 1.0         0.0         0.0          0.7          0.8          0.5          0.00         0.00         0.00         0.00         // envlai[11]: monthly LAI for a year, used for static input of LAI
 //===========================================================
-// CMT12 // Lowland Boreal Wet Shrubland - (max. 10 PFTs over 1 soil column) (BGC) Plant structure/dimension
+// CMT12 // Lowland Boreal Wet Shrubland
 //DecShrub   EvrShrub     DecTree      EvrTree      Forbs        Gram         Feather      Lichen       Equisetum    Misc.        // names: comments 
 1.00         1.00         1.00         1.00         1.00         1.00         1.00         1.00         1.00         0            // vegfrac: vegetation coverage on land - 0 indicates that PFT does't exist
 1            1            1            1            0            0            0            0            0            0            // ifwoody: woody plants (1) or not (0)
@@ -386,7 +389,7 @@
 0.0          0.8          0.0          0.8          1.0          0.0          2.00         2.00         0.8          0           // envlai[10]:
 0.0          0.7          0.0          0.7          0.5          0.0          2.00         2.00         0.7          0           // envlai[11]:
 //===========================================================
-// CMT20 // EML Shrub Tundra - 
+// CMT20 // EML Shrub Tundra
 //Betnan     Carex        Ericoid      Feather      Lichen      OthMoss       Rubcha       Misc1        Misc2        Misc3        // names: comments
 1.00         1.00         1.00         1.00         1.00         1.00         1.00         0            0            0            // vegfrac: vegetation coverage on land - 0 indicates that PFT does't exist
 1            0            1            0            0            0            1            0            0            0            // ifwoody: woody plants (1) or not (0)
@@ -429,7 +432,7 @@
 0.0          0.5          0.8          0.0          1.9          0.0          0.0          0.0          0.0          0.0          // envlai[10]:
 0.0          0.8          0.7          1.1          2.1          1.1          0.0          0.0          0.0          0.0          // envlai[11]:
 //===========================================================
-// CMT21 // EML Tussock Tundra -
+// CMT21 // EML Tussock Tundra
 //Betnan     Carex        Ericoid      Erivag       Feather     Lichen       OtherMoss    Rubcha      Sphagnum       Misc.           // names: comments
 0.01         0.01         0.01         0.01         0.01         0.01         0.01        0.01         0.01          0            // vegfrac: vegetation coverage on land - 0 indicates that PFT does't exist
 1            0            1            0            0            0            0            1            0            0            // ifwoody: woody plants (1) or not (0)

--- a/parameters/cmt_dimvegetation.txt
+++ b/parameters/cmt_dimvegetation.txt
@@ -349,7 +349,7 @@
 1.0         0.0         0.0          0.7          0.8          0.5          0.00         0.00         0.00         0.00         // envlai[11]: monthly LAI for a year, used for static input of LAI
 //===========================================================
 // CMT12 // Lowland Boreal Wet Shrubland
-//DecShrub   EvrShrub     DecTree      EvrTree      Forbs        Gram         Feather      Lichen       Equisetum    Misc.        // names: comments 
+//DecShrub   EvrShrub     DecTree      EvrTree      Forbs        Gram        Feather      Lichen      Equisetum      PFT9         // pftnames:
 1.00         1.00         1.00         1.00         1.00         1.00         1.00         1.00         1.00         0            // vegfrac: vegetation coverage on land - 0 indicates that PFT does't exist
 1            1            1            1            0            0            0            0            0            0            // ifwoody: woody plants (1) or not (0)
 1            0            1            0            0            0            0            0            0            0            // ifdeciwoody: deciduous woodland (1) or not (0)

--- a/parameters/cmt_dimvegetation.txt
+++ b/parameters/cmt_dimvegetation.txt
@@ -220,7 +220,7 @@
 1.0         0.0         0.0          0.7          0.8          0.5          1.5          2.1          1.1          0            // envlai[11]: monthly LAI for a year, used for static input of LAI
 //===========================================================
 // CMT05 // Tussock Tundra // (updated 1/15/2016 JDC)
-//Betula    Decid.      E.green      Sedges       Forbs        Lichens      Feather.     Sphag.       Misc1.       Misc2.       // names: comments                  
+//Betula    Decid       EGreen       Sedges       Forbs        Lichens      Feather      Sphag        PFT8         PFT9         // pftnames:
 0.01        0.01        0.01         0.01         0.01         0.01         0.01         0.01         0.           0.           // vegfrac: vegetation coverage on land - 0 indicates that PFT does't exist
 1           1           1            0            0            0            0            0            0            0            // ifwoody: woody plants (1) or not (0)
 1           0           0            0            0            0            0            0            0            0            // ifdeciwoody: deciduous woodland (1) or not (0)

--- a/parameters/cmt_dimvegetation.txt
+++ b/parameters/cmt_dimvegetation.txt
@@ -306,7 +306,7 @@
 1.0         0.0         0.0          0.7          1.5          1.5          1.5          0.00         0.00         0.00         // envlai[11]: monthly LAI for a year, used for static input of LAI
 //===========================================================
 // CMT07 // Heath Tundra
-//Decid.    E.green     Forbs        Lichens      Grasses      Moss         Misc.       Misc.         Misc.        Misc.        // names: comments                  
+//Decid     EGreen      Forbs        Lichens      Grasses      Moss         PFT6         PFT7         PFT8         PFT9         // pftnames:
 1.00        1.00        1.00         1.00         1.00         1.00         0.00         0.00         0.00         0.00         // vegfrac: vegetation coverage on land - 0 indicates that PFT does't exist
 1           1           1            1            0            0            0            0            0            0            // ifwoody: woody plants (1) or not (0)
 0           1           1            0            0            0            0            0            0            0            // ifdeciwoody: deciduous woodland (1) or not (0)

--- a/parameters/cmt_dimvegetation.txt
+++ b/parameters/cmt_dimvegetation.txt
@@ -263,7 +263,7 @@
 0.0         0.0         0.7          0.0          0.5          2.00         2.00         2.00          0            0           // envlai[11]:
 //===========================================================
 // CMT06 // Wet Sedge Tundra
-//Decid.    Sedges      Grasses      Forbs        Lichens      Feather      Sphag.       PFT7         PFT8         PFT9         // names: comments                  
+//Decid     Sedges      Grasses      Forbs        Lichens      Feather      Sphag        PFT7         PFT8         PFT9         // pftnames
 1.00        1.00        1.00         1.00         1.00         1.00         1.00         0.00         0.00         0.00         // vegfrac: vegetation coverage on land - 0 indicates that PFT does't exist
 1           1           1            1            0            0            0            0            0            0            // ifwoody: woody plants (1) or not (0)
 0           1           1            0            0            0            0            0            0            0            // ifdeciwoody: deciduous woodland (1) or not (0)

--- a/parameters/cmt_dimvegetation.txt
+++ b/parameters/cmt_dimvegetation.txt
@@ -435,7 +435,7 @@
 0.0          0.8          0.7          1.1          2.1          1.1          0.0          0.0          0.0          0.0          // envlai[11]:
 //===========================================================
 // CMT21 // EML Tussock Tundra
-//Betnan     Carex        Ericoid      Erivag       Feather     Lichen       OtherMoss    Rubcha      Sphagnum       Misc.           // names: comments
+//Betnan     Carex        Ericoid      Erivag       Feather     Lichen       OtherMoss    Rubcha      Sphagnum       PFT9         // pftnames:
 0.01         0.01         0.01         0.01         0.01         0.01         0.01        0.01         0.01          0            // vegfrac: vegetation coverage on land - 0 indicates that PFT does't exist
 1            0            1            0            0            0            0            1            0            0            // ifwoody: woody plants (1) or not (0)
 1            0            0            0            0            0            0            0            0            0            // ifdeciwoody: deciduous woodland (1) or not (0)

--- a/parameters/cmt_dimvegetation.txt
+++ b/parameters/cmt_dimvegetation.txt
@@ -1,6 +1,8 @@
 // dvmdostem parameter file
 // Plant structure and dimensions
 // Max 10 PFTs
+// PFT names should be CamelCase and must not have a period in them!
+//
 //===========================================================
 // CMT00 // BARE GROUND OPEN WATER SNOW AND ICE
 //PFT0      PFT1        PFT2         PFT3         PFT4         PFT5         PFT6         PFT7         PFT8         PFT9         // names: comments                  
@@ -46,7 +48,7 @@
 1.0         0.0         0.0          0.7          0.8          0.5          1.5          2.1          1.1          0            // envlai[11]: monthly LAI for a year, used for static input of LAI
 //===========================================================
 // CMT01 // Black Spruce Forest
-//PFT0      PFT1        PFT2         PFT3         PFT4         PFT5         PFT6         PFT7         PFT8         PFT9         // names: comments                  
+//BlackSpr  Decid       DecidShrub   EGreen       Sphag      Feather        Moss         Lichen       Forbs        Sedge        // pftnames:
 1.00        1.00        1.00         1.00         1.00         1.00         1.00         1.00         1.00         0.           // vegfrac: vegetation coverage on land - 0 indicates that PFT does't exist
 1           1           1            1            0            0            0            0            0            0            // ifwoody: woody plants (1) or not (0)
 0           0           1            0            0            0            0            0            0            0            // ifdeciwoody: deciduous woodland (1) or not (0)

--- a/parameters/cmt_dimvegetation.txt
+++ b/parameters/cmt_dimvegetation.txt
@@ -47,7 +47,7 @@
 1.1         0.0         0.0          0.8          0.5          1.0          1.5          1.9          0.0          0            // envlai[10]: monthly LAI for a year, used for static input of LAI 
 1.0         0.0         0.0          0.7          0.8          0.5          1.5          2.1          1.1          0            // envlai[11]: monthly LAI for a year, used for static input of LAI
 //===========================================================
-// CMT01 // Black Spruce Forest
+// CMT01 // Black Spruce Forest //###THESE ARE JUNK VALUES!!!###
 //BlackSpr  Decid       DecidShrub   EGreen       Sphag      Feather        Moss         Lichen       Forbs        Sedge        // pftnames:
 1.00        1.00        1.00         1.00         1.00         1.00         1.00         1.00         1.00         0.           // vegfrac: vegetation coverage on land - 0 indicates that PFT does't exist
 1           1           1            1            0            0            0            0            0            0            // ifwoody: woody plants (1) or not (0)

--- a/parameters/cmt_dimvegetation.txt
+++ b/parameters/cmt_dimvegetation.txt
@@ -177,7 +177,7 @@
 1.0         0.0         0.0          0.7          0.8          0.5          1.5          2.1          1.1          0            // envlai[11]: monthly LAI for a year, used for static input of LAI
 //===========================================================
 // CMT04 // Shrub Tundra
-//Salix     Betula      Decid.       E.green      Sedges       Forbs        Grasses      Lichens      Feather      Misc1.       // names: comments                  
+//Salix     Betula      Decid        EGreen       Sedges       Forbs        Grasses      Lichens      Feather      PFT9         // pftnames:
 1.00        1.00        1.00         1.00         1.00         1.00         1.00         1.00         1.00         0.           // vegfrac: vegetation coverage on land - 0 indicates that PFT does't exist
 1           1           1            1            0            0            0            0            0            0            // ifwoody: woody plants (1) or not (0)
 0           0           0            0            0            0            0            0            0            0            // ifdeciwoody: deciduous woodland (1) or not (0)

--- a/parameters/cmt_envcanopy.txt
+++ b/parameters/cmt_envcanopy.txt
@@ -80,7 +80,7 @@
 0.0         0.0         0.0          0.0          0.0          0.0          0.0          0.0          0.0          0.0              // initvegsnow: initial intercepted snow water in canopy
 //===========================================================
 // CMT05 // Tussock Tundra // (updated 1/15/2016 JDC)
-//Betula    Decid.      E.green      Sedges       Forbs        Lichens      Feather.     Sphag.       Misc1.       Misc2.            // names: comments                  
+//Betula    Decid       EGreen       Sedges       Forbs        Lichens      Feather      Sphag        PFT8         PFT9             // pftnames:
 0.10        0.10        0.10         0.10         0.10         0.10         0.10         0.10         0.10         0.10             // albvisnir: canopy albedo
 0.5         0.5         0.5          0.5          0.5          0.5          0.5          0.5          0.5          0.5              // er: light extinction coefficient
 0.041       0.041       0.041        0.041        0.041        0.041        0.041        0.041        0.041        0.041            // ircoef: rainfall interception 

--- a/parameters/cmt_envcanopy.txt
+++ b/parameters/cmt_envcanopy.txt
@@ -155,7 +155,7 @@
 0.0         0.0         0.0          0.0          0.0          0.0          0.0          0.0          0.0          0.0              // initvegsnow: initial intercepted snow water in canopy
 //===========================================================
 // CMT21 // EML Tussock Tundra
-//Betnan    Carex       Ericoid      Erivag       Feather      Lichen       OtherMoss    Rubcha       Sphagnum     Misc.            // names: comments
+//Betnan    Carex       Ericoid      Erivag       Feather      Lichen       OtherMoss    Rubcha       Sphagnum     PFT9             // pftnames:
 0.10        0.10        0.10         0.10         0.10         0.10         0.10         0.10         0.10         0.10             // albvisnir: canopy albedo
 0.5         0.5         0.5          0.5          0.5          0.5          0.5          0.5          0.5          0.5              // er: light extinction coefficient
 0.041       0.041       0.041        0.041        0.041        0.041        0.041        0.041        0.041        0.041            // ircoef: rainfall interception 

--- a/parameters/cmt_envcanopy.txt
+++ b/parameters/cmt_envcanopy.txt
@@ -19,7 +19,7 @@
 0.0         0.0         0.0          0.0          0.0          0.0          0.0          0.0          0.0          0.0              // initvegwater: initial intercepted rain water in canopy
 0.0         0.0         0.0          0.0          0.0          0.0          0.0          0.0          0.0          0.0              // initvegsnow: initial intercepted snow water in canopy
 //===========================================================
-// CMT01 // Black Spruce Forest
+// CMT01 // Black Spruce Forest // ###THESE ARE JUNK VALUES!!!###
 //BlackSpr  Decid       DecidShrub   EGreen       Sphag        Feather      Moss         Lichen       Forbs        Sedge            // pftnames:
 0.10        0.10        0.10         0.10         0.10         0.10         0.10         0.10         0.10         0.10             // albvisnir: canopy albedo
 0.5         0.5         0.5          0.5          0.5          0.5          0.5          0.5          0.5          0.5              // er: light extinction coefficient

--- a/parameters/cmt_envcanopy.txt
+++ b/parameters/cmt_envcanopy.txt
@@ -125,7 +125,7 @@
 0.0         0.0         0.0          0.0          0.0          0.0          0.0          0.0          0.0          0.0              // initvegsnow: initial intercepted snow water in canopy
 //===========================================================
 // CMT12 // Lowland Boreal Wet Shrubland
-//DecShrub   EvrShrub     DecTree     EvrTree       Forbs        Gram         Feather      Lichen       Equisetum    Misc.            // names: comments 
+//DecShrub   EvrShrub     DecTree      EvrTree       Forbs       Gram       Feather       Lichen      Equisetum      PFT9             // pftnames:
 0.10         0.10         0.10         0.10         0.10         0.10         0.10         0.10         0.10         0.10             // albvisnir: canopy albedo
 0.5          0.5          0.5          0.5          0.5          0.5          0.5          0.5          0.5          0.5              // er: light extinction coefficient
 0.041        0.041        0.041        0.041        0.041        0.041        0.041        0.041        0.041        0.041            // ircoef: rainfall interception 

--- a/parameters/cmt_envcanopy.txt
+++ b/parameters/cmt_envcanopy.txt
@@ -65,7 +65,7 @@
 0.0         0.0         0.0          0.0          0.0          0.0          0.0          0.0          0.0          0.0              // initvegsnow: initial intercepted snow water in canopy
 //===========================================================
 // CMT04 // Shrub Tundra
-//Salix     Betula      Decid.       E.green      Sedges       Forbs        Grasses      Lichens      Feather      Misc1.       // names: comments
+//Salix     Betula      Decid        EGreen       Sedges       Forbs        Grasses      Lichens      Feather      PFT9             // pftnames:
 0.10        0.10        0.10         0.10         0.10         0.10         0.10         0.10         0.10         0.10             // albvisnir: canopy albedo
 0.5         0.5         0.5          0.5          0.5          0.5          0.5          0.5          0.5          0.5              // er: light extinction coefficient
 0.041       0.041       0.041        0.041        0.041        0.041        0.041        0.041        0.041        0.041            // ircoef: rainfall interception 

--- a/parameters/cmt_envcanopy.txt
+++ b/parameters/cmt_envcanopy.txt
@@ -1,5 +1,8 @@
+// dvmdostem parameter file
+// Biophysical plant leaf characteristics and parameters
+// Maximum of 10 PFTs
 //===========================================================
-// CMT00 // Default TEM Community - (max. 10 PFTs) (Biophysical) plant leaf characteristics and parameters
+// CMT00 // Default TEM Community
 //PFT0      PFT1        PFT2         PFT3         PFT4         PFT5         PFT6         PFT7         PFT8         PFT9             // names: comments                  
 0.10        0.10        0.10         0.10         0.10         0.10         0.10         0.10         0.10         0.10             // albvisnir: canopy albedo
 0.5         0.5         0.5          0.5          0.5          0.5          0.5          0.5          0.5          0.5              // er: light extinction coefficient
@@ -14,7 +17,7 @@
 0.0         0.0         0.0          0.0          0.0          0.0          0.0          0.0          0.0          0.0              // initvegwater: initial intercepted rain water in canopy
 0.0         0.0         0.0          0.0          0.0          0.0          0.0          0.0          0.0          0.0              // initvegsnow: initial intercepted snow water in canopy
 //===========================================================
-// CMT01 // CMT1 TEM Community - (max. 10 PFTs) (Biophysical) plant leaf characteristics and parameters
+// CMT01 // Black Spruce Forest
 //PFT0      PFT1        PFT2         PFT3         PFT4         PFT5         PFT6         PFT7         PFT8         PFT9             // names: comments                  
 0.10        0.10        0.10         0.10         0.10         0.10         0.10         0.10         0.10         0.10             // albvisnir: canopy albedo
 0.5         0.5         0.5          0.5          0.5          0.5          0.5          0.5          0.5          0.5              // er: light extinction coefficient
@@ -29,7 +32,7 @@
 0.0         0.0         0.0          0.0          0.0          0.0          0.0          0.0          0.0          0.0              // initvegwater: initial intercepted rain water in canopy
 0.0         0.0         0.0          0.0          0.0          0.0          0.0          0.0          0.0          0.0              // initvegsnow: initial intercepted snow water in canopy
 //===========================================================
-// CMT02 // CMT2 TEM Community - (max. 10 PFTs) (Biophysical) plant leaf characteristics and parameters
+// CMT02 // White Spruce Forest
 //PFT0      PFT1        PFT2         PFT3         PFT4         PFT5         PFT6         PFT7         PFT8         PFT9             // names: comments                  
 0.10        0.10        0.10         0.10         0.10         0.10         0.10         0.10         0.10         0.10             // albvisnir: canopy albedo
 0.5         0.5         0.5          0.5          0.5          0.5          0.5          0.5          0.5          0.5              // er: light extinction coefficient
@@ -44,7 +47,7 @@
 0.0         0.0         0.0          0.0          0.0          0.0          0.0          0.0          0.0          0.0              // initvegwater: initial intercepted rain water in canopy
 0.0         0.0         0.0          0.0          0.0          0.0          0.0          0.0          0.0          0.0              // initvegsnow: initial intercepted snow water in canopy
 //===========================================================
-// CMT03 // CMT3 TEM Community - (max. 10 PFTs) (Biophysical) plant leaf characteristics and parameters
+// CMT03 // Boreal Deciduous Forest
 //PFT0      PFT1        PFT2         PFT3         PFT4         PFT5         PFT6         PFT7         PFT8         PFT9             // names: comments                  
 0.10        0.10        0.10         0.10         0.10         0.10         0.10         0.10         0.10         0.10             // albvisnir: canopy albedo
 0.5         0.5         0.5          0.5          0.5          0.5          0.5          0.5          0.5          0.5              // er: light extinction coefficient
@@ -59,7 +62,7 @@
 0.0         0.0         0.0          0.0          0.0          0.0          0.0          0.0          0.0          0.0              // initvegwater: initial intercepted rain water in canopy
 0.0         0.0         0.0          0.0          0.0          0.0          0.0          0.0          0.0          0.0              // initvegsnow: initial intercepted snow water in canopy
 //===========================================================
-// CMT04 // Shrub Tundra - (max. 10 PFTs) (Biophysical) plant leaf characteristics and parameters
+// CMT04 // Shrub Tundra
 //Salix     Betula      Decid.       E.green      Sedges       Forbs        Grasses      Lichens      Feather      Misc1.       // names: comments
 0.10        0.10        0.10         0.10         0.10         0.10         0.10         0.10         0.10         0.10             // albvisnir: canopy albedo
 0.5         0.5         0.5          0.5          0.5          0.5          0.5          0.5          0.5          0.5              // er: light extinction coefficient
@@ -74,7 +77,7 @@
 0.0         0.0         0.0          0.0          0.0          0.0          0.0          0.0          0.0          0.0              // initvegwater: initial intercepted rain water in canopy
 0.0         0.0         0.0          0.0          0.0          0.0          0.0          0.0          0.0          0.0              // initvegsnow: initial intercepted snow water in canopy
 //===========================================================
-// CMT05 // Tussock Tundra (updated 1/15/2016 JDC) - (max. 10 PFTs) (Biophysical) plant leaf characteristics and parameters
+// CMT05 // Tussock Tundra // (updated 1/15/2016 JDC)
 //Betula    Decid.      E.green      Sedges       Forbs        Lichens      Feather.     Sphag.       Misc1.       Misc2.            // names: comments                  
 0.10        0.10        0.10         0.10         0.10         0.10         0.10         0.10         0.10         0.10             // albvisnir: canopy albedo
 0.5         0.5         0.5          0.5          0.5          0.5          0.5          0.5          0.5          0.5              // er: light extinction coefficient
@@ -89,7 +92,7 @@
 0.0         0.0         0.0          0.0          0.0          0.0          0.0          0.0          0.0          0.0              // initvegwater: initial intercepted rain water in canopy
 0.0         0.0         0.0          0.0          0.0          0.0          0.0          0.0          0.0          0.0              // initvegsnow: initial intercepted snow water in canopy
 //===========================================================
-// CMT06 // Wet Sedge Tundra - (max. 10 PFTs) (Biophysical) plant leaf characteristics and parameters
+// CMT06 // Wet Sedge Tundra
 //Decid.    Sedges      Grasses      Forbs        Lichens      Feather      Sphag.       PFT7         PFT8         PFT9         // names: comments
 0.10        0.10        0.10         0.10         0.10         0.10         0.10         0.10         0.10         0.10             // albvisnir: canopy albedo
 0.5         0.5         0.5          0.5          0.5          0.5          0.5          0.5          0.5          0.5              // er: light extinction coefficient
@@ -104,7 +107,7 @@
 0.0         0.0         0.0          0.0          0.0          0.0          0.0          0.0          0.0          0.0              // initvegwater: initial intercepted rain water in canopy
 0.0         0.0         0.0          0.0          0.0          0.0          0.0          0.0          0.0          0.0              // initvegsnow: initial intercepted snow water in canopy
 //===========================================================
-// CMT07 // Heath Tundra - (max. 10 PFTs) (Biophysical) plant leaf characteristics and parameters
+// CMT07 // Heath Tundra
 //Decid.    E.green     Forbs        Lichens      Grasses      Moss         Misc.        Misc.        Misc.        Misc.            // names: comments
 0.10        0.10        0.10         0.10         0.10         0.10         0.10         0.10         0.10         0.10             // albvisnir: canopy albedo
 0.5         0.5         0.5          0.5          0.5          0.5          0.5          0.5          0.5          0.5              // er: light extinction coefficient
@@ -119,7 +122,7 @@
 0.0         0.0         0.0          0.0          0.0          0.0          0.0          0.0          0.0          0.0              // initvegwater: initial intercepted rain water in canopy
 0.0         0.0         0.0          0.0          0.0          0.0          0.0          0.0          0.0          0.0              // initvegsnow: initial intercepted snow water in canopy
 //===========================================================
-// CMT12 // Lowland Boreal Wet Shrubland - (max. 10 PFTs) (Biophysical) plant leaf characteristics and parameters
+// CMT12 // Lowland Boreal Wet Shrubland
 //DecShrub   EvrShrub     DecTree     EvrTree       Forbs        Gram         Feather      Lichen       Equisetum    Misc.            // names: comments 
 0.10         0.10         0.10         0.10         0.10         0.10         0.10         0.10         0.10         0.10             // albvisnir: canopy albedo
 0.5          0.5          0.5          0.5          0.5          0.5          0.5          0.5          0.5          0.5              // er: light extinction coefficient
@@ -134,7 +137,7 @@
 0.0          0.0          0.0          0.0          0.0          0.0          0.0          0.0          0.0          0.0              // initvegwater: initial intercepted rain water in canopy
 0.0          0.0          0.0          0.0          0.0          0.0          0.0          0.0          0.0          0.0              // initvegsnow: initial intercepted snow water in canopy
 //===========================================================
-// CMT20 // EML Shrub Tundra - 
+// CMT20 // EML Shrub Tundra 
 //Betnan    Carex       Ericoid      Feather      Lichen       OthMoss      Rubcha       Misc1        Misc2        Misc3            // names: comments
 0.10        0.10        0.10         0.10         0.10         0.10         0.10         0.10         0.10         0.10             // albvisnir: canopy albedo
 0.5         0.5         0.5          0.5          0.5          0.5          0.5          0.5          0.5          0.5              // er: light extinction coefficient
@@ -149,7 +152,7 @@
 0.0         0.0         0.0          0.0          0.0          0.0          0.0          0.0          0.0          0.0              // initvegwater: initial intercepted rain water in canopy
 0.0         0.0         0.0          0.0          0.0          0.0          0.0          0.0          0.0          0.0              // initvegsnow: initial intercepted snow water in canopy
 //===========================================================
-// CMT21 // EML Tussock Tundra -
+// CMT21 // EML Tussock Tundra
 //Betnan    Carex       Ericoid      Erivag       Feather      Lichen       OtherMoss    Rubcha       Sphagnum     Misc.            // names: comments
 0.10        0.10        0.10         0.10         0.10         0.10         0.10         0.10         0.10         0.10             // albvisnir: canopy albedo
 0.5         0.5         0.5          0.5          0.5          0.5          0.5          0.5          0.5          0.5              // er: light extinction coefficient

--- a/parameters/cmt_envcanopy.txt
+++ b/parameters/cmt_envcanopy.txt
@@ -110,7 +110,7 @@
 0.0         0.0         0.0          0.0          0.0          0.0          0.0          0.0          0.0          0.0              // initvegsnow: initial intercepted snow water in canopy
 //===========================================================
 // CMT07 // Heath Tundra
-//Decid.    E.green     Forbs        Lichens      Grasses      Moss         Misc.        Misc.        Misc.        Misc.            // names: comments
+//Decid     EGreen      Forbs        Lichens      Grasses      Moss         PFT6         PFT7         PFT8         PFT9             // pftnames:
 0.10        0.10        0.10         0.10         0.10         0.10         0.10         0.10         0.10         0.10             // albvisnir: canopy albedo
 0.5         0.5         0.5          0.5          0.5          0.5          0.5          0.5          0.5          0.5              // er: light extinction coefficient
 0.041       0.041       0.041        0.041        0.041        0.041        0.041        0.041        0.041        0.041            // ircoef: rainfall interception 

--- a/parameters/cmt_envcanopy.txt
+++ b/parameters/cmt_envcanopy.txt
@@ -1,6 +1,8 @@
 // dvmdostem parameter file
 // Biophysical plant leaf characteristics and parameters
 // Maximum of 10 PFTs
+// PFT names should be CamelCase and must not have a period in them!
+//
 //===========================================================
 // CMT00 // Default TEM Community
 //PFT0      PFT1        PFT2         PFT3         PFT4         PFT5         PFT6         PFT7         PFT8         PFT9             // names: comments                  
@@ -18,7 +20,7 @@
 0.0         0.0         0.0          0.0          0.0          0.0          0.0          0.0          0.0          0.0              // initvegsnow: initial intercepted snow water in canopy
 //===========================================================
 // CMT01 // Black Spruce Forest
-//PFT0      PFT1        PFT2         PFT3         PFT4         PFT5         PFT6         PFT7         PFT8         PFT9             // names: comments                  
+//BlackSpr  Decid       DecidShrub   EGreen       Sphag        Feather      Moss         Lichen       Forbs        Sedge            // pftnames:
 0.10        0.10        0.10         0.10         0.10         0.10         0.10         0.10         0.10         0.10             // albvisnir: canopy albedo
 0.5         0.5         0.5          0.5          0.5          0.5          0.5          0.5          0.5          0.5              // er: light extinction coefficient
 0.041       0.041       0.041        0.041        0.041        0.041        0.041        0.041        0.041        0.041            // ircoef: rainfall interception 

--- a/parameters/cmt_envcanopy.txt
+++ b/parameters/cmt_envcanopy.txt
@@ -95,7 +95,7 @@
 0.0         0.0         0.0          0.0          0.0          0.0          0.0          0.0          0.0          0.0              // initvegsnow: initial intercepted snow water in canopy
 //===========================================================
 // CMT06 // Wet Sedge Tundra
-//Decid.    Sedges      Grasses      Forbs        Lichens      Feather      Sphag.       PFT7         PFT8         PFT9         // names: comments
+//Decid     Sedges      Grasses      Forbs        Lichens      Feather      Sphag        PFT7         PFT8         PFT9             // pftnames
 0.10        0.10        0.10         0.10         0.10         0.10         0.10         0.10         0.10         0.10             // albvisnir: canopy albedo
 0.5         0.5         0.5          0.5          0.5          0.5          0.5          0.5          0.5          0.5              // er: light extinction coefficient
 0.041       0.041       0.041        0.041        0.041        0.041        0.041        0.041        0.041        0.041            // ircoef: rainfall interception 

--- a/parameters/cmt_envground.txt
+++ b/parameters/cmt_envground.txt
@@ -1,5 +1,7 @@
+// dvmdostem parameter file
+// ground (snow and soil) biophysical properties and parameters
 //===========================================================
-// CMT00 // Default TEM Community - ground(snow-soil) (bio)physical properties and parameters
+// CMT00 // Default TEM Community
 0.8                // snwalbmax:
 0.4                // snwalbmin:
 -1.5e7             // psimax:
@@ -28,7 +30,7 @@
 0.20               // initvwc(8): initial soil volume water content at every 10 cm interval
 0.20               // initvwc(9): initial soil volume water content at every 10 cm interval
 //===========================================================
-// CMT01 // CMT1 TEM Community - ground(snow-soil) (bio)physical properties and parameters
+// CMT01 // Black Spruce Forest
 0.8                // snwalbmax:
 0.4                // snwalbmin:
 -1.5e7             // psimax:
@@ -57,7 +59,7 @@
 0.10               // initvwc(8): initial soil volume water content at every 10 cm interval
 0.10               // initvwc(9): initial soil volume water content at every 10 cm interval
 //===========================================================
-// CMT02 // CMT2 TEM Community - ground(snow-soil) (bio)physical properties and parameters
+// CMT02 // White Spruce Forest
 0.8                // snwalbmax:
 0.4                // snwalbmin:
 -1.5e7             // psimax:
@@ -86,7 +88,7 @@
 0.10               // initvwc(8): initial soil volume water content at every 10 cm interval
 0.10               // initvwc(9): initial soil volume water content at every 10 cm interval
 //===========================================================
-// CMT03 // CMT3 TEM Community - ground(snow-soil) (bio)physical properties and parameters
+// CMT03 // Boreal Deciduous Forest
 0.8                // snwalbmax:
 0.4                // snwalbmin:
 -1.5e7             // psimax:
@@ -115,7 +117,7 @@
 0.10               // initvwc(8): initial soil volume water content at every 10 cm interval
 0.10               // initvwc(9): initial soil volume water content at every 10 cm interval
 //===========================================================
-// CMT04 // Shrub Tundra - ground(snow-soil) (bio)physical properties and parameters
+// CMT04 // Shrub Tundra
 0.8                // snwalbmax:
 0.4                // snwalbmin:
 -1.5e7             // psimax:
@@ -144,7 +146,7 @@
 0.10               // initvwc(8): initial soil volume water content at every 10 cm interval
 0.10               // initvwc(9): initial soil volume water content at every 10 cm interval
 //===========================================================
-// CMT05 // Tussock Tundra (updated 1/15/2016 JDC) - ground(snow-soil) (bio)physical properties and parameters
+// CMT05 // Tussock Tundra // (updated 1/15/2016 JDC)
 0.8                // snwalbmax:
 0.4                // snwalbmin:
 -1.5e7             // psimax:
@@ -174,7 +176,7 @@
 0.10               // initvwc(9): initial soil volume water content at every 10 cm interval
 
 //===========================================================
-// CMT06 // Wet Sedge Tundra - ground(snow-soil) (bio)physical properties and parameters
+// CMT06 // Wet Sedge Tundra
 0.8                // snwalbmax:
 0.4                // snwalbmin:
 -1.5e7             // psimax:
@@ -203,7 +205,7 @@
 0.10               // initvwc(8): initial soil volume water content at every 10 cm interval
 0.10               // initvwc(9): initial soil volume water content at every 10 cm interval
 //===========================================================
-// CMT07 // Heath Tundra - ground(snow-soil) (bio)physical properties and parameters
+// CMT07 // Heath Tundra
 0.8                // snwalbmax:
 0.4                // snwalbmin:
 -1.5e7             // psimax:
@@ -232,7 +234,7 @@
 0.10               // initvwc(8): initial soil volume water content at every 10 cm interval
 0.10               // initvwc(9): initial soil volume water content at every 10 cm interval
 //===========================================================
-// CMT12 // Lowland Boreal Wet Shrubland - ground(snow-soil) (bio)physical properties and parameters
+// CMT12 // Lowland Boreal Wet Shrubland
 0.8                // snwalbmax:
 0.4                // snwalbmin:
 -1.5e7             // psimax:
@@ -261,7 +263,7 @@
 0.10               // initvwc(8): initial soil volume water content at every 10 cm interval
 0.10               // initvwc(9): initial soil volume water content at every 10 cm interval
 //===========================================================
-// CMT20 // EML Shrub Tundra - 
+// CMT20 // EML Shrub Tundra
 0.8                // snwalbmax:
 0.4                // snwalbmin:
 -1.5e7             // psimax:
@@ -290,7 +292,7 @@
 0.10               // initvwc(8): initial soil volume water content at every 10 cm interval
 0.10               // initvwc(9): initial soil volume water content at every 10 cm interval
 //===========================================================
-// CMT21 // EML Tussock Tundra -
+// CMT21 // EML Tussock Tundra
 0.8                // snwalbmax:
 0.4                // snwalbmin:
 -1.5e7             // psimax:

--- a/parameters/cmt_envground.txt
+++ b/parameters/cmt_envground.txt
@@ -30,7 +30,7 @@
 0.20               // initvwc(8): initial soil volume water content at every 10 cm interval
 0.20               // initvwc(9): initial soil volume water content at every 10 cm interval
 //===========================================================
-// CMT01 // Black Spruce Forest
+// CMT01 // Black Spruce Forest // ### THESE ARE JUNK VALUES!!! ###
 0.8                // snwalbmax:
 0.4                // snwalbmin:
 -1.5e7             // psimax:

--- a/parameters/cmt_firepar.txt
+++ b/parameters/cmt_firepar.txt
@@ -1,5 +1,8 @@
+// dvmdostem parameter file
+// Fire disturbance parameters
+// Max of 10 PFTs over 1 soil column
 //===========================================================
-// CMT00 // Default TEM Community - fire disturbance parameters
+// CMT00 // BARE GROUND OPEN WATER SNOW AND ICE
 //PFT0      PFT1        PFT2         PFT3         PFT4         PFT5         PFT6         PFT7         PFT8         PFT9      // names: comments                  
 0.00         0.00        0.00        0.00         0.00         0.00         0.00         0.00         0.00         0.00      // fvcomb[5][10]: fraction of each PFT vegetation combusted for 5 severities
 0.15         0.15        0.15        0.15         0.80         0.80         0.80         1.00         1.00         0.00      // 
@@ -12,7 +15,7 @@
 0.64         0.64        0.64        0.64         0.00         0.00         0.00         0.00         0.00         0.00      // 
 0.64         0.64        0.64        0.64         0.00         0.00         0.00         0.00         0.00         0.00      // 
 // ground
-0.00                                                   // foslburn[5]:  fraction of OS layer burned for each of 5 fire severity classes                                                                                           
+0.00                                                   // foslburn[5]:  fraction of OS layer burned for each of 5 fire severity classes
 0.48
 0.54
 0.69
@@ -22,7 +25,7 @@
 0.10                                                   // r_retain_c: ratio of burning residue C (retained into soil) 
 0.10                                                   // r_retain_n: ratio of burning residue N (retained into soil)
 //===========================================================
-// CMT01 // CMT1 TEM Community - fire disturbance parameters
+// CMT01 // Black Spruce Forest
 //PFT0      PFT1        PFT2         PFT3         PFT4         PFT5         PFT6         PFT7         PFT8         PFT9      // names: comments                  
 0.00         0.00        0.00        0.00         0.00         0.00         0.00         0.00         0.00         0.00      // fvcomb[5][10]: fraction of each PFT vegetation combusted for 5 severities
 0.15         0.15        0.15        0.15         0.80         0.80         0.80         1.00         1.00         0.00      // 
@@ -35,7 +38,7 @@
 0.64         0.64        0.64        0.64         0.00         0.00         0.00         0.00         0.00         0.00      // 
 0.64         0.64        0.64        0.64         0.00         0.00         0.00         0.00         0.00         0.00      // 
 // ground
-0.00                                                   // foslburn[5]:  fraction of OS layer burned for each of 5 fire severity classes                                                                                           
+0.00                                                   // foslburn[5]:  fraction of OS layer burned for each of 5 fire severity classes
 0.48
 0.54
 0.69
@@ -45,7 +48,7 @@
 0.10                                                   // r_retain_c: ratio of burning residue C (retained into soil) 
 0.10                                                   // r_retain_n: ratio of burning residue N (retained into soil)
 //===========================================================
-// CMT02 // CMT2 TEM Community - fire disturbance parameters
+// CMT02 // White Spruce Forest
 //PFT0      PFT1        PFT2         PFT3         PFT4         PFT5         PFT6         PFT7         PFT8         PFT9      // names: comments                  
 0.00         0.00        0.00        0.00         0.00         0.00         0.00         0.00         0.00         0.00      // fvcomb[5][10]: fraction of each PFT vegetation combusted for 5 severities
 0.15         0.15        0.15        0.15         0.80         0.80         0.80         1.00         1.00         0.00      // 
@@ -58,7 +61,7 @@
 0.64         0.64        0.64        0.64         0.00         0.00         0.00         0.00         0.00         0.00      // 
 0.64         0.64        0.64        0.64         0.00         0.00         0.00         0.00         0.00         0.00      // 
 // ground
-0.00                                                   // foslburn[5]:  fraction of OS layer burned for each of 5 fire severity classes                                                                                           
+0.00                                                   // foslburn[5]:  fraction of OS layer burned for each of 5 fire severity classes
 0.48
 0.54
 0.69
@@ -68,7 +71,7 @@
 0.10                                                   // r_retain_c: ratio of burning residue C (retained into soil) 
 0.10                                                   // r_retain_n: ratio of burning residue N (retained into soil)
 //===========================================================
-// CMT03 // CMT3 TEM Community - fire disturbance parameters
+// CMT03 // Boreal Deciduous Forest
 //PFT0      PFT1        PFT2         PFT3         PFT4         PFT5         PFT6         PFT7         PFT8         PFT9      // names: comments                  
 0.00         0.00        0.00        0.00         0.00         0.00         0.00         0.00         0.00         0.00      // fvcomb[5][10]: fraction of each PFT vegetation combusted for 5 severities
 0.15         0.15        0.15        0.15         0.80         0.80         0.80         1.00         1.00         0.00      // 
@@ -81,7 +84,7 @@
 0.64         0.64        0.64        0.64         0.00         0.00         0.00         0.00         0.00         0.00      // 
 0.64         0.64        0.64        0.64         0.00         0.00         0.00         0.00         0.00         0.00      // 
 // ground
-0.00                                                   // foslburn[5]:  fraction of OS layer burned for each of 5 fire severity classes                                                                                           
+0.00                                                   // foslburn[5]:  fraction of OS layer burned for each of 5 fire severity classes
 0.48
 0.54
 0.69
@@ -91,7 +94,7 @@
 0.10                                                   // r_retain_c: ratio of burning residue C (retained into soil) 
 0.10                                                   // r_retain_n: ratio of burning residue N (retained into soil)
 //===========================================================
-// CMT04 // Shrub Tundra - fire disturbance parameters
+// CMT04 // Shrub Tundra
 //Salix     Betula      Decid.       E.green      Sedges       Forbs        Grasses      Lichens      Feather      Misc1.       // names: comments
 0.00         0.00        0.00        0.00         0.00         0.00         0.00         0.00         0.00         0.00      // fvcomb[5][10]: fraction of each PFT vegetation combusted for 5 severities
 0.15         0.15        0.15        0.15         0.80         0.80         0.80         1.00         1.00         0.00      // 
@@ -104,7 +107,7 @@
 0.64         0.64        0.64        0.64         0.00         0.00         0.00         0.00         0.00         0.00      // 
 0.64         0.64        0.64        0.64         0.00         0.00         0.00         0.00         0.00         0.00      // 
 // ground
-0.00                                                   // foslburn[5]:  fraction of OS layer burned for each of 5 fire severity classes                                                                                           
+0.00                                                   // foslburn[5]:  fraction of OS layer burned for each of 5 fire severity classes
 0.48
 0.54
 0.69
@@ -114,7 +117,7 @@
 0.10                                                   // r_retain_c: ratio of burning residue C (retained into soil) 
 0.10                                                   // r_retain_n: ratio of burning residue N (retained into soil)
 //===========================================================
-// CMT05 // Tussock Tundra - fire disturbance parameters
+// CMT05 // Tussock Tundra
 //Betula     Decid.      E.green     Sedges       Forbs        Lichens      Feather.     Sphag.       Misc1.       Misc2.    // names: comments                  
 0.00         0.00        0.00        0.00         0.00         0.00         0.00         0.00         0.00         0.00      // fvcomb[5][10]: fraction of each PFT vegetation combusted for 5 severities
 0.15         0.15        0.15        0.15         0.15         0.70         0.70         0.80         0.00         0.00      // 
@@ -127,7 +130,7 @@
 0.64         0.64        0.64        0.64         0.64         0.00         0.00         0.00         0.00         0.00      // 
 0.64         0.64        0.64        0.64         0.64         0.00         0.00         0.00         0.00         0.00      // 
 // ground
-0.00                                                   // foslburn[5]:  fraction of OS layer burned for each of 5 fire severity classes                                                                                           
+0.00                                                   // foslburn[5]:  fraction of OS layer burned for each of 5 fire severity classes
 0.1
 0.3
 0.5
@@ -137,7 +140,7 @@
 0.10                                                   // r_retain_c: ratio of burning residue C (retained into soil) 
 0.10                                                   // r_retain_n: ratio of burning residue N (retained into soil)
 //===========================================================
-// CMT06 // Wet Sedge Tundra - fire disturbance parameters
+// CMT06 // Wet Sedge Tundra
 //Decid.     Sedges       Grasses    Forbs        Lichens      Feather      Sphag.       PFT7         PFT8         PFT9      // names: comments                  
 0.00         0.00        0.00        0.00         0.00         0.00         0.00         0.00         0.00         0.00      // fvcomb[5][10]: fraction of each PFT vegetation combusted for 5 severities
 0.15         0.15        0.15        0.15         0.15         0.70         0.70         0.80         1.00         0.00      // 
@@ -150,7 +153,7 @@
 0.64         0.64        0.64        0.64         0.64         0.00         0.00         0.00         0.00         0.00      // 
 0.64         0.64        0.64        0.64         0.64         0.00         0.00         0.00         0.00         0.00      // 
 // ground
-0.00                                                   // foslburn[5]:  fraction of OS layer burned for each of 5 fire severity classes                                                                                           
+0.00                                                   // foslburn[5]:  fraction of OS layer burned for each of 5 fire severity classes
 0.48
 0.54
 0.69
@@ -160,7 +163,7 @@
 0.10                                                   // r_retain_c: ratio of burning residue C (retained into soil) 
 0.10                                                   // r_retain_n: ratio of burning residue N (retained into soil)
 //===========================================================
-// CMT07 // Heath Tundra - fire disturbance parameters
+// CMT07 // Heath Tundra
 //Decid.     E.green     Forbs       Lichens      Grasses      Moss         Misc.        Misc.        Misc.        Misc.     // names: comments
 0.00         0.00        0.00        0.00         0.00         0.00         0.00         0.00         0.00         0.00      // fvcomb[5][10]: fraction of each PFT vegetation combusted for 5 severities
 0.15         0.15        0.15        0.15         0.15         0.70         0.70         0.80         1.00         0.00      // 
@@ -183,7 +186,7 @@
 0.10                                                   // r_retain_c: ratio of burning residue C (retained into soil) 
 0.10                                                   // r_retain_n: ratio of burning residue N (retained into soil)
 //===========================================================
-// CMT12 // Lowland Boreal Wet Shrubland - fire disturbance parameters
+// CMT12 // Lowland Boreal Wet Shrubland
 //DecShrub   EvrShrub     DecTree      EvrTree      Forbs        Gram         Feather      Lichen       Equisetum    Misc.     // names: comments 
 0.00         0.00         0.00         0.00         0.00         0.00         0.00         0.00         0.00         0.00      // fvcomb[5][10]: fraction of each PFT vegetation combusted for 5 severities
 0.15         0.15         0.15         0.15         0.15         0.70         0.70         0.80         1.00         0.00      // 
@@ -206,7 +209,7 @@
 0.10                                                   // r_retain_c: ratio of burning residue C (retained into soil) 
 0.10                                                   // r_retain_n: ratio of burning residue N (retained into soil)
 //===========================================================
-// CMT20 // EML Shrub Tundra - 
+// CMT20 // EML Shrub Tundra
 //Betnan     Carex       Ericoid      Feather     Lichen       OthMoss      Rubcha       Misc1        Misc2        Misc3     // names: comments
 0.00         0.00        0.00        0.00         0.00         0.00         0.00         0.00         0.00         0.00      // fvcomb[5][10]: fraction of each PFT vegetation combusted for 5 severities
 0.15         0.15        0.15        0.15         0.15         0.70         0.70         0.80         1.00         0.00      // 
@@ -229,7 +232,7 @@
 0.10                                                   // r_retain_c: ratio of burning residue C (retained into soil) 
 0.10                                                   // r_retain_n: ratio of burning residue N (retained into soil)
 //===========================================================
-// CMT21 // EML Tussock Tundra -
+// CMT21 // EML Tussock Tundra
 //Betnan     Carex       Ericoid     Erivag       Feather     Lichen      OtherMoss    Rubcha     Sphagnum        Misc.      // names: comments
 0.00         0.00        0.00        0.00         0.00         0.00         0.00         0.00         0.00         0.00      // fvcomb[5][10]: fraction of each PFT vegetation combusted for 5 severities
 0.15         0.15        0.15        0.15         0.15         0.70         0.70         0.80         1.00         0.00      // 
@@ -242,7 +245,7 @@
 0.64         0.64        0.64        0.64         0.64         0.00         0.00         0.00         0.00         0.00      // 
 0.64         0.64        0.64        0.64         0.64         0.00         0.00         0.00         0.00         0.00      // 
 // ground
-0.00                                                   // foslburn[5]:  fraction of OS layer burned for each of 5 fire severity classes                                                                                           
+0.00                                                   // foslburn[5]:  fraction of OS layer burned for each of 5 fire severity classes
 0.48
 0.54
 0.69

--- a/parameters/cmt_firepar.txt
+++ b/parameters/cmt_firepar.txt
@@ -120,7 +120,7 @@
 0.10                                                   // r_retain_n: ratio of burning residue N (retained into soil)
 //===========================================================
 // CMT05 // Tussock Tundra
-//Betula     Decid.      E.green     Sedges       Forbs        Lichens      Feather.     Sphag.       Misc1.       Misc2.    // names: comments                  
+//Betula     Decid       EGreen      Sedges       Forbs        Lichens      Feather      Sphag        PFT8         PFT9      // pftnames:
 0.00         0.00        0.00        0.00         0.00         0.00         0.00         0.00         0.00         0.00      // fvcomb[5][10]: fraction of each PFT vegetation combusted for 5 severities
 0.15         0.15        0.15        0.15         0.15         0.70         0.70         0.80         0.00         0.00      // 
 0.25         0.25        0.25        0.25         0.25         0.80         0.80         0.90         0.00         0.00      // 

--- a/parameters/cmt_firepar.txt
+++ b/parameters/cmt_firepar.txt
@@ -1,6 +1,8 @@
 // dvmdostem parameter file
 // Fire disturbance parameters
 // Max of 10 PFTs over 1 soil column
+// PFT names should be CamelCase and must not have a period in them!
+//
 //===========================================================
 // CMT00 // BARE GROUND OPEN WATER SNOW AND ICE
 //PFT0      PFT1        PFT2         PFT3         PFT4         PFT5         PFT6         PFT7         PFT8         PFT9      // names: comments                  
@@ -26,7 +28,7 @@
 0.10                                                   // r_retain_n: ratio of burning residue N (retained into soil)
 //===========================================================
 // CMT01 // Black Spruce Forest
-//PFT0      PFT1        PFT2         PFT3         PFT4         PFT5         PFT6         PFT7         PFT8         PFT9      // names: comments                  
+//BlackSpr   Decid       DecidShrub  EGreen       Sphag        Feather      Moss         Lichen       Forbs        Sedge     // pftnames:
 0.00         0.00        0.00        0.00         0.00         0.00         0.00         0.00         0.00         0.00      // fvcomb[5][10]: fraction of each PFT vegetation combusted for 5 severities
 0.15         0.15        0.15        0.15         0.80         0.80         0.80         1.00         1.00         0.00      // 
 0.25         0.25        0.25        0.25         1.00         1.00         1.00         1.00         1.00         0.00      // 

--- a/parameters/cmt_firepar.txt
+++ b/parameters/cmt_firepar.txt
@@ -97,7 +97,7 @@
 0.10                                                   // r_retain_n: ratio of burning residue N (retained into soil)
 //===========================================================
 // CMT04 // Shrub Tundra
-//Salix     Betula      Decid.       E.green      Sedges       Forbs        Grasses      Lichens      Feather      Misc1.       // names: comments
+//Salix      Betula      Decid       EGreen       Sedges       Forbs        Grasses      Lichens      Feather      PFT9      // pftnames:
 0.00         0.00        0.00        0.00         0.00         0.00         0.00         0.00         0.00         0.00      // fvcomb[5][10]: fraction of each PFT vegetation combusted for 5 severities
 0.15         0.15        0.15        0.15         0.80         0.80         0.80         1.00         1.00         0.00      // 
 0.25         0.25        0.25        0.25         1.00         1.00         1.00         1.00         1.00         0.00      // 

--- a/parameters/cmt_firepar.txt
+++ b/parameters/cmt_firepar.txt
@@ -166,7 +166,7 @@
 0.10                                                   // r_retain_n: ratio of burning residue N (retained into soil)
 //===========================================================
 // CMT07 // Heath Tundra
-//Decid.     E.green     Forbs       Lichens      Grasses      Moss         Misc.        Misc.        Misc.        Misc.     // names: comments
+//Decid      EGreen      Forbs       Lichens      Grasses      Moss         PFT6         PFT7         PFT8         PFT9      // pftnames:
 0.00         0.00        0.00        0.00         0.00         0.00         0.00         0.00         0.00         0.00      // fvcomb[5][10]: fraction of each PFT vegetation combusted for 5 severities
 0.15         0.15        0.15        0.15         0.15         0.70         0.70         0.80         1.00         0.00      // 
 0.25         0.25        0.25        0.25         0.25         0.80         0.80         0.90         1.00         0.00      // 

--- a/parameters/cmt_firepar.txt
+++ b/parameters/cmt_firepar.txt
@@ -189,7 +189,7 @@
 0.10                                                   // r_retain_n: ratio of burning residue N (retained into soil)
 //===========================================================
 // CMT12 // Lowland Boreal Wet Shrubland
-//DecShrub   EvrShrub     DecTree      EvrTree      Forbs        Gram         Feather      Lichen       Equisetum    Misc.     // names: comments 
+//DecShrub   EvrShrub     DecTree      EvrTree      Forbs        Gram      Feather        Lichen    Equisetum        PFT9      // pftnames:
 0.00         0.00         0.00         0.00         0.00         0.00         0.00         0.00         0.00         0.00      // fvcomb[5][10]: fraction of each PFT vegetation combusted for 5 severities
 0.15         0.15         0.15         0.15         0.15         0.70         0.70         0.80         1.00         0.00      // 
 0.25         0.25         0.25         0.25         0.25         0.80         0.80         0.90         1.00         0.00      // 

--- a/parameters/cmt_firepar.txt
+++ b/parameters/cmt_firepar.txt
@@ -143,7 +143,7 @@
 0.10                                                   // r_retain_n: ratio of burning residue N (retained into soil)
 //===========================================================
 // CMT06 // Wet Sedge Tundra
-//Decid.     Sedges       Grasses    Forbs        Lichens      Feather      Sphag.       PFT7         PFT8         PFT9      // names: comments                  
+//Decid      Sedges      Grasses     Forbs        Lichens      Feather      Sphag        PFT7         PFT8         PFT9      // pftnames
 0.00         0.00        0.00        0.00         0.00         0.00         0.00         0.00         0.00         0.00      // fvcomb[5][10]: fraction of each PFT vegetation combusted for 5 severities
 0.15         0.15        0.15        0.15         0.15         0.70         0.70         0.80         1.00         0.00      // 
 0.25         0.25        0.25        0.25         0.25         0.80         0.80         0.90         1.00         0.00      // 

--- a/parameters/cmt_firepar.txt
+++ b/parameters/cmt_firepar.txt
@@ -27,7 +27,7 @@
 0.10                                                   // r_retain_c: ratio of burning residue C (retained into soil) 
 0.10                                                   // r_retain_n: ratio of burning residue N (retained into soil)
 //===========================================================
-// CMT01 // Black Spruce Forest
+// CMT01 // Black Spruce Forest // ###THESE ARE JUNK VALUES!!!###
 //BlackSpr   Decid       DecidShrub  EGreen       Sphag        Feather      Moss         Lichen       Forbs        Sedge     // pftnames:
 0.00         0.00        0.00        0.00         0.00         0.00         0.00         0.00         0.00         0.00      // fvcomb[5][10]: fraction of each PFT vegetation combusted for 5 severities
 0.15         0.15        0.15        0.15         0.80         0.80         0.80         1.00         1.00         0.00      // 

--- a/parameters/cmt_firepar.txt
+++ b/parameters/cmt_firepar.txt
@@ -235,7 +235,7 @@
 0.10                                                   // r_retain_n: ratio of burning residue N (retained into soil)
 //===========================================================
 // CMT21 // EML Tussock Tundra
-//Betnan     Carex       Ericoid     Erivag       Feather     Lichen      OtherMoss    Rubcha     Sphagnum        Misc.      // names: comments
+//Betnan     Carex       Ericoid     Erivag       Feather     Lichen      OtherMoss    Rubcha     Sphagnum         PFT9      // pftnames:
 0.00         0.00        0.00        0.00         0.00         0.00         0.00         0.00         0.00         0.00      // fvcomb[5][10]: fraction of each PFT vegetation combusted for 5 severities
 0.15         0.15        0.15        0.15         0.15         0.70         0.70         0.80         1.00         0.00      // 
 0.25         0.25        0.25        0.25         0.25         0.80         0.80         0.90         1.00         0.00      // 

--- a/scripts/param_util.py
+++ b/scripts/param_util.py
@@ -543,6 +543,11 @@ if __name__ == '__main__':
       help=textwrap.dedent('''Prints the CMT number and name for each file.
         Prints na/ if the CMT does not exist in the file!'''))
 
+  parser.add_argument('--report-all-cmts', nargs=1, metavar=('FOLDER'),
+      help=textwrap.dedent('''Prints out a table with all the CMT names found
+        in each file found in the %(metavar)s. Only looks at files named like:
+        'cmt_*.txt' in the %(metavar)s.'''))
+
   args = parser.parse_args()
 
   required_param_files = [
@@ -575,6 +580,22 @@ if __name__ == '__main__':
           print "{:>45s}: {}".format(f2, (db[1]).strip())
         else:
           pass #print "{} is not a pft file!".format(f)
+    sys.exit(0)
+
+  if args.report_all_cmts:
+
+    infolder = args.report_all_cmts[0]
+
+    all_files = glob.glob(os.path.join(args.report_all_cmts[0], 'cmt_*.txt'))
+
+    for f in all_files:
+      cmts = get_CMTs_in_file(f)
+      print f
+      print "{:>7} {:>5}   {:<50s} {}".format('key', 'num', 'name', 'comment')
+      for c in cmts:
+        print "{:>7} {:>5d}   {:50s} {}".format(c['cmtkey'], c['cmtnum'], c['cmtname'], c['cmtcomment'])
+      print ""
+
     sys.exit(0)
 
   if args.report_cmt_names:

--- a/scripts/param_util.py
+++ b/scripts/param_util.py
@@ -474,7 +474,7 @@ def enforce_initvegc_split(aFile, cmtnum):
   set in initvegc variables in a cmt_bgcvegetation.txt file.
 
   The initvegc(leaf, wood, root) variables in cmt_bgcvegetation.txt are the
-  measured values from literature. The cpar(leaf, wood, root) variables, which 
+  measured values from literature. The cpart(leaf, wood, root) variables, which 
   are in the same file, should be set to the fractional make up of the the
   components. So if the initvegc values for l, w, r are 100, 200, 300, then the 
   cpart values should be 0.166, 0.33, and 0.5. It is very easy for these values
@@ -538,7 +538,10 @@ if __name__ == '__main__':
       help=textwrap.dedent('''??'''))
 
   parser.add_argument('--enforce-initvegc', nargs=2, metavar=('FILE', 'CMT'),
-      help=textwrap.dedent('''??'''))
+      help=textwrap.dedent('''Reads data from cmt_bgcvegetation.txt file for
+        the specified community and adjusts the cpart compartment parmeters so 
+        as to match the proportions of the initvegc compartment parameters.
+        Re-formats the block of data and prints to stdout.'''))
 
   parser.add_argument('--dump-block-to-json', nargs=2, metavar=('FILE', 'CMT'),
       help=textwrap.dedent('''Extract the specific CMT data block from the

--- a/scripts/param_util.py
+++ b/scripts/param_util.py
@@ -51,24 +51,16 @@ def get_CMTs_in_file(aFile):
   for i, line in enumerate(data):
     # Looks for CMT at the beginning of a comment line.
     # Will match:
-    # "// CMT06 ....", "  //   CMT06"
+    # "// CMT06 ....", or "  //   CMT06 ..."
     # but not
     # '// some other text CMT06 '
     line = line.strip().lstrip('//').strip()
     if line.find('CMT') == 0:
-      components = line.split('//')
-      clean_components = [c.strip() for c in components]
-      clean_components = filter(None, clean_components) # Get rid of empty strings
-
-      if len(clean_components) < 2:
-        error_exit(aFile, "Invalid CMT specification! Must have cmtkey AND name!", linenumber=i+1)
-
-      cmtkey = clean_components[0]
+      cmtkey, cmtname, cmtcomments = parse_header_line(line)
       cmtnum = int(cmtkey[3:])
-      cmtname = clean_components[1]
-      cmtcomments = ' // '.join(clean_components[2:])
       cmtdict = dict(cmtkey=cmtkey, cmtnum=cmtnum, cmtname=cmtname, cmtcomment=cmtcomments)
       cmt_list.append(cmtdict)
+
     elif line.find('CMT') > 0:
       # Must be a comment line, and not the start of a valid CMT data block.
       pass

--- a/scripts/param_util.py
+++ b/scripts/param_util.py
@@ -545,6 +545,10 @@ if __name__ == '__main__':
         specified data input file and print the contents to stdout as a json
         object (string).'''))
 
+  parser.add_argument('--dump-block', nargs=2, metavar=('FILE', 'CMT'),
+      help=textwrap.dedent('''Extract the specific CMT data block from the
+        specified input file and print the contents to stdout'''))
+
   parser.add_argument('--fmt-block-from-json', nargs=2, metavar=('INFILE', 'REFFILE'),
       help=textwrap.dedent('''Reads infile (assumed to be a well formed data
         dict of dvmdostem parameter data in json form), formats the block
@@ -645,6 +649,13 @@ if __name__ == '__main__':
     lines = format_CMTdatadict(dd, refFile)
     for l in lines:
       print l
+    sys.exit(0)
+
+  if args.dump_block:
+    theFile = args.dump_block[0]
+    cmt = int(args.dump_block[1])
+    d = get_CMT_datablock(theFile, cmt)
+    print ''.join(d)
     sys.exit(0)
 
   if args.dump_block_to_json:


### PR DESCRIPTION
The main purpose of this PR is to standardize the PFT names so that we can more easily integrate with PEcAn and the BetyDB, but fixed a few other things along the way:
* changes "header lines" that denote CMT blocks of data in parameter files to use a slightly different format.
* changes `param_util.py` to work with adjusted format
* standardizes PFT names for integration with (PFTs entered into BetyDB for use with PEcAn will take the form [cmt]-[pftname], so something like: CMT04-EGreen)
* comments, help text, etc to param_util.py
