### PR TITLE
Modify so that *.tar.gz archives made when cmdline flag --tar-caljson is used are...

### DIFF
--- a/src/ArgHandler.cpp
+++ b/src/ArgHandler.cpp
@@ -16,8 +16,10 @@ void ArgHandler::parse(int argc, char** argv) {
     ("cal-mode,c", boost::program_options::bool_switch(&cal_mode),
      "Switch for calibration mode. When this flag is present, the program will "
      "be forced to run a single site and with '--loop-order=space-major'. The "
-     "program will generate yearly and monthly '.json' files in your /tmp "
-     "directory that are intended to be read by other programs or scripts.")
+     "program will generate yearly and monthly .json files (commonly somewhere "
+     "in your /tmp directory so that the operating system will periodically clean "
+     "them up). The location that the .json files will be written can be controlled "
+     "by the caldata_tree_loc configuration setting.")
 
     ("force-cmt", boost::program_options::value<int>(&force_cmt)
      ->default_value(-1),
@@ -59,10 +61,8 @@ void ArgHandler::parse(int argc, char** argv) {
      "When this flag is present, the calibration-json files will be bundled "
      "into a *-data.tar.gz archive at the end of each stage. The prefix for "
      "the archive will be a two letter code for the run-stage, (i.e. 'pr', "
-     "'eq', 'sp', 'tr', or 'sc'). The resulting archive will be in the "
-     "system's /tmp directory. It is up to the user to move or otherwise save "
-     "these archive files. Subsequent model runs will overwrite any existing "
-     "archive files.")
+     "'eq', 'sp', 'tr', or 'sc'). The resulting archive will be written to the "
+     "location specified in the output_dir configuration setting.")
 
     ("archive-all-json", boost::program_options::bool_switch(&archive_all_json),
      "DEPRECATED! Prefer --tar-caljson. "

--- a/src/CalController.cpp
+++ b/src/CalController.cpp
@@ -490,7 +490,10 @@ void CalController::clear_archived_json() {
 
 void CalController::tar_caljson_for_stage(const std::string& stage) {
 
-  std::string outfile = "/tmp/" + stage + "-data.tar.gz";
+  // Write the archived data from the calibration data tree
+  // location (which is often in /tmp) to the run's output
+  // directory to be saved.
+  std::string outfile = this->cohort_ptr->md->output_dir + "/" + stage + "-data.tar.gz";
 
   std::string system_call_string = "tar -czf " + outfile + " " + this->base_dir.c_str();
   BOOST_LOG_SEV(glg, info) << "Attempting system() call with this command: " << system_call_string;


### PR DESCRIPTION
...stored in the output directory instead of /tmp.