### PR TITLE
Fix segfault that occurs when checking water and running off the bott…

### DIFF
--- a/src/Ground.cpp
+++ b/src/Ground.cpp
@@ -2231,7 +2231,7 @@ void Ground::checkFrontsValidity() {
 void Ground::checkWaterValidity() {
   BOOST_LOG_SEV(glg, debug) << "Checking water validity...";
 
-  Layer* currl = toplayer;
+  Layer* currl = this->toplayer;
 
   while (currl != NULL) {
     if (fabs(currl->ice) < 1.e-9) {
@@ -2296,11 +2296,12 @@ void Ground::checkWaterValidity() {
       }
     }
 
-    currl = currl->nextl;
-
     if(currl->isRock) {
       break;
     }
+
+    currl = currl->nextl;
+
   }
 }
 


### PR DESCRIPTION
…om of the stack.

For some reason this only shows up on the PEcAn VM (Ubuntu 18.04, gcc 7.x).
Previously, during the water check, as we iterated thru layers, we'd
assign the next layer (which could possibly be NULL if we are at the end
of the stack!) and then check for rock, breaking if there was rock.

Now we break the loop if there is rock encountered before trying to advance
the layer pointer.