### PR TITLE
Refactor lai variable names

### DIFF
--- a/calibration/calibration-viewer.py
+++ b/calibration/calibration-viewer.py
@@ -484,7 +484,7 @@ class ExpandingWindow(object):
             pfdata = json.load(pfile)
 
           for k in ["Nfeed", "AvlNFlag", "Baseline", "EnvModule", "BgcModule",
-                    "DvmModule", "DslModule", "DsbModule"]:
+                    "DynLaiModule", "DslModule", "DsbModule"]:
 
             cstate = fdata[k]
             pstate = pfdata[k]
@@ -538,7 +538,7 @@ class ExpandingWindow(object):
 
     # Then loop over the dictionary and plot a vertical line wherever necessary.
     # The module stage dictionary could looks something like this:
-    # { 12: ('DslModule', true), 54: ('DvmModule', false)}
+    # { 12: ('DslModule', true), 54: ('DynLaiModule', false)}
     for ax in self.axes:
       for k, val in module_state_dict.iteritems():
         ax.axvline(k, linestyle='--', linewidth=0.3, color='blue', label='__mscm')

--- a/include/CalController.h
+++ b/include/CalController.h
@@ -114,7 +114,7 @@ private:
 
 
   void dsl_cmd(const std::string& s);
-  void dvm_cmd(const std::string& s);
+  void dynlai_cmd(const std::string& s);
   void nfeed_cmd(const std::string& s);
   void baseline_cmd(const std::string& s);
 

--- a/include/Cohort.h
+++ b/include/Cohort.h
@@ -119,7 +119,7 @@ private:
   Integrator solintegrator;
 
 
-  void updateMonthly_DIMveg(const int & currmind, const bool & dvmmodule);
+  void updateMonthly_DIMveg(const int & currmind, const bool & dynamic_lai_module);
   void updateMonthly_DIMgrd(const int & currmind, const bool & dslmodule);
 
   void updateMonthly_Env(const int & currmind, const int & dinmcurr);

--- a/include/CohortLookup.h
+++ b/include/CohortLookup.h
@@ -58,7 +58,7 @@ public:
   double vegcov[NUM_PFT]; //actual veg. covered fraction, NOTE this is
                           //  different from 'fpc' - the former is for the
                           //  whole canopy, while the latter is for foliage
-  double lai[NUM_PFT]; //lai
+  double initial_lai[NUM_PFT]; // Starting LAI value
   int ifwoody[NUM_PFT]; //woody (1) or non-woody (0)
   int ifdeciwoody[NUM_PFT]; //deciduous (1) or evergreen (0)
                             //  woodland (forest or shrubland)

--- a/include/CohortLookup.h
+++ b/include/CohortLookup.h
@@ -66,7 +66,7 @@ public:
   int nonvascular[NUM_PFT]; //vascular plant (0), sphagnum (1),
                             //  feathermoss (2), lichen (3)
 
-  double envlai[12][NUM_PFT]; //input static monthly lai for a year
+  double static_lai[12][NUM_PFT]; // A year's worth of LAI values for use when dynamic LAI is turned off.
 
   // root distribution
   double frootfrac[MAX_ROT_LAY][NUM_PFT]; //percentage

--- a/include/ModelData.h
+++ b/include/ModelData.h
@@ -95,9 +95,9 @@ public:
   void set_bgcmodule(const std::string &s);
   void set_bgcmodule(const bool v);
 
-  bool get_dvmmodule();
-  void set_dvmmodule(const std::string &s);
-  void set_dvmmodule(const bool v);
+  bool get_dynamic_lai_module();
+  void set_dynamic_lai_module(const std::string &s);
+  void set_dynamic_lai_module(const bool v);
 
   bool get_dslmodule();
   void set_dslmodule(const std::string &s);
@@ -133,9 +133,9 @@ private:
   // adjusting c/n of soil - partial open N cycle
 
 
-  bool envmodule;  // (Bio?)physical module on/off
-  bool bgcmodule;  // BGC module on/off
-  bool dvmmodule;  // dynamic vegetation module on/off
+  bool envmodule;             // (Bio?)physical module on/off
+  bool bgcmodule;             // BGC module on/off
+  bool dynamic_lai_module;    // dynamic lai module on/off
 
   bool dslmodule;  // dynamic soil layer module on/off
   bool dsbmodule;  // disturbance module on/off

--- a/include/ModelData.h
+++ b/include/ModelData.h
@@ -82,7 +82,7 @@ public:
 
   int changeclimate; // 0: default (up to run stage); 1: dynamical; -1: static
   int changeco2; // 0: default (up to run stage); 1: dynamical; -1: static
-  bool dynamic_LAI; // True: calculate LAI as a function of vegc, False: use envlai from CohortLookup 
+  bool dynamic_LAI; // True: calculate LAI as a function of vegc, False: use static_lai from CohortLookup 
   bool useseverity; // using fire severity inputs
 
   bool outSiteDay;

--- a/include/ModelData.h
+++ b/include/ModelData.h
@@ -82,7 +82,7 @@ public:
 
   int changeclimate; // 0: default (up to run stage); 1: dynamical; -1: static
   int changeco2; // 0: default (up to run stage); 1: dynamical; -1: static
-  bool updatelai; // dynamical LAI in model or static LAI (from 'chtlu')
+  bool dynamic_LAI; // True: calculate LAI as a function of vegc, False: use envlai from CohortLookup 
   bool useseverity; // using fire severity inputs
 
   bool outSiteDay;

--- a/include/Vegetation.h
+++ b/include/Vegetation.h
@@ -25,7 +25,7 @@ public:
 
   vegpar_dim vegdimpar;
 
-  bool updateLAI5vegc;
+  bool update_LAI_from_vegc;
 
   void initializeParameter();
   void initializeState();

--- a/parameters/cmt_dimvegetation.txt
+++ b/parameters/cmt_dimvegetation.txt
@@ -291,7 +291,7 @@
 0.00        0.00        0.00         0.00         0.00         0.00         0.00         0.00         0.00         0.00         // frprod[7]:
 0.00        0.00        0.00         0.00         0.00         0.00         0.00         0.00         0.00         0.00         // frprod[8]:
 0.00        0.00        0.00         0.00         0.00         0.00         0.00         0.00         0.00         0.00         // frprod[9]:
-0.143       0.143       0.143        0.143        0.142        0.142        0.142        0.00         0.00         0.00         // initial_lai: starting value for Leaf Area Index
+0.01        0.03        0.02         0.01         2.0          1.9          2.1          0.00         0.00         0.00         // initial_lai: starting value for Leaf Area Index
 1.0         0.0         0.0          0.5          1.5          1.5          1.5          0.00         0.00         0.00         // static_lai[0]: monthly LAI for a year, used for static input of LAI
 1.1         0.0         0.0          0.3          1.5          1.5          1.5          0.00         0.00         0.00         // static_lai[1]:
 1.2         0.0         0.0          0.5          1.5          1.5          1.5          0.00         0.00         0.00         // static_lai[2]:

--- a/parameters/cmt_dimvegetation.txt
+++ b/parameters/cmt_dimvegetation.txt
@@ -34,18 +34,18 @@
 0.00        0.00        0.00         0.00         0.00         0.00         0.00         0.00         0.00         0.00         // frprod[8]: fine root allocation percentage vertically in soils (every 10 cm) 
 0.00        0.00        0.00         0.00         0.00         0.00         0.00         0.00         0.00         0.00         // frprod[9]: fine root allocation percentage vertically in soils (every 10 cm)
 0.93        0.00        0.07         0.05         0.04         0.04         0.02         0.29         0.77         0.           // initial_lai: starting value for Leaf Area Index
-1.0         0.0         0.0          0.5          1.0          0.0          1.5          0.1          1.0          0            // envlai[0]: monthly LAI for a year, used for static input of LAI
-1.1         0.0         0.0          0.3          1.5          0.0          1.5          0.2          1.5          0            // envlai[1]: monthly LAI for a year, used for static input of LAI 
-1.2         0.0         0.0          0.5          2.0          0.5          1.5          0.3          0.0          0            // envlai[2]: monthly LAI for a year, used for static input of LAI 
-1.2         0.5         1.0          1.2          1.5          1.0          1.5          0.6          0.0          0            // envlai[3]: monthly LAI for a year, used for static input of LAI
-1.3         1.3         1.9          1.3          0.3          1.3          1.5          1.3          1.3          0            // envlai[4]: monthly LAI for a year, used for static input of LAI 
-1.9         1.9         2.5          1.9          0.0          1.9          1.5          1.9          1.9          0            // envlai[5]: monthly LAI for a year, used for static input of LAI  
-2.0         2.0         2.0          2.0          0.0          2.0          1.5          0.1          0.0          0            // envlai[6]: monthly LAI for a year, used for static input of LAI 
-2.0         2.0         2.0          2.0          0.0          2.0          1.5          0.2          0.0          0            // envlai[7]: monthly LAI for a year, used for static input of LAI
-1.5         0.5         1.5          1.5          0.0          1.5          1.5          0.5          1.5          0            // envlai[8]: monthly LAI for a year, used for static input of LAI  
-1.3         0.2         0.0          1.3          0.3          1.3          1.5          1.3          1.3          0            // envlai[9]: monthly LAI for a year, used for static input of LAI
-1.1         0.0         0.0          0.8          0.5          1.0          1.5          1.9          0.0          0            // envlai[10]: monthly LAI for a year, used for static input of LAI 
-1.0         0.0         0.0          0.7          0.8          0.5          1.5          2.1          1.1          0            // envlai[11]: monthly LAI for a year, used for static input of LAI
+1.0         0.0         0.0          0.5          1.0          0.0          1.5          0.1          1.0          0            // static_lai[0]: monthly LAI for a year, used for static input of LAI
+1.1         0.0         0.0          0.3          1.5          0.0          1.5          0.2          1.5          0            // static_lai[1]:
+1.2         0.0         0.0          0.5          2.0          0.5          1.5          0.3          0.0          0            // static_lai[2]:
+1.2         0.5         1.0          1.2          1.5          1.0          1.5          0.6          0.0          0            // static_lai[3]:
+1.3         1.3         1.9          1.3          0.3          1.3          1.5          1.3          1.3          0            // static_lai[4]:
+1.9         1.9         2.5          1.9          0.0          1.9          1.5          1.9          1.9          0            // static_lai[5]:
+2.0         2.0         2.0          2.0          0.0          2.0          1.5          0.1          0.0          0            // static_lai[6]:
+2.0         2.0         2.0          2.0          0.0          2.0          1.5          0.2          0.0          0            // static_lai[7]:
+1.5         0.5         1.5          1.5          0.0          1.5          1.5          0.5          1.5          0            // static_lai[8]:
+1.3         0.2         0.0          1.3          0.3          1.3          1.5          1.3          1.3          0            // static_lai[9]:
+1.1         0.0         0.0          0.8          0.5          1.0          1.5          1.9          0.0          0            // static_lai[10]:
+1.0         0.0         0.0          0.7          0.8          0.5          1.5          2.1          1.1          0            // static_lai[11]:
 //===========================================================
 // CMT01 // Black Spruce Forest //###THESE ARE JUNK VALUES!!!###
 //BlackSpr  Decid       DecidShrub   EGreen       Sphag      Feather        Moss         Lichen       Forbs        Sedge        // pftnames:
@@ -77,18 +77,18 @@
 0.00        0.00        0.00         0.00         0.00         0.00         0.00         0.00         0.00         0.00         // frprod[8]: fine root allocation percentage vertically in soils (every 10 cm) 
 0.00        0.00        0.00         0.00         0.00         0.00         0.00         0.00         0.00         0.00         // frprod[9]: fine root allocation percentage vertically in soils (every 10 cm)
 0.93        0.93        0.07         0.05         0.04         0.04         0.02         0.29         0.77         0.           // initial_lai: starting value for Leaf Area Index
-1.00        1.00        0.50         0.50         0.50         0.50         0.50         0.5          1.0          0            // envlai[0]: monthly LAI for a year, used for static input of LAI
-1.1         1.1         0.0          0.3          1.5          0.0          1.5          0.2          1.5          0            // envlai[1]: monthly LAI for a year, used for static input of LAI 
-1.2         1.2         0.0          0.5          2.0          0.5          1.5          0.3          0.0          0            // envlai[2]: monthly LAI for a year, used for static input of LAI 
-1.2         1.2         1.0          1.2          1.5          1.0          1.5          0.6          0.0          0            // envlai[3]: monthly LAI for a year, used for static input of LAI
-1.3         1.3         1.9          1.3          0.3          1.3          1.5          1.3          1.3          0            // envlai[4]: monthly LAI for a year, used for static input of LAI 
-1.9         1.9         2.5          1.9          0.0          1.9          1.5          1.9          1.9          0            // envlai[5]: monthly LAI for a year, used for static input of LAI  
-2.0         2.0         2.0          2.0          0.0          2.0          1.5          0.1          0.0          0            // envlai[6]: monthly LAI for a year, used for static input of LAI 
-2.0         2.0         2.0          2.0          0.0          2.0          1.5          0.2          0.0          0            // envlai[7]: monthly LAI for a year, used for static input of LAI
-1.5         1.5         1.5          1.5          0.0          1.5          1.5          0.5          1.5          0            // envlai[8]: monthly LAI for a year, used for static input of LAI  
-1.3         1.5         0.0          1.3          0.3          1.3          1.5          1.3          1.3          0            // envlai[9]: monthly LAI for a year, used for static input of LAI
-1.1         1.5         0.0          0.8          0.5          1.0          1.5          1.9          0.0          0            // envlai[10]: monthly LAI for a year, used for static input of LAI 
-1.0         1.5         0.0          0.7          0.8          0.5          1.5          2.1          1.1          0            // envlai[11]: monthly LAI for a year, used for static input of LAI
+1.00        1.00        0.50         0.50         0.50         0.50         0.50         0.5          1.0          0            // static_lai[0]: monthly LAI for a year, used for static input of LAI
+1.1         1.1         0.0          0.3          1.5          0.0          1.5          0.2          1.5          0            // static_lai[1]:
+1.2         1.2         0.0          0.5          2.0          0.5          1.5          0.3          0.0          0            // static_lai[2]:
+1.2         1.2         1.0          1.2          1.5          1.0          1.5          0.6          0.0          0            // static_lai[3]:
+1.3         1.3         1.9          1.3          0.3          1.3          1.5          1.3          1.3          0            // static_lai[4]:
+1.9         1.9         2.5          1.9          0.0          1.9          1.5          1.9          1.9          0            // static_lai[5]:
+2.0         2.0         2.0          2.0          0.0          2.0          1.5          0.1          0.0          0            // static_lai[6]:
+2.0         2.0         2.0          2.0          0.0          2.0          1.5          0.2          0.0          0            // static_lai[7]:
+1.5         1.5         1.5          1.5          0.0          1.5          1.5          0.5          1.5          0            // static_lai[8]:
+1.3         1.5         0.0          1.3          0.3          1.3          1.5          1.3          1.3          0            // static_lai[9]:
+1.1         1.5         0.0          0.8          0.5          1.0          1.5          1.9          0.0          0            // static_lai[10]:
+1.0         1.5         0.0          0.7          0.8          0.5          1.5          2.1          1.1          0            // static_lai[11]:
 //===========================================================
 // CMT02 // White Spruce Forest
 //PFT0      PFT1        PFT2         PFT3         PFT4         PFT5         PFT6         PFT7         PFT8         PFT9         // names: comments                  
@@ -120,18 +120,18 @@
 0.00        0.00        0.00         0.00         0.00         0.00         0.00         0.00         0.00         0.00         // frprod[8]: fine root allocation percentage vertically in soils (every 10 cm) 
 0.00        0.00        0.00         0.00         0.00         0.00         0.00         0.00         0.00         0.00         // frprod[9]: fine root allocation percentage vertically in soils (every 10 cm)
 0.93        0.00        0.07         0.05         0.04         0.04         0.02         0.29         0.77         0.           // initial_lai: starting value for Leaf Area Index
-1.0         0.0         0.0          0.5          1.0          0.0          1.5          0.1          1.0          0            // envlai[0]: monthly LAI for a year, used for static input of LAI
-1.1         0.0         0.0          0.3          1.5          0.0          1.5          0.2          1.5          0            // envlai[1]: monthly LAI for a year, used for static input of LAI 
-1.2         0.0         0.0          0.5          2.0          0.5          1.5          0.3          0.0          0            // envlai[2]: monthly LAI for a year, used for static input of LAI 
-1.2         0.5         1.0          1.2          1.5          1.0          1.5          0.6          0.0          0            // envlai[3]: monthly LAI for a year, used for static input of LAI
-1.3         1.3         1.9          1.3          0.3          1.3          1.5          1.3          1.3          0            // envlai[4]: monthly LAI for a year, used for static input of LAI 
-1.9         1.9         2.5          1.9          0.0          1.9          1.5          1.9          1.9          0            // envlai[5]: monthly LAI for a year, used for static input of LAI  
-2.0         2.0         2.0          2.0          0.0          2.0          1.5          0.1          0.0          0            // envlai[6]: monthly LAI for a year, used for static input of LAI 
-2.0         2.0         2.0          2.0          0.0          2.0          1.5          0.2          0.0          0            // envlai[7]: monthly LAI for a year, used for static input of LAI
-1.5         0.5         1.5          1.5          0.0          1.5          1.5          0.5          1.5          0            // envlai[8]: monthly LAI for a year, used for static input of LAI  
-1.3         0.2         0.0          1.3          0.3          1.3          1.5          1.3          1.3          0            // envlai[9]: monthly LAI for a year, used for static input of LAI
-1.1         0.0         0.0          0.8          0.5          1.0          1.5          1.9          0.0          0            // envlai[10]: monthly LAI for a year, used for static input of LAI 
-1.0         0.0         0.0          0.7          0.8          0.5          1.5          2.1          1.1          0            // envlai[11]: monthly LAI for a year, used for static input of LAI
+1.0         0.0         0.0          0.5          1.0          0.0          1.5          0.1          1.0          0            // static_lai[0]: monthly LAI for a year, used for static input of LAI
+1.1         0.0         0.0          0.3          1.5          0.0          1.5          0.2          1.5          0            // static_lai[1]:
+1.2         0.0         0.0          0.5          2.0          0.5          1.5          0.3          0.0          0            // static_lai[2]:
+1.2         0.5         1.0          1.2          1.5          1.0          1.5          0.6          0.0          0            // static_lai[3]:
+1.3         1.3         1.9          1.3          0.3          1.3          1.5          1.3          1.3          0            // static_lai[4]:
+1.9         1.9         2.5          1.9          0.0          1.9          1.5          1.9          1.9          0            // static_lai[5]:
+2.0         2.0         2.0          2.0          0.0          2.0          1.5          0.1          0.0          0            // static_lai[6]:
+2.0         2.0         2.0          2.0          0.0          2.0          1.5          0.2          0.0          0            // static_lai[7]:
+1.5         0.5         1.5          1.5          0.0          1.5          1.5          0.5          1.5          0            // static_lai[8]:
+1.3         0.2         0.0          1.3          0.3          1.3          1.5          1.3          1.3          0            // static_lai[9]:
+1.1         0.0         0.0          0.8          0.5          1.0          1.5          1.9          0.0          0            // static_lai[10]:
+1.0         0.0         0.0          0.7          0.8          0.5          1.5          2.1          1.1          0            // static_lai[11]:
 //===========================================================
 // CMT03 // Boreal Deciduous Forest
 //PFT0      PFT1        PFT2         PFT3         PFT4         PFT5         PFT6         PFT7         PFT8         PFT9         // names: comments                  
@@ -163,18 +163,18 @@
 0.00        0.00        0.00         0.00         0.00         0.00         0.00         0.00         0.00         0.00         // frprod[8]: fine root allocation percentage vertically in soils (every 10 cm) 
 0.00        0.00        0.00         0.00         0.00         0.00         0.00         0.00         0.00         0.00         // frprod[9]: fine root allocation percentage vertically in soils (every 10 cm)
 0.93        0.00        0.07         0.05         0.04         0.04         0.02         0.29         0.77         0.           // initial_lai: starting value for Leaf Area Index
-1.0         0.0         0.0          0.5          1.0          0.0          1.5          0.1          1.0          0            // envlai[0]: monthly LAI for a year, used for static input of LAI
-1.1         0.0         0.0          0.3          1.5          0.0          1.5          0.2          1.5          0            // envlai[1]: monthly LAI for a year, used for static input of LAI 
-1.2         0.0         0.0          0.5          2.0          0.5          1.5          0.3          0.0          0            // envlai[2]: monthly LAI for a year, used for static input of LAI 
-1.2         0.5         1.0          1.2          1.5          1.0          1.5          0.6          0.0          0            // envlai[3]: monthly LAI for a year, used for static input of LAI
-1.3         1.3         1.9          1.3          0.3          1.3          1.5          1.3          1.3          0            // envlai[4]: monthly LAI for a year, used for static input of LAI 
-1.9         1.9         2.5          1.9          0.0          1.9          1.5          1.9          1.9          0            // envlai[5]: monthly LAI for a year, used for static input of LAI  
-2.0         2.0         2.0          2.0          0.0          2.0          1.5          0.1          0.0          0            // envlai[6]: monthly LAI for a year, used for static input of LAI 
-2.0         2.0         2.0          2.0          0.0          2.0          1.5          0.2          0.0          0            // envlai[7]: monthly LAI for a year, used for static input of LAI
-1.5         0.5         1.5          1.5          0.0          1.5          1.5          0.5          1.5          0            // envlai[8]: monthly LAI for a year, used for static input of LAI  
-1.3         0.2         0.0          1.3          0.3          1.3          1.5          1.3          1.3          0            // envlai[9]: monthly LAI for a year, used for static input of LAI
-1.1         0.0         0.0          0.8          0.5          1.0          1.5          1.9          0.0          0            // envlai[10]: monthly LAI for a year, used for static input of LAI 
-1.0         0.0         0.0          0.7          0.8          0.5          1.5          2.1          1.1          0            // envlai[11]: monthly LAI for a year, used for static input of LAI
+1.0         0.0         0.0          0.5          1.0          0.0          1.5          0.1          1.0          0            // static_lai[0]: monthly LAI for a year, used for static input of LAI
+1.1         0.0         0.0          0.3          1.5          0.0          1.5          0.2          1.5          0            // static_lai[1]:
+1.2         0.0         0.0          0.5          2.0          0.5          1.5          0.3          0.0          0            // static_lai[2]:
+1.2         0.5         1.0          1.2          1.5          1.0          1.5          0.6          0.0          0            // static_lai[3]:
+1.3         1.3         1.9          1.3          0.3          1.3          1.5          1.3          1.3          0            // static_lai[4]:
+1.9         1.9         2.5          1.9          0.0          1.9          1.5          1.9          1.9          0            // static_lai[5]:
+2.0         2.0         2.0          2.0          0.0          2.0          1.5          0.1          0.0          0            // static_lai[6]:
+2.0         2.0         2.0          2.0          0.0          2.0          1.5          0.2          0.0          0            // static_lai[7]:
+1.5         0.5         1.5          1.5          0.0          1.5          1.5          0.5          1.5          0            // static_lai[8]:
+1.3         0.2         0.0          1.3          0.3          1.3          1.5          1.3          1.3          0            // static_lai[9]:
+1.1         0.0         0.0          0.8          0.5          1.0          1.5          1.9          0.0          0            // static_lai[10]:
+1.0         0.0         0.0          0.7          0.8          0.5          1.5          2.1          1.1          0            // static_lai[11]:
 //===========================================================
 // CMT04 // Shrub Tundra
 //Salix     Betula      Decid        EGreen       Sedges       Forbs        Grasses      Lichens      Feather      PFT9         // pftnames:
@@ -206,18 +206,18 @@
 0.00        0.00        0.00         0.00         0.00         0.00         0.00         0.00         0.00         0.00         // frprod[8]: fine root allocation percentage vertically in soils (every 10 cm) 
 0.00        0.00        0.00         0.00         0.00         0.00         0.00         0.00         0.00         0.00         // frprod[9]: fine root allocation percentage vertically in soils (every 10 cm)
 0.93        0.00        0.07         0.05         0.04         0.04         0.02         0.29         0.77         0.           // initial_lai: starting value for Leaf Area Index
-1.0         0.0         0.0          0.5          1.0          0.0          1.5          0.1          1.0          0            // envlai[0]: monthly LAI for a year, used for static input of LAI
-1.1         0.0         0.0          0.3          1.5          0.0          1.5          0.2          1.5          0            // envlai[1]: monthly LAI for a year, used for static input of LAI 
-1.2         0.0         0.0          0.5          2.0          0.5          1.5          0.3          0.0          0            // envlai[2]: monthly LAI for a year, used for static input of LAI 
-1.2         0.5         1.0          1.2          1.5          1.0          1.5          0.6          0.0          0            // envlai[3]: monthly LAI for a year, used for static input of LAI
-1.3         1.3         1.9          1.3          0.3          1.3          1.5          1.3          1.3          0            // envlai[4]: monthly LAI for a year, used for static input of LAI 
-1.9         1.9         2.5          1.9          0.0          1.9          1.5          1.9          1.9          0            // envlai[5]: monthly LAI for a year, used for static input of LAI  
-2.0         2.0         2.0          2.0          0.0          2.0          1.5          0.1          0.0          0            // envlai[6]: monthly LAI for a year, used for static input of LAI 
-2.0         2.0         2.0          2.0          0.0          2.0          1.5          0.2          0.0          0            // envlai[7]: monthly LAI for a year, used for static input of LAI
-1.5         0.5         1.5          1.5          0.0          1.5          1.5          0.5          1.5          0            // envlai[8]: monthly LAI for a year, used for static input of LAI  
-1.3         0.2         0.0          1.3          0.3          1.3          1.5          1.3          1.3          0            // envlai[9]: monthly LAI for a year, used for static input of LAI
-1.1         0.0         0.0          0.8          0.5          1.0          1.5          1.9          0.0          0            // envlai[10]: monthly LAI for a year, used for static input of LAI 
-1.0         0.0         0.0          0.7          0.8          0.5          1.5          2.1          1.1          0            // envlai[11]: monthly LAI for a year, used for static input of LAI
+1.0         0.0         0.0          0.5          1.0          0.0          1.5          0.1          1.0          0            // static_lai[0]: monthly LAI for a year, used for static input of LAI
+1.1         0.0         0.0          0.3          1.5          0.0          1.5          0.2          1.5          0            // static_lai[1]:
+1.2         0.0         0.0          0.5          2.0          0.5          1.5          0.3          0.0          0            // static_lai[2]:
+1.2         0.5         1.0          1.2          1.5          1.0          1.5          0.6          0.0          0            // static_lai[3]:
+1.3         1.3         1.9          1.3          0.3          1.3          1.5          1.3          1.3          0            // static_lai[4]:
+1.9         1.9         2.5          1.9          0.0          1.9          1.5          1.9          1.9          0            // static_lai[5]:
+2.0         2.0         2.0          2.0          0.0          2.0          1.5          0.1          0.0          0            // static_lai[6]:
+2.0         2.0         2.0          2.0          0.0          2.0          1.5          0.2          0.0          0            // static_lai[7]:
+1.5         0.5         1.5          1.5          0.0          1.5          1.5          0.5          1.5          0            // static_lai[8]:
+1.3         0.2         0.0          1.3          0.3          1.3          1.5          1.3          1.3          0            // static_lai[9]:
+1.1         0.0         0.0          0.8          0.5          1.0          1.5          1.9          0.0          0            // static_lai[10]:
+1.0         0.0         0.0          0.7          0.8          0.5          1.5          2.1          1.1          0            // static_lai[11]:
 //===========================================================
 // CMT05 // Tussock Tundra // (updated 1/15/2016 JDC)
 //Betula    Decid       EGreen       Sedges       Forbs        Lichens      Feather      Sphag        PFT8         PFT9         // pftnames:
@@ -249,18 +249,18 @@
 0.00        0.00        0.00         0.00         0.00         0.00         0.00         0.00         0.00         0.00         // frprod[8]:
 0.00        0.00        0.00         0.00         0.00         0.00         0.00         0.00         0.00         0.00         // frprod[9]:
 0.125       0.125       0.125        0.125        0.125        0.125        0.125        0.125        0.00         0.00         // initial_lai: starting value for Leaf Area Index
-0.0         0.0         0.5          0.0          0.0          2.00         2.00         2.00          0            0           // envlai[0]: monthly lai for a year, used for static input of LAI
-0.0         0.0         0.3          0.0          0.0          2.00         2.00         2.00          0            0           // envlai[1]:   
-0.0         0.0         0.5          0.0          0.5          2.00         2.00         2.00          0            0           // envlai[2]: 
-0.5         1.0         1.2          0.5          1.0          2.00         2.00         2.00          0            0           // envlai[3]:
-1.3         1.9         1.3          1.5          1.3          2.00         2.00         2.00          0            0           // envlai[4]:
-1.9         2.5         1.9          1.5          1.9          2.00         2.00         2.00          0            0           // envlai[5]:
-2.0         2.0         2.0          1.5          2.0          2.00         2.00         2.00          0            0           // envlai[6]:
-2.0         2.0         2.0          1.5          2.0          2.00         2.00         2.00          0            0           // envlai[7]:
-0.5         1.5         1.5          1.0          1.5          2.00         2.00         2.00          0            0           // envlai[8]:
-0.2         0.0         1.3          0.5          1.3          2.00         2.00         2.00          0            0           // envlai[9]:
-0.0         0.0         0.8          0.0          1.0          2.00         2.00         2.00          0            0           // envlai[10]:
-0.0         0.0         0.7          0.0          0.5          2.00         2.00         2.00          0            0           // envlai[11]:
+0.0         0.0         0.5          0.0          0.0          2.00         2.00         2.00          0            0           // static_lai[0]: monthly lai for a year, used for static input of LAI
+0.0         0.0         0.3          0.0          0.0          2.00         2.00         2.00          0            0           // static_lai[1]:
+0.0         0.0         0.5          0.0          0.5          2.00         2.00         2.00          0            0           // static_lai[2]:
+0.5         1.0         1.2          0.5          1.0          2.00         2.00         2.00          0            0           // static_lai[3]:
+1.3         1.9         1.3          1.5          1.3          2.00         2.00         2.00          0            0           // static_lai[4]:
+1.9         2.5         1.9          1.5          1.9          2.00         2.00         2.00          0            0           // static_lai[5]:
+2.0         2.0         2.0          1.5          2.0          2.00         2.00         2.00          0            0           // static_lai[6]:
+2.0         2.0         2.0          1.5          2.0          2.00         2.00         2.00          0            0           // static_lai[7]:
+0.5         1.5         1.5          1.0          1.5          2.00         2.00         2.00          0            0           // static_lai[8]:
+0.2         0.0         1.3          0.5          1.3          2.00         2.00         2.00          0            0           // static_lai[9]:
+0.0         0.0         0.8          0.0          1.0          2.00         2.00         2.00          0            0           // static_lai[10]:
+0.0         0.0         0.7          0.0          0.5          2.00         2.00         2.00          0            0           // static_lai[11]:
 //===========================================================
 // CMT06 // Wet Sedge Tundra
 //Decid     Sedges      Grasses      Forbs        Lichens      Feather      Sphag        PFT7         PFT8         PFT9         // pftnames
@@ -292,18 +292,18 @@
 0.00        0.00        0.00         0.00         0.00         0.00         0.00         0.00         0.00         0.00         // frprod[8]:
 0.00        0.00        0.00         0.00         0.00         0.00         0.00         0.00         0.00         0.00         // frprod[9]:
 0.143       0.143       0.143        0.143        0.142        0.142        0.142        0.00         0.00         0.00         // initial_lai: starting value for Leaf Area Index
-1.0         0.0         0.0          0.5          1.5          1.5          1.5          0.00         0.00         0.00         // envlai[0]: monthly LAI for a year, used for static input of LAI
-1.1         0.0         0.0          0.3          1.5          1.5          1.5          0.00         0.00         0.00         // envlai[1]: monthly LAI for a year, used for static input of LAI 
-1.2         0.0         0.0          0.5          1.5          1.5          1.5          0.00         0.00         0.00         // envlai[2]: monthly LAI for a year, used for static input of LAI 
-1.2         0.5         1.0          1.2          1.5          1.5          1.5          0.00         0.00         0.00         // envlai[3]: monthly LAI for a year, used for static input of LAI
-1.3         1.3         1.9          1.3          1.5          1.5          1.5          0.00         0.00         0.00         // envlai[4]: monthly LAI for a year, used for static input of LAI 
-1.9         1.9         2.5          1.9          1.5          1.5          1.5          0.00         0.00         0.00         // envlai[5]: monthly LAI for a year, used for static input of LAI  
-2.0         2.0         2.0          2.0          1.5          1.5          1.5          0.00         0.00         0.00         // envlai[6]: monthly LAI for a year, used for static input of LAI 
-2.0         2.0         2.0          2.0          1.5          1.5          1.5          0.00         0.00         0.00         // envlai[7]: monthly LAI for a year, used for static input of LAI
-1.5         0.5         1.5          1.5          1.5          1.5          1.5          0.00         0.00         0.00         // envlai[8]: monthly LAI for a year, used for static input of LAI  
-1.3         0.2         0.0          1.3          1.5          1.5          1.5          0.00         0.00         0.00         // envlai[9]: monthly LAI for a year, used for static input of LAI
-1.1         0.0         0.0          0.8          1.5          1.5          1.5          0.00         0.00         0.00         // envlai[10]: monthly LAI for a year, used for static input of LAI 
-1.0         0.0         0.0          0.7          1.5          1.5          1.5          0.00         0.00         0.00         // envlai[11]: monthly LAI for a year, used for static input of LAI
+1.0         0.0         0.0          0.5          1.5          1.5          1.5          0.00         0.00         0.00         // static_lai[0]: monthly LAI for a year, used for static input of LAI
+1.1         0.0         0.0          0.3          1.5          1.5          1.5          0.00         0.00         0.00         // static_lai[1]:
+1.2         0.0         0.0          0.5          1.5          1.5          1.5          0.00         0.00         0.00         // static_lai[2]:
+1.2         0.5         1.0          1.2          1.5          1.5          1.5          0.00         0.00         0.00         // static_lai[3]:
+1.3         1.3         1.9          1.3          1.5          1.5          1.5          0.00         0.00         0.00         // static_lai[4]:
+1.9         1.9         2.5          1.9          1.5          1.5          1.5          0.00         0.00         0.00         // static_lai[5]:
+2.0         2.0         2.0          2.0          1.5          1.5          1.5          0.00         0.00         0.00         // static_lai[6]:
+2.0         2.0         2.0          2.0          1.5          1.5          1.5          0.00         0.00         0.00         // static_lai[7]:
+1.5         0.5         1.5          1.5          1.5          1.5          1.5          0.00         0.00         0.00         // static_lai[8]:
+1.3         0.2         0.0          1.3          1.5          1.5          1.5          0.00         0.00         0.00         // static_lai[9]:
+1.1         0.0         0.0          0.8          1.5          1.5          1.5          0.00         0.00         0.00         // static_lai[10]:
+1.0         0.0         0.0          0.7          1.5          1.5          1.5          0.00         0.00         0.00         // static_lai[11]:
 //===========================================================
 // CMT07 // Heath Tundra
 //Decid     EGreen      Forbs        Lichens      Grasses      Moss         PFT6         PFT7         PFT8         PFT9         // pftnames:
@@ -335,18 +335,18 @@
 0.00        0.00        0.00         0.00         0.00         0.00         0.00         0.00         0.00         0.00         // frprod[8]:
 0.00        0.00        0.00         0.00         0.00         0.00         0.00         0.00         0.00         0.00         // frprod[9]:
 0.93        0.00        0.07         0.05         0.04         0.04         0.00         0.00         0.00         0.00         // initial_lai: starting value for Leaf Area Index
-1.0         0.0         0.0          0.5          1.0          0.0          0.00         0.00         0.00         0.00         // envlai[0]: monthly LAI for a year, used for static input of LAI
-1.1         0.0         0.0          0.3          1.5          0.0          0.00         0.00         0.00         0.00         // envlai[1]: monthly LAI for a year, used for static input of LAI 
-1.2         0.0         0.0          0.5          2.0          0.5          0.00         0.00         0.00         0.00         // envlai[2]: monthly LAI for a year, used for static input of LAI 
-1.2         0.5         1.0          1.2          1.5          1.0          0.00         0.00         0.00         0.00         // envlai[3]: monthly LAI for a year, used for static input of LAI
-1.3         1.3         1.9          1.3          0.3          1.3          0.00         0.00         0.00         0.00         // envlai[4]: monthly LAI for a year, used for static input of LAI 
-1.9         1.9         2.5          1.9          0.0          1.9          0.00         0.00         0.00         0.00         // envlai[5]: monthly LAI for a year, used for static input of LAI  
-2.0         2.0         2.0          2.0          0.0          2.0          0.00         0.00         0.00         0.00         // envlai[6]: monthly LAI for a year, used for static input of LAI 
-2.0         2.0         2.0          2.0          0.0          2.0          0.00         0.00         0.00         0.00         // envlai[7]: monthly LAI for a year, used for static input of LAI
-1.5         0.5         1.5          1.5          0.0          1.5          0.00         0.00         0.00         0.00         // envlai[8]: monthly LAI for a year, used for static input of LAI  
-1.3         0.2         0.0          1.3          0.3          1.3          0.00         0.00         0.00         0.00         // envlai[9]: monthly LAI for a year, used for static input of LAI
-1.1         0.0         0.0          0.8          0.5          1.0          0.00         0.00         0.00         0.00         // envlai[10]: monthly LAI for a year, used for static input of LAI 
-1.0         0.0         0.0          0.7          0.8          0.5          0.00         0.00         0.00         0.00         // envlai[11]: monthly LAI for a year, used for static input of LAI
+1.0         0.0         0.0          0.5          1.0          0.0          0.00         0.00         0.00         0.00         // static_lai[0]: monthly LAI for a year, used for static input of LAI
+1.1         0.0         0.0          0.3          1.5          0.0          0.00         0.00         0.00         0.00         // static_lai[1]:
+1.2         0.0         0.0          0.5          2.0          0.5          0.00         0.00         0.00         0.00         // static_lai[2]:
+1.2         0.5         1.0          1.2          1.5          1.0          0.00         0.00         0.00         0.00         // static_lai[3]:
+1.3         1.3         1.9          1.3          0.3          1.3          0.00         0.00         0.00         0.00         // static_lai[4]:
+1.9         1.9         2.5          1.9          0.0          1.9          0.00         0.00         0.00         0.00         // static_lai[5]:
+2.0         2.0         2.0          2.0          0.0          2.0          0.00         0.00         0.00         0.00         // static_lai[6]:
+2.0         2.0         2.0          2.0          0.0          2.0          0.00         0.00         0.00         0.00         // static_lai[7]:
+1.5         0.5         1.5          1.5          0.0          1.5          0.00         0.00         0.00         0.00         // static_lai[8]:
+1.3         0.2         0.0          1.3          0.3          1.3          0.00         0.00         0.00         0.00         // static_lai[9]:
+1.1         0.0         0.0          0.8          0.5          1.0          0.00         0.00         0.00         0.00         // static_lai[10]:
+1.0         0.0         0.0          0.7          0.8          0.5          0.00         0.00         0.00         0.00         // static_lai[11]:
 //===========================================================
 // CMT12 // Lowland Boreal Wet Shrubland
 //DecShrub   EvrShrub     DecTree      EvrTree      Forbs        Gram        Feather      Lichen      Equisetum      PFT9         // pftnames:
@@ -378,18 +378,18 @@
 0.00         0.00         0.00         0.00         0.00         0.00         0.00         0.00         0.00         0.00         // frprod[8]:
 0.00         0.00         0.00         0.00         0.00         0.00         0.00         0.00         0.00         0.00         // frprod[9]:
 0.125        0.125        0.125        0.125        0.125        0.125        0.125        0.125        0.00         0.00         // initial_lai: starting value for Leaf Area Index
-0.0          0.5          0.0          0.5          0.0          0.0          2.00         2.00         0.0          0             // envlai[0]: monthly lai for a year, used for static input of LAI
-0.0          0.3          0.0          0.3          0.0          0.0          2.00         2.00         0.0          0             // envlai[1]:   
-0.0          0.5          0.0          0.5          0.5          0.0          2.00         2.00         0.5          0             // envlai[2]: 
-1.0          1.2          1.0          1.2          1.0          0.5          2.00         2.00         1.0          0             // envlai[3]:
-1.9          1.3          1.9          1.3          1.3          1.5          2.00         2.00         1.3          0             // envlai[4]:
-2.5          1.9          2.5          1.9          1.9          1.5          2.00         2.00         1.9          0             // envlai[5]:
-2.0          2.0          2.0          2.0          2.0          1.5          2.00         2.00         2.0          0             // envlai[6]:
-2.0          2.0          2.0          2.0          2.0          1.5          2.00         2.00         2.0          0           // envlai[7]:
-1.5          1.5          1.5          1.5          1.5          1.0          2.00         2.00         1.5          0           // envlai[8]:
-0.0          1.3          0.0          1.3          1.3          0.5          2.00         2.00         1.3          0           // envlai[9]:
-0.0          0.8          0.0          0.8          1.0          0.0          2.00         2.00         0.8          0           // envlai[10]:
-0.0          0.7          0.0          0.7          0.5          0.0          2.00         2.00         0.7          0           // envlai[11]:
+0.0          0.5          0.0          0.5          0.0          0.0          2.00         2.00         0.0          0             // static_lai[0]: monthly lai for a year, used for static input of LAI
+0.0          0.3          0.0          0.3          0.0          0.0          2.00         2.00         0.0          0             // static_lai[1]:
+0.0          0.5          0.0          0.5          0.5          0.0          2.00         2.00         0.5          0             // static_lai[2]:
+1.0          1.2          1.0          1.2          1.0          0.5          2.00         2.00         1.0          0             // static_lai[3]:
+1.9          1.3          1.9          1.3          1.3          1.5          2.00         2.00         1.3          0             // static_lai[4]:
+2.5          1.9          2.5          1.9          1.9          1.5          2.00         2.00         1.9          0             // static_lai[5]:
+2.0          2.0          2.0          2.0          2.0          1.5          2.00         2.00         2.0          0             // static_lai[6]:
+2.0          2.0          2.0          2.0          2.0          1.5          2.00         2.00         2.0          0           // static_lai[7]:
+1.5          1.5          1.5          1.5          1.5          1.0          2.00         2.00         1.5          0           // static_lai[8]:
+0.0          1.3          0.0          1.3          1.3          0.5          2.00         2.00         1.3          0           // static_lai[9]:
+0.0          0.8          0.0          0.8          1.0          0.0          2.00         2.00         0.8          0           // static_lai[10]:
+0.0          0.7          0.0          0.7          0.5          0.0          2.00         2.00         0.7          0           // static_lai[11]:
 //===========================================================
 // CMT20 // EML Shrub Tundra
 //Betnan     Carex        Ericoid      Feather      Lichen      OthMoss       Rubcha       Misc1        Misc2        Misc3        // names: comments
@@ -421,18 +421,18 @@
 0.00         0.00         0.00         0.00         0.00         0.00         0.00         0.00         0.00         0.00         // frprod[8]:
 0.00         0.00         0.00         0.00         0.00         0.00         0.00         0.00         0.00         0.00         // frprod[9]:
 0.00         0.04         0.05         0.77         0.29         0.77         0.07         0.00         0.00         0.00         // initial_lai: starting value for Leaf Area Index
-0.0          1.0          0.5          1.0          0.1          1.0          0.0          0.0          0.0          0.0          // envlai[0]: monthly lai for a year, used for static input of LAI
-0.0          1.5          0.3          1.5          0.2          1.5          0.0          0.0          0.0          0.0          // envlai[1]:   
-0.0          2.0          0.5          0.0          0.3          0.0          0.0          0.0          0.0          0.0          // envlai[2]: 
-0.5          1.5          1.2          0.0          0.6          0.0          1.0          0.0          0.0          0.0          // envlai[3]:
-1.3          0.3          1.3          1.3          1.3          1.3          1.9          0.0          0.0          0.0          // envlai[4]:
-1.9          0.0          1.9          1.9          1.9          1.9          2.5          0.0          0.0          0.0          // envlai[5]:
-2.0          0.0          2.0          0.0          0.1          0.0          2.0          0.0          0.0          0.0          // envlai[6]:
-2.0          0.0          2.0          0.0          0.2          0.0          2.0          0.0          0.0          0.0          // envlai[7]:
-0.5          0.0          1.5          1.5          0.5          1.5          1.5          0.0          0.0          0.0          // envlai[8]:
-0.2          0.3          1.3          1.3          1.3          1.3          0.0          0.0          0.0          0.0          // envlai[9]:
-0.0          0.5          0.8          0.0          1.9          0.0          0.0          0.0          0.0          0.0          // envlai[10]:
-0.0          0.8          0.7          1.1          2.1          1.1          0.0          0.0          0.0          0.0          // envlai[11]:
+0.0          1.0          0.5          1.0          0.1          1.0          0.0          0.0          0.0          0.0          // static_lai[0]: monthly lai for a year, used for static input of LAI
+0.0          1.5          0.3          1.5          0.2          1.5          0.0          0.0          0.0          0.0          // static_lai[1]:
+0.0          2.0          0.5          0.0          0.3          0.0          0.0          0.0          0.0          0.0          // static_lai[2]:
+0.5          1.5          1.2          0.0          0.6          0.0          1.0          0.0          0.0          0.0          // static_lai[3]:
+1.3          0.3          1.3          1.3          1.3          1.3          1.9          0.0          0.0          0.0          // static_lai[4]:
+1.9          0.0          1.9          1.9          1.9          1.9          2.5          0.0          0.0          0.0          // static_lai[5]:
+2.0          0.0          2.0          0.0          0.1          0.0          2.0          0.0          0.0          0.0          // static_lai[6]:
+2.0          0.0          2.0          0.0          0.2          0.0          2.0          0.0          0.0          0.0          // static_lai[7]:
+0.5          0.0          1.5          1.5          0.5          1.5          1.5          0.0          0.0          0.0          // static_lai[8]:
+0.2          0.3          1.3          1.3          1.3          1.3          0.0          0.0          0.0          0.0          // static_lai[9]:
+0.0          0.5          0.8          0.0          1.9          0.0          0.0          0.0          0.0          0.0          // static_lai[10]:
+0.0          0.8          0.7          1.1          2.1          1.1          0.0          0.0          0.0          0.0          // static_lai[11]:
 //===========================================================
 // CMT21 // EML Tussock Tundra
 //Betnan     Carex        Ericoid      Erivag       Feather     Lichen       OtherMoss    Rubcha      Sphagnum       PFT9         // pftnames:
@@ -464,15 +464,15 @@
 0.00         0.243        0.00         0.00         0.00         0.00         0.00         0.162        0.00         0.00         // frprod[8]:
 0.00         0.080        0.00         0.00         0.00         0.00         0.00         0.00         0.00         0.00         // frprod[9]:
 0.125        0.125        0.125        0.125        0.125        0.125        0.125        0.125        0.125        0.00         // initial_lai: starting value for Leaf Area Index
-0.0          0.0          0.5          0.0          2.0          2.0          2.0          0.0          2.0          0.0          // envlai[0]: monthly lai for a year, used for static input of LAI
-0.0          0.0          0.3          0.0          2.0          2.0          2.0          0.0          2.0          0.0          // envlai[1]:   
-0.0          0.0          0.5          0.0          2.0          2.0          2.0          0.0          2.0          0.0          // envlai[2]: 
-0.5          0.5          1.2          0.5          2.0          2.0          2.0          1.0          2.0          0.0          // envlai[3]:
-1.3          1.5          1.3          1.5          2.0          2.0          2.0          1.9          2.0          0.0          // envlai[4]:
-1.9          1.5          1.9          1.5          2.0          2.0          2.0          2.5          2.0          0.0          // envlai[5]:
-2.0          1.5          2.0          1.5          2.0          2.0          2.0          2.0          2.0          0.0          // envlai[6]:
-2.0          1.5          2.0          1.5          2.0          2.0          2.0          2.0          2.0          0.0          // envlai[7]:
-0.5          1.0          1.5          1.0          2.0          2.0          2.0          1.5          2.0          0.0          // envlai[8]:
-0.2          0.5          1.3          0.5          2.0          2.0          2.0          0.0          2.0          0.0          // envlai[9]:
-0.0          0.0          0.8          0.0          2.0          2.0          2.0          0.0          2.0          0.0          // envlai[10]:
-0.0          0.0          0.7          0.0          2.0          2.0          2.0          0.0          2.0          0.0          // envlai[11]:
+0.0          0.0          0.5          0.0          2.0          2.0          2.0          0.0          2.0          0.0          // static_lai[0]: monthly lai for a year, used for static input of LAI
+0.0          0.0          0.3          0.0          2.0          2.0          2.0          0.0          2.0          0.0          // static_lai[1]:
+0.0          0.0          0.5          0.0          2.0          2.0          2.0          0.0          2.0          0.0          // static_lai[2]:
+0.5          0.5          1.2          0.5          2.0          2.0          2.0          1.0          2.0          0.0          // static_lai[3]:
+1.3          1.5          1.3          1.5          2.0          2.0          2.0          1.9          2.0          0.0          // static_lai[4]:
+1.9          1.5          1.9          1.5          2.0          2.0          2.0          2.5          2.0          0.0          // static_lai[5]:
+2.0          1.5          2.0          1.5          2.0          2.0          2.0          2.0          2.0          0.0          // static_lai[6]:
+2.0          1.5          2.0          1.5          2.0          2.0          2.0          2.0          2.0          0.0          // static_lai[7]:
+0.5          1.0          1.5          1.0          2.0          2.0          2.0          1.5          2.0          0.0          // static_lai[8]:
+0.2          0.5          1.3          0.5          2.0          2.0          2.0          0.0          2.0          0.0          // static_lai[9]:
+0.0          0.0          0.8          0.0          2.0          2.0          2.0          0.0          2.0          0.0          // static_lai[10]:
+0.0          0.0          0.7          0.0          2.0          2.0          2.0          0.0          2.0          0.0          // static_lai[11]:

--- a/parameters/cmt_dimvegetation.txt
+++ b/parameters/cmt_dimvegetation.txt
@@ -205,7 +205,7 @@
 0.00        0.00        0.00         0.00         0.00         0.00         0.00         0.00         0.00         0.00         // frprod[7]: fine root allocation percentage vertically in soils (every 10 cm)  
 0.00        0.00        0.00         0.00         0.00         0.00         0.00         0.00         0.00         0.00         // frprod[8]: fine root allocation percentage vertically in soils (every 10 cm) 
 0.00        0.00        0.00         0.00         0.00         0.00         0.00         0.00         0.00         0.00         // frprod[9]: fine root allocation percentage vertically in soils (every 10 cm)
-0.93        0.00        0.07         0.05         0.04         0.04         0.02         0.29         0.77         0.           // initial_lai: starting value for Leaf Area Index
+0.05        0.03        0.04         1.8          0.04         0.04         0.02         1.8          1.8          0.           // initial_lai: starting value for Leaf Area Index
 1.0         0.0         0.0          0.5          1.0          0.0          1.5          0.1          1.0          0            // static_lai[0]: monthly LAI for a year, used for static input of LAI
 1.1         0.0         0.0          0.3          1.5          0.0          1.5          0.2          1.5          0            // static_lai[1]:
 1.2         0.0         0.0          0.5          2.0          0.5          1.5          0.3          0.0          0            // static_lai[2]:

--- a/parameters/cmt_dimvegetation.txt
+++ b/parameters/cmt_dimvegetation.txt
@@ -33,7 +33,7 @@
 0.00        0.00        0.00         0.00         0.00         0.00         0.00         0.00         0.00         0.00         // frprod[7]: fine root allocation percentage vertically in soils (every 10 cm)  
 0.00        0.00        0.00         0.00         0.00         0.00         0.00         0.00         0.00         0.00         // frprod[8]: fine root allocation percentage vertically in soils (every 10 cm) 
 0.00        0.00        0.00         0.00         0.00         0.00         0.00         0.00         0.00         0.00         // frprod[9]: fine root allocation percentage vertically in soils (every 10 cm)
-0.93        0.00        0.07         0.05         0.04         0.04         0.02         0.29         0.77         0.           // lai: initial LAI
+0.93        0.00        0.07         0.05         0.04         0.04         0.02         0.29         0.77         0.           // initial_lai: starting value for Leaf Area Index
 1.0         0.0         0.0          0.5          1.0          0.0          1.5          0.1          1.0          0            // envlai[0]: monthly LAI for a year, used for static input of LAI
 1.1         0.0         0.0          0.3          1.5          0.0          1.5          0.2          1.5          0            // envlai[1]: monthly LAI for a year, used for static input of LAI 
 1.2         0.0         0.0          0.5          2.0          0.5          1.5          0.3          0.0          0            // envlai[2]: monthly LAI for a year, used for static input of LAI 
@@ -76,7 +76,7 @@
 0.00        0.00        0.00         0.00         0.00         0.00         0.00         0.00         0.00         0.00         // frprod[7]: fine root allocation percentage vertically in soils (every 10 cm)  
 0.00        0.00        0.00         0.00         0.00         0.00         0.00         0.00         0.00         0.00         // frprod[8]: fine root allocation percentage vertically in soils (every 10 cm) 
 0.00        0.00        0.00         0.00         0.00         0.00         0.00         0.00         0.00         0.00         // frprod[9]: fine root allocation percentage vertically in soils (every 10 cm)
-0.93        0.93        0.07         0.05         0.04         0.04         0.02         0.29         0.77         0.           // lai: initial LAI
+0.93        0.93        0.07         0.05         0.04         0.04         0.02         0.29         0.77         0.           // initial_lai: starting value for Leaf Area Index
 1.00        1.00        0.50         0.50         0.50         0.50         0.50         0.5          1.0          0            // envlai[0]: monthly LAI for a year, used for static input of LAI
 1.1         1.1         0.0          0.3          1.5          0.0          1.5          0.2          1.5          0            // envlai[1]: monthly LAI for a year, used for static input of LAI 
 1.2         1.2         0.0          0.5          2.0          0.5          1.5          0.3          0.0          0            // envlai[2]: monthly LAI for a year, used for static input of LAI 
@@ -119,7 +119,7 @@
 0.00        0.00        0.00         0.00         0.00         0.00         0.00         0.00         0.00         0.00         // frprod[7]: fine root allocation percentage vertically in soils (every 10 cm)  
 0.00        0.00        0.00         0.00         0.00         0.00         0.00         0.00         0.00         0.00         // frprod[8]: fine root allocation percentage vertically in soils (every 10 cm) 
 0.00        0.00        0.00         0.00         0.00         0.00         0.00         0.00         0.00         0.00         // frprod[9]: fine root allocation percentage vertically in soils (every 10 cm)
-0.93        0.00        0.07         0.05         0.04         0.04         0.02         0.29         0.77         0.           // lai: initial LAI
+0.93        0.00        0.07         0.05         0.04         0.04         0.02         0.29         0.77         0.           // initial_lai: starting value for Leaf Area Index
 1.0         0.0         0.0          0.5          1.0          0.0          1.5          0.1          1.0          0            // envlai[0]: monthly LAI for a year, used for static input of LAI
 1.1         0.0         0.0          0.3          1.5          0.0          1.5          0.2          1.5          0            // envlai[1]: monthly LAI for a year, used for static input of LAI 
 1.2         0.0         0.0          0.5          2.0          0.5          1.5          0.3          0.0          0            // envlai[2]: monthly LAI for a year, used for static input of LAI 
@@ -162,7 +162,7 @@
 0.00        0.00        0.00         0.00         0.00         0.00         0.00         0.00         0.00         0.00         // frprod[7]: fine root allocation percentage vertically in soils (every 10 cm)  
 0.00        0.00        0.00         0.00         0.00         0.00         0.00         0.00         0.00         0.00         // frprod[8]: fine root allocation percentage vertically in soils (every 10 cm) 
 0.00        0.00        0.00         0.00         0.00         0.00         0.00         0.00         0.00         0.00         // frprod[9]: fine root allocation percentage vertically in soils (every 10 cm)
-0.93        0.00        0.07         0.05         0.04         0.04         0.02         0.29         0.77         0.           // lai: initial LAI
+0.93        0.00        0.07         0.05         0.04         0.04         0.02         0.29         0.77         0.           // initial_lai: starting value for Leaf Area Index
 1.0         0.0         0.0          0.5          1.0          0.0          1.5          0.1          1.0          0            // envlai[0]: monthly LAI for a year, used for static input of LAI
 1.1         0.0         0.0          0.3          1.5          0.0          1.5          0.2          1.5          0            // envlai[1]: monthly LAI for a year, used for static input of LAI 
 1.2         0.0         0.0          0.5          2.0          0.5          1.5          0.3          0.0          0            // envlai[2]: monthly LAI for a year, used for static input of LAI 
@@ -205,7 +205,7 @@
 0.00        0.00        0.00         0.00         0.00         0.00         0.00         0.00         0.00         0.00         // frprod[7]: fine root allocation percentage vertically in soils (every 10 cm)  
 0.00        0.00        0.00         0.00         0.00         0.00         0.00         0.00         0.00         0.00         // frprod[8]: fine root allocation percentage vertically in soils (every 10 cm) 
 0.00        0.00        0.00         0.00         0.00         0.00         0.00         0.00         0.00         0.00         // frprod[9]: fine root allocation percentage vertically in soils (every 10 cm)
-0.93        0.00        0.07         0.05         0.04         0.04         0.02         0.29         0.77         0.           // lai: initial LAI
+0.93        0.00        0.07         0.05         0.04         0.04         0.02         0.29         0.77         0.           // initial_lai: starting value for Leaf Area Index
 1.0         0.0         0.0          0.5          1.0          0.0          1.5          0.1          1.0          0            // envlai[0]: monthly LAI for a year, used for static input of LAI
 1.1         0.0         0.0          0.3          1.5          0.0          1.5          0.2          1.5          0            // envlai[1]: monthly LAI for a year, used for static input of LAI 
 1.2         0.0         0.0          0.5          2.0          0.5          1.5          0.3          0.0          0            // envlai[2]: monthly LAI for a year, used for static input of LAI 
@@ -248,7 +248,7 @@
 0.00        0.00        0.00         0.00         0.00         0.00         0.00         0.00         0.00         0.00         // frprod[7]:
 0.00        0.00        0.00         0.00         0.00         0.00         0.00         0.00         0.00         0.00         // frprod[8]:
 0.00        0.00        0.00         0.00         0.00         0.00         0.00         0.00         0.00         0.00         // frprod[9]:
-0.125       0.125       0.125        0.125        0.125        0.125        0.125        0.125        0.00         0.00         // lai: initial LAI
+0.125       0.125       0.125        0.125        0.125        0.125        0.125        0.125        0.00         0.00         // initial_lai: starting value for Leaf Area Index
 0.0         0.0         0.5          0.0          0.0          2.00         2.00         2.00          0            0           // envlai[0]: monthly lai for a year, used for static input of LAI
 0.0         0.0         0.3          0.0          0.0          2.00         2.00         2.00          0            0           // envlai[1]:   
 0.0         0.0         0.5          0.0          0.5          2.00         2.00         2.00          0            0           // envlai[2]: 
@@ -291,7 +291,7 @@
 0.00        0.00        0.00         0.00         0.00         0.00         0.00         0.00         0.00         0.00         // frprod[7]:
 0.00        0.00        0.00         0.00         0.00         0.00         0.00         0.00         0.00         0.00         // frprod[8]:
 0.00        0.00        0.00         0.00         0.00         0.00         0.00         0.00         0.00         0.00         // frprod[9]:
-0.143       0.143       0.143        0.143        0.142        0.142        0.142        0.00         0.00         0.00         // lai: initial LAI
+0.143       0.143       0.143        0.143        0.142        0.142        0.142        0.00         0.00         0.00         // initial_lai: starting value for Leaf Area Index
 1.0         0.0         0.0          0.5          1.5          1.5          1.5          0.00         0.00         0.00         // envlai[0]: monthly LAI for a year, used for static input of LAI
 1.1         0.0         0.0          0.3          1.5          1.5          1.5          0.00         0.00         0.00         // envlai[1]: monthly LAI for a year, used for static input of LAI 
 1.2         0.0         0.0          0.5          1.5          1.5          1.5          0.00         0.00         0.00         // envlai[2]: monthly LAI for a year, used for static input of LAI 
@@ -334,7 +334,7 @@
 0.00        0.00        0.00         0.00         0.00         0.00         0.00         0.00         0.00         0.00         // frprod[7]:
 0.00        0.00        0.00         0.00         0.00         0.00         0.00         0.00         0.00         0.00         // frprod[8]:
 0.00        0.00        0.00         0.00         0.00         0.00         0.00         0.00         0.00         0.00         // frprod[9]:
-0.93        0.00        0.07         0.05         0.04         0.04         0.00         0.00         0.00         0.00         // lai: initial LAI
+0.93        0.00        0.07         0.05         0.04         0.04         0.00         0.00         0.00         0.00         // initial_lai: starting value for Leaf Area Index
 1.0         0.0         0.0          0.5          1.0          0.0          0.00         0.00         0.00         0.00         // envlai[0]: monthly LAI for a year, used for static input of LAI
 1.1         0.0         0.0          0.3          1.5          0.0          0.00         0.00         0.00         0.00         // envlai[1]: monthly LAI for a year, used for static input of LAI 
 1.2         0.0         0.0          0.5          2.0          0.5          0.00         0.00         0.00         0.00         // envlai[2]: monthly LAI for a year, used for static input of LAI 
@@ -377,7 +377,7 @@
 0.00         0.00         0.00         0.00         0.00         0.00         0.00         0.00         0.00         0.00         // frprod[7]:
 0.00         0.00         0.00         0.00         0.00         0.00         0.00         0.00         0.00         0.00         // frprod[8]:
 0.00         0.00         0.00         0.00         0.00         0.00         0.00         0.00         0.00         0.00         // frprod[9]:
-0.125        0.125        0.125        0.125        0.125        0.125        0.125        0.125        0.00         0.00         // lai: initial LAI
+0.125        0.125        0.125        0.125        0.125        0.125        0.125        0.125        0.00         0.00         // initial_lai: starting value for Leaf Area Index
 0.0          0.5          0.0          0.5          0.0          0.0          2.00         2.00         0.0          0             // envlai[0]: monthly lai for a year, used for static input of LAI
 0.0          0.3          0.0          0.3          0.0          0.0          2.00         2.00         0.0          0             // envlai[1]:   
 0.0          0.5          0.0          0.5          0.5          0.0          2.00         2.00         0.5          0             // envlai[2]: 
@@ -420,7 +420,7 @@
 0.00         0.00         0.00         0.00         0.00         0.00         0.00         0.00         0.00         0.00         // frprod[7]:
 0.00         0.00         0.00         0.00         0.00         0.00         0.00         0.00         0.00         0.00         // frprod[8]:
 0.00         0.00         0.00         0.00         0.00         0.00         0.00         0.00         0.00         0.00         // frprod[9]:
-0.00         0.04         0.05         0.77         0.29         0.77         0.07         0.00         0.00         0.00         // lai: initial LAI
+0.00         0.04         0.05         0.77         0.29         0.77         0.07         0.00         0.00         0.00         // initial_lai: starting value for Leaf Area Index
 0.0          1.0          0.5          1.0          0.1          1.0          0.0          0.0          0.0          0.0          // envlai[0]: monthly lai for a year, used for static input of LAI
 0.0          1.5          0.3          1.5          0.2          1.5          0.0          0.0          0.0          0.0          // envlai[1]:   
 0.0          2.0          0.5          0.0          0.3          0.0          0.0          0.0          0.0          0.0          // envlai[2]: 
@@ -463,7 +463,7 @@
 0.00         0.210        0.00         0.00         0.00         0.00         0.00         0.489        0.00         0.00         // frprod[7]:
 0.00         0.243        0.00         0.00         0.00         0.00         0.00         0.162        0.00         0.00         // frprod[8]:
 0.00         0.080        0.00         0.00         0.00         0.00         0.00         0.00         0.00         0.00         // frprod[9]:
-0.125        0.125        0.125        0.125        0.125        0.125        0.125        0.125        0.125        0.00         // lai: initial LAI
+0.125        0.125        0.125        0.125        0.125        0.125        0.125        0.125        0.125        0.00         // initial_lai: starting value for Leaf Area Index
 0.0          0.0          0.5          0.0          2.0          2.0          2.0          0.0          2.0          0.0          // envlai[0]: monthly lai for a year, used for static input of LAI
 0.0          0.0          0.3          0.0          2.0          2.0          2.0          0.0          2.0          0.0          // envlai[1]:   
 0.0          0.0          0.5          0.0          2.0          2.0          2.0          0.0          2.0          0.0          // envlai[2]: 

--- a/parameters/cmt_dimvegetation.txt
+++ b/parameters/cmt_dimvegetation.txt
@@ -248,7 +248,7 @@
 0.00        0.00        0.00         0.00         0.00         0.00         0.00         0.00         0.00         0.00         // frprod[7]:
 0.00        0.00        0.00         0.00         0.00         0.00         0.00         0.00         0.00         0.00         // frprod[8]:
 0.00        0.00        0.00         0.00         0.00         0.00         0.00         0.00         0.00         0.00         // frprod[9]:
-0.125       0.125       0.125        0.125        0.125        0.125        0.125        0.125        0.00         0.00         // initial_lai: starting value for Leaf Area Index
+0.05        0.03        1.9          0.02         0.01         1.8          2.00         1.8          0.00         0.00         // initial_lai: starting value for Leaf Area Index
 0.0         0.0         0.5          0.0          0.0          2.00         2.00         2.00          0            0           // static_lai[0]: monthly lai for a year, used for static input of LAI
 0.0         0.0         0.3          0.0          0.0          2.00         2.00         2.00          0            0           // static_lai[1]:
 0.0         0.0         0.5          0.0          0.5          2.00         2.00         2.00          0            0           // static_lai[2]:

--- a/parameters/cmt_dimvegetation.txt
+++ b/parameters/cmt_dimvegetation.txt
@@ -334,7 +334,7 @@
 0.00        0.00        0.00         0.00         0.00         0.00         0.00         0.00         0.00         0.00         // frprod[7]:
 0.00        0.00        0.00         0.00         0.00         0.00         0.00         0.00         0.00         0.00         // frprod[8]:
 0.00        0.00        0.00         0.00         0.00         0.00         0.00         0.00         0.00         0.00         // frprod[9]:
-0.93        0.00        0.07         0.05         0.04         0.04         0.00         0.00         0.00         0.00         // initial_lai: starting value for Leaf Area Index
+0.01        1.8         0.07         1.5          0.04         2.0          0.00         0.00         0.00         0.00         // initial_lai: starting value for Leaf Area Index
 1.0         0.0         0.0          0.5          1.0          0.0          0.00         0.00         0.00         0.00         // static_lai[0]: monthly LAI for a year, used for static input of LAI
 1.1         0.0         0.0          0.3          1.5          0.0          0.00         0.00         0.00         0.00         // static_lai[1]:
 1.2         0.0         0.0          0.5          2.0          0.5          0.00         0.00         0.00         0.00         // static_lai[2]:

--- a/scripts/param_util.py
+++ b/scripts/param_util.py
@@ -249,7 +249,7 @@ def cmtdatablock2dict(cmtdatablock):
   -------
   d : dict
     A multi-level dict mapping names (deduced from comments) to parameter 
-    values.holding parameter values.
+    values.
   '''
 
   cmtdict = {}
@@ -579,10 +579,10 @@ if __name__ == '__main__':
         in each file found in the %(metavar)s. Only looks at files named like:
         'cmt_*.txt' in the %(metavar)s.'''))
 
-  parser.add_argument('--plot-envlai', nargs=2, metavar=('INFOLDER','CMT'),
-      help=textwrap.dedent('''Makes plots of the envlai parameter. envlai is a
-        monthly value, so each PFT has 12 entries in the parameter file. The
-        plot shows the values over the year so you can check the seasonality.
+  parser.add_argument('--plot-static-lai', nargs=2, metavar=('INFOLDER','CMT'),
+      help=textwrap.dedent('''Makes plots of the static_lai parameter. static_lai
+        is a monthly value, so each PFT has 12 entries in the parameter file. 
+        The plot shows the values over the year so you can check the seasonality.
         Looks a 'cmt_dimvegetation.txt file in the INFOLDER.'''))
 
   args = parser.parse_args()
@@ -649,9 +649,9 @@ if __name__ == '__main__':
  
     sys.exit(0)
 
-  if args.plot_envlai:
-    infolder = args.plot_envlai[0]
-    cmtnum = int(args.plot_envlai[1])
+  if args.plot_static_lai:
+    infolder = args.plot_static_lai[0]
+    cmtnum = int(args.plot_static_lai[1])
 
     print infolder, cmtnum
     print "Reading: {}".format(os.path.join(infolder, "cmt_dimvegetation.txt"))
@@ -664,8 +664,8 @@ if __name__ == '__main__':
     for key in sorted(filter(lambda x: 'pft' in x, dd.keys())):
       pft = dd[key]
       print "{:>12}".format(pft['name']),
-      envlai = [ pft['envlai[%s]'%m] for m in range(0,12) ]
-      print "{:.2f}  {:.2f}  {:.2f}  {:.2f}  {:.2f}  {:.2f}  {:.2f}  {:.2f}  {:.2f}  {:.2f}  {:.2f}  {:.2f}".format(*envlai)
+      static_lai = [ pft['static_lai[%s]'%m] for m in range(0,12) ]
+      print "{:.2f}  {:.2f}  {:.2f}  {:.2f}  {:.2f}  {:.2f}  {:.2f}  {:.2f}  {:.2f}  {:.2f}  {:.2f}  {:.2f}".format(*static_lai)
 
     # make plots, keep imports here so that other features of the script 
     # can be used withough maplotlib installed.
@@ -673,10 +673,11 @@ if __name__ == '__main__':
 
     fig, axes = plt.subplots(len(filter(lambda x: 'pft' in x, dd.keys()))+1, 1, sharex=True)
     for i, key in enumerate(sorted(filter(lambda x: 'pft' in x, dd.keys()))):
-      envlai = [ dd[key]['envlai[%s]'%m] for m in range(0,12) ]
-      l = axes[0].plot(range(0,12), envlai, label=dd[key]['name'])
-      axes[i+1].plot(range(0,12), envlai, label=dd[key]['name'], color=l[0].get_color(), marker='o')
+      static_lai = [ dd[key]['static_lai[%s]'%m] for m in range(0,12) ]
+      l = axes[0].plot(range(0,12), static_lai, label=dd[key]['name'])
+      axes[i+1].plot(range(0,12), static_lai, label=dd[key]['name'], color=l[0].get_color(), marker='o')
       axes[i+1].set_ylabel(dd[key]['name'], rotation=0, labelpad=35)
+      axes[i+1].scatter(0.5,dd[key]['initial_lai'], marker='x', color='black')
 
     plt.suptitle("file: {}\n CMT: {}".format(
         os.path.abspath(os.path.join(infolder, "cmt_dimvegetation.txt")),

--- a/src/CalController.cpp
+++ b/src/CalController.cpp
@@ -83,9 +83,9 @@ CalController::CalController(Cohort* cht_p):
             {"dsl",
               CalCommand("changes dsl module state",
                          boost::bind(&CalController::dsl_cmd, this, _1)) },
-            {"dvm",
-              CalCommand("changes dvm module state",
-                         boost::bind(&CalController::dvm_cmd, this, _1)) },
+            {"dynlai",
+              CalCommand("changes dynamic lai module state",
+                         boost::bind(&CalController::dynlai_cmd, this, _1)) },
             {"nfeed",
               CalCommand("changes nitrogen feedback setting",
                           boost::bind(&CalController::nfeed_cmd, this, _1)) },
@@ -725,8 +725,8 @@ void CalController::dsl_cmd(const std::string& s) {
   cmd_wrapper(&ModelData::set_dslmodule, "dsl", s);
 }
 
-void CalController::dvm_cmd(const std::string& s) {
-  cmd_wrapper(&ModelData::set_dvmmodule, "dvm", s);
+void CalController::dynlai_cmd(const std::string& s) {
+  cmd_wrapper(&ModelData::set_dynamic_lai_module, "dynlai", s);
 }
 
 void CalController::nfeed_cmd(const std::string& s) {

--- a/src/Cohort.cpp
+++ b/src/Cohort.cpp
@@ -764,7 +764,7 @@ void Cohort::updateMonthly_DIMveg(const int & currmind, const bool & dvmmodule) 
   //switch for using LAI read-in (false) or dynamically with vegC
   // the read-in LAI is through the 'chtlu->envlai[12]', i.e., a 12 monthly-LAI
   if (dvmmodule) {
-    veg.update_LAI_from_vegc = md->updatelai;
+    veg.update_LAI_from_vegc = md->dynamic_LAI;
   } else {
     veg.update_LAI_from_vegc = false;
   }

--- a/src/Cohort.cpp
+++ b/src/Cohort.cpp
@@ -373,7 +373,7 @@ void Cohort::updateMonthly(const int & yrcnt, const int & currmind,
   }
 
   BOOST_LOG_SEV(glg, debug) << "Update the current dimension/structure of veg-snow/soil column (domain).";
-  updateMonthly_DIMveg(currmind, md->get_dvmmodule());
+  updateMonthly_DIMveg(currmind, md->get_dynamic_lai_module());
   updateMonthly_DIMgrd(currmind, md->get_dslmodule());
 
   if(md->get_bgcmodule()) {
@@ -758,12 +758,19 @@ void Cohort::updateMonthly_Fir(const int & year, const int & midx, std::string s
 }
 
 /** Dynamic Vegetation Module function. */
-void Cohort::updateMonthly_DIMveg(const int & currmind, const bool & dvmmodule) {
+void Cohort::updateMonthly_DIMveg(const int & currmind, const bool & dynamic_lai_module) {
   BOOST_LOG_NAMED_SCOPE("DIMveg");
   BOOST_LOG_SEV(glg, debug) << "A sample log message in DVM ...";
-  //switch for using LAI read-in (false) or dynamically with vegC
-  // the read-in LAI is through the 'chtlu->envlai[12]', i.e., a 12 monthly-LAI
-  if (dvmmodule) {
+
+  // Switch for using dynamic LAI (calculated on the fly as a function of vegc)
+  // or "static" LAI which is read in thru the CohortLookup::envlai parameter.
+  // The CohortLookup::envlai parameter is generally fed from the 
+  // cmt_dimvegetation.txt parameter file, with the 12 envlai values (monthly).
+  if (dynamic_lai_module) {
+    // If the module in enabled, then use the value from the ModelData instance
+    // the ModelData instance is set from the config file. So it would be
+    // possible to have the module enabled, but the user has set the config
+    // file to use static LAI. Seems funky.
     veg.update_LAI_from_vegc = md->dynamic_LAI;
   } else {
     veg.update_LAI_from_vegc = false;

--- a/src/Cohort.cpp
+++ b/src/Cohort.cpp
@@ -764,9 +764,9 @@ void Cohort::updateMonthly_DIMveg(const int & currmind, const bool & dvmmodule) 
   //switch for using LAI read-in (false) or dynamically with vegC
   // the read-in LAI is through the 'chtlu->envlai[12]', i.e., a 12 monthly-LAI
   if (dvmmodule) {
-    veg.updateLAI5vegc = md->updatelai;
+    veg.update_LAI_from_vegc = md->updatelai;
   } else {
-    veg.updateLAI5vegc = false;
+    veg.update_LAI_from_vegc = false;
   }
 
   // vegetation standing age

--- a/src/Cohort.cpp
+++ b/src/Cohort.cpp
@@ -763,9 +763,9 @@ void Cohort::updateMonthly_DIMveg(const int & currmind, const bool & dynamic_lai
   BOOST_LOG_SEV(glg, debug) << "A sample log message in DVM ...";
 
   // Switch for using dynamic LAI (calculated on the fly as a function of vegc)
-  // or "static" LAI which is read in thru the CohortLookup::envlai parameter.
-  // The CohortLookup::envlai parameter is generally fed from the 
-  // cmt_dimvegetation.txt parameter file, with the 12 envlai values (monthly).
+  // or static LAI which is read in thru the CohortLookup::static_lai parameter.
+  // The CohortLookup::static_lai parameter is generally fed from the 
+  // cmt_dimvegetation.txt parameter file, with the 12 static_lai values (monthly).
   if (dynamic_lai_module) {
     // If the module in enabled, then use the value from the ModelData instance
     // the ModelData instance is set from the config file. So it would be

--- a/src/CohortLookup.cpp
+++ b/src/CohortLookup.cpp
@@ -220,7 +220,7 @@ void CohortLookup::assignVegDimension(string &dircmt) {
   temutil::pfll2data_pft(l, initial_lai);
 
   for (int im = 0; im < MINY; im++) {
-    temutil::pfll2data_pft( l, envlai[im]);
+    temutil::pfll2data_pft( l, static_lai[im]);
   }
 
 }

--- a/src/CohortLookup.cpp
+++ b/src/CohortLookup.cpp
@@ -217,7 +217,7 @@ void CohortLookup::assignVegDimension(string &dircmt) {
     temutil::pfll2data_pft(l, frootfrac[i]);
   }
 
-  temutil::pfll2data_pft(l, lai);
+  temutil::pfll2data_pft(l, initial_lai);
 
   for (int im = 0; im < MINY; im++) {
     temutil::pfll2data_pft( l, envlai[im]);

--- a/src/ModelData.cpp
+++ b/src/ModelData.cpp
@@ -103,7 +103,7 @@ void ModelData::update(ArgHandler const * arghandler) {
 ModelData::ModelData():force_cmt(-1) {
   set_envmodule(false);
   set_bgcmodule(false);
-  set_dvmmodule(false);
+  set_dynamic_lai_module(false);
   set_dslmodule(false);
   set_dsbmodule(false);
 }
@@ -133,16 +133,16 @@ void ModelData::set_bgcmodule(const bool v) {
   this->bgcmodule = v;
 }
 
-bool ModelData::get_dvmmodule() {
-  return this->dvmmodule;
+bool ModelData::get_dynamic_lai_module() {
+  return this->dynamic_lai_module;
 }
-void ModelData::set_dvmmodule(const std::string &s) {
-  BOOST_LOG_SEV(glg, info) << "Setting dvmmodule to " << s;
-  this->dvmmodule = temutil::onoffstr2bool(s);
+void ModelData::set_dynamic_lai_module(const std::string &s) {
+  BOOST_LOG_SEV(glg, info) << "Setting dynamic_lai_module to " << s;
+  this->dynamic_lai_module = temutil::onoffstr2bool(s);
 }
-void ModelData::set_dvmmodule(const bool v) {
-  BOOST_LOG_SEV(glg, info) << "Setting dvmmodule to " << v;
-  this->dvmmodule = v;
+void ModelData::set_dynamic_lai_module(const bool v) {
+  BOOST_LOG_SEV(glg, info) << "Setting dynamic_lai_module to " << v;
+  this->dynamic_lai_module = v;
 }
 
 bool ModelData::get_dslmodule() {
@@ -207,14 +207,14 @@ void ModelData::set_baseline(const bool v) {
 
 std::string ModelData::describe_module_settings() {
   std::stringstream s;
-  s << table_row(15, "envmodule", this->get_envmodule());
-  s << table_row(15, "bgcmodule", this->get_bgcmodule());
-  s << table_row(15, "dvmmodule", this->get_dvmmodule());
-  s << table_row(15, "dslmodule", this->get_dslmodule());
-  s << table_row(15, "dsbmodule", this->get_dsbmodule());
-  s << table_row(15, "baseline", this->get_baseline());
-  s << table_row(15, "nfeed", this->get_nfeed());
-  s << table_row(15, "avlnflg", this->get_avlnflg());
+  s << table_row(22, "envmodule", this->get_envmodule());
+  s << table_row(22, "bgcmodule", this->get_bgcmodule());
+  s << table_row(22, "dynamic_lai_module", this->get_dynamic_lai_module());
+  s << table_row(22, "dslmodule", this->get_dslmodule());
+  s << table_row(22, "dsbmodule", this->get_dsbmodule());
+  s << table_row(22, "baseline", this->get_baseline());
+  s << table_row(22, "nfeed", this->get_nfeed());
+  s << table_row(22, "avlnflg", this->get_avlnflg());
   return s.str();
 }
 

--- a/src/ModelData.cpp
+++ b/src/ModelData.cpp
@@ -60,7 +60,7 @@ ModelData::ModelData(Json::Value controldata):force_cmt(-1) {
   pid_tag           = controldata["calibration-IO"]["pid_tag"].asString();
   caldata_tree_loc  = controldata["calibration-IO"]["caldata_tree_loc"].asString();
 
-  updatelai     = controldata["model_settings"]["dynamic_lai"].asInt(); // checked in Cohort::updateMonthly_DIMVeg
+  dynamic_LAI       = controldata["model_settings"]["dynamic_lai"].asInt(); // checked in Cohort::updateMonthly_DIMVeg
 
   // Unused (11/23/2015)
   //changeclimate = controldata["model_settings"]["dynamic_climate"].asInt();

--- a/src/Runner.cpp
+++ b/src/Runner.cpp
@@ -419,7 +419,7 @@ void Runner::output_caljson_monthly(int year, int month, std::string stage, boos
   data["Baseline"] = this->cohort.md->get_baseline();
   data["EnvModule"] = this->cohort.md->get_envmodule();
   data["BgcModule"] = this->cohort.md->get_bgcmodule();
-  data["DvmModule"] = this->cohort.md->get_dvmmodule();
+  data["DynLaiModule"] = this->cohort.md->get_dynamic_lai_module();
   data["DslModule"] = this->cohort.md->get_dslmodule();
   data["DsbModule"] = this->cohort.md->get_dsbmodule();
 
@@ -643,7 +643,7 @@ void Runner::output_caljson_yearly(int year, std::string stage, boost::filesyste
   data["Baseline"] = this->cohort.md->get_baseline();
   data["EnvModule"] = this->cohort.md->get_envmodule();
   data["BgcModule"] = this->cohort.md->get_bgcmodule();
-  data["DvmModule"] = this->cohort.md->get_dvmmodule();
+  data["DynLaiModule"] = this->cohort.md->get_dynamic_lai_module();
   data["DslModule"] = this->cohort.md->get_dslmodule();
   data["DsbModule"] = this->cohort.md->get_dsbmodule();
 

--- a/src/TEM.cpp
+++ b/src/TEM.cpp
@@ -556,7 +556,7 @@ void advance_model(const int rowidx, const int colidx,
     runner.cohort.md->set_baseline(false);
     runner.cohort.md->set_dsbmodule(false);
     runner.cohort.md->set_dslmodule(false);
-    runner.cohort.md->set_dvmmodule(false);
+    runner.cohort.md->set_dynamic_lai_module(false);
 
     BOOST_LOG_SEV(glg, debug) << "Ground, right before 'pre-run'. "
                               << runner.cohort.ground.layer_report_string("depth thermal");
@@ -592,7 +592,7 @@ void advance_model(const int rowidx, const int colidx,
     }
 
     runner.cohort.md->set_envmodule(true);
-    runner.cohort.md->set_dvmmodule(true);
+    runner.cohort.md->set_dynamic_lai_module(true);
     runner.cohort.md->set_bgcmodule(true);
     runner.cohort.md->set_dslmodule(true);
 
@@ -665,7 +665,7 @@ void advance_model(const int rowidx, const int colidx,
     runner.cohort.md->set_baseline(true);
     runner.cohort.md->set_dsbmodule(false);
     runner.cohort.md->set_dslmodule(true);
-    runner.cohort.md->set_dvmmodule(true);
+    runner.cohort.md->set_dynamic_lai_module(true);
 
     runner.cohort.climate.monthlycontainers2log();
 
@@ -719,7 +719,7 @@ void advance_model(const int rowidx, const int colidx,
     runner.cohort.md->set_baseline(true);
     runner.cohort.md->set_dsbmodule(false);
     runner.cohort.md->set_dslmodule(true);
-    runner.cohort.md->set_dvmmodule(true);
+    runner.cohort.md->set_dynamic_lai_module(true);
 
     // update the cohort's restart data object
     BOOST_LOG_SEV(glg, debug) << "Loading RestartData from: " << sp_restart_fname;
@@ -769,7 +769,7 @@ void advance_model(const int rowidx, const int colidx,
     runner.cohort.md->set_baseline(true);
     runner.cohort.md->set_dsbmodule(false);
     runner.cohort.md->set_dslmodule(true);
-    runner.cohort.md->set_dvmmodule(true);
+    runner.cohort.md->set_dynamic_lai_module(true);
 
     // update the cohort's restart data object
     BOOST_LOG_SEV(glg, debug) << "Loading RestartData from: " << tr_restart_fname;

--- a/src/Vegetation.cpp
+++ b/src/Vegetation.cpp
@@ -84,7 +84,7 @@ Vegetation::Vegetation(int cmtnum, const ModelData* mdp) {
 //  temutil::pfll2data_pft(l, vegdimpar.lai);
 //
 //  for (int im = 0; im < MINY; im++) {
-//    temutil::pfll2data_pft( l, vegdimpar.envlai[im]);
+//    temutil::pfll2data_pft( l, vegdimpar.static_lai[im]);
 //  }
 }
 
@@ -234,20 +234,19 @@ void Vegetation::updateLai(const int &currmind) {
   for(int ip=0; ip<NUM_PFT; ip++) {
     if (cd->m_veg.vegcov[ip]>0.) {
       if(!update_LAI_from_vegc) {
-        cd->m_veg.lai[ip] = chtlu->envlai[currmind][ip];//So, this will give a
-                                                        //  portal for input LAI
+        cd->m_veg.lai[ip] = chtlu->static_lai[currmind][ip];
       } else {
-        if (bd[ip]->m_vegs.c[I_leaf] > 0.) {
+        if (bd[ip]->m_vegs.c[I_leaf] > 0.0) {
           cd->m_veg.lai[ip] = vegdimpar.sla[ip] * bd[ip]->m_vegs.c[I_leaf];
         } else {
           if (ed[ip]->m_soid.rtdpgrowstart>0 && ed[ip]->m_soid.rtdpgrowend<0) {
             cd->m_veg.lai[ip] = 0.001; // this is needed for leaf emerging
           }
         }
-      }
+      } 
     }
   }
-};
+}
 
 // sum of all PFTs' fpc must be not greater than 1.0
 void Vegetation::updateFpc() {
@@ -478,12 +477,13 @@ double Vegetation::getFfoliage(const int &ipft, const bool & ifwoody,
 
 // plant max. LAI function
 double Vegetation::getYearlyMaxLAI(const int &ipft) {
-  double laimax = 0.;
 
-  for (int im=0; im<12; im++) {//taking the max. of input 'envlai[12]'
+  double laimax = 0.0;
+
+  for (int im=0; im<12; im++) {//taking the max. of input 'static_lai[12]'
                                //  adjusted by 'vegcov'
-//    double covlai = chtlu->envlai[im][ipft]*cd->m_veg.vegcov[ipft];
-      double covlai = chtlu->envlai[im][ipft];
+//    double covlai = chtlu->static_lai[im][ipft]*cd->m_veg.vegcov[ipft];
+      double covlai = chtlu->static_lai[im][ipft];
     if (laimax <= covlai) {
       laimax = covlai;
     }

--- a/src/Vegetation.cpp
+++ b/src/Vegetation.cpp
@@ -148,7 +148,7 @@ void Vegetation::initializeState() {
         cd->hasnonvascular = true;
       }
 
-      cd->m_veg.lai[i] = chtlu->lai[i];
+      cd->m_veg.lai[i] = chtlu->initial_lai[i];
 
       for (int il=0; il<MAX_ROT_LAY; il++) {
         cd->m_veg.frootfrac[il][i] = chtlu->frootfrac[il][i]/100.0; // chtlu - in %

--- a/src/Vegetation.cpp
+++ b/src/Vegetation.cpp
@@ -233,7 +233,7 @@ void Vegetation::set_state_from_restartdata(const RestartData & rd) {
 void Vegetation::updateLai(const int &currmind) {
   for(int ip=0; ip<NUM_PFT; ip++) {
     if (cd->m_veg.vegcov[ip]>0.) {
-      if(!updateLAI5vegc) {
+      if(!update_LAI_from_vegc) {
         cd->m_veg.lai[ip] = chtlu->envlai[currmind][ip];//So, this will give a
                                                         //  portal for input LAI
       } else {


### PR DESCRIPTION
Generally cleans up the naming surrounding LAI.

* Changes variable names to indicate the initial LAI values (values for starting the simulations).
* Changes configuration settings (held in ModelData and CohortLookup) to indicate dynamic LAI (i.e. LAI is being calculated at run time, not using fixed values from parameter files).
* Changes default parameter name. **NOTE:** this will requires changes in PEcAn wrapper code!
* Changes "dvm module" to "dynamic_lai_module". "dvm module" was confusing because it made it seem as though the model would run without dynamic vegetation, when in fact, all the switch controlled is whether LAI is calculated from veg C or not.
 * Changes `envlai` to `static_lai` to complement the new `dynamic_lai` name. Static lai is not calculated at run time; values are used from the parameter files for the entire simulation.