### PR TITLE
Fix calviewer bugs

### DIFF
--- a/calibration/calibration-viewer.py
+++ b/calibration/calibration-viewer.py
@@ -1196,7 +1196,12 @@ if __name__ == '__main__':
   else:
     if args.data_path is None:
       parser.error("You must specify --data-path so the program knows which files to plot!")
-    input_helper = InputHelper(path=args.data_path, monthly=args.monthly)
+    if os.path.basename(args.data_path) != 'dvmdostem':
+      logging.info("Adding 'dvmdostem' to data path...")
+      dp = os.path.join(args.data_path, 'dvmdostem')
+    else:
+      dp = args.data_path
+    input_helper = InputHelper(path=dp, monthly=args.monthly)
 
   #logging.info("from_archive=%s" % args.from_archive)
   #logging.info("data_path=%s" % args.data_path)

--- a/calibration/calibration-viewer.py
+++ b/calibration/calibration-viewer.py
@@ -347,6 +347,14 @@ class ExpandingWindow(object):
 
     self.no_blit = no_blit
 
+    # Setting controlling where this program will look for reference parameters 
+    # that are used for finding PFT names. The default setting is to look for 
+    # in a parameters/ directory relative to the current location (location 
+    # from which this calibration_viewer.py script was run). An alternate value 
+    # for this setting is 'relative_to_dvmdostem' in which this program will
+    # look for the parameters/ directory that ships with dvmdostem.
+    self.reference_param_loc = 'relative_to_curdir'
+
     self.fig = plt.figure(figsize=(6*1.3, 8*1.3))
     self.ewp_title = self.fig.suptitle(figtitle)
 
@@ -450,7 +458,6 @@ class ExpandingWindow(object):
 
     # ----- READ FIRST FILE FOR TITLE ------
     self.set_title_from_first_file(files)
-
     # for each trace, create a tmp y container the same size as x
     for trace in self.traces:
       trace['tmpy'] = x.copy() * np.nan
@@ -899,7 +906,7 @@ class ExpandingWindow(object):
           vname = ''
         else:
           cmtkey = t_line0[spos:spos+5]
-          vname = "(%s)" % pu.get_pft_verbose_name(pftkey=trace['pft'], cmtkey=cmtkey)
+          vname = "(%s)" % pu.get_pft_verbose_name(pftkey=trace['pft'], cmtkey=cmtkey, lookup_path=self.reference_param_loc)
         logger.debug("verbose PFT name is: %s" % vname)
 
         ax.text(
@@ -1090,9 +1097,8 @@ if __name__ == '__main__':
       help=textwrap.dedent('''Read and disply monthly json files instead of 
           yearly. NOTE: may be slow!!'''))
 
-  parser.add_argument('--data-path', default="/tmp/dvmdostem/",
-      help=textwrap.dedent('''Look for json files in the specified path
-          (instead of the default location)'''))
+  parser.add_argument('--data-path', default=None,
+      help=textwrap.dedent('''Look for json files in the specified path'''))
 
   parser.add_argument('--bulk', action='store_true',
       help=textwrap.dedent('''With this flag, the viewer will attempt to
@@ -1188,6 +1194,8 @@ if __name__ == '__main__':
   if args.from_archive:
     input_helper = InputHelper(path=args.from_archive, monthly=args.monthly)
   else:
+    if args.data_path is None:
+      parser.error("You must specify --data-path so the program knows which files to plot!")
     input_helper = InputHelper(path=args.data_path, monthly=args.monthly)
 
   #logging.info("from_archive=%s" % args.from_archive)

--- a/scripts/param_util.py
+++ b/scripts/param_util.py
@@ -139,6 +139,8 @@ def get_CMT_datablock(afile, cmtnum):
     cmtkey = cmtnum
 
   startidx = find_cmt_start_idx(data, cmtkey)
+  if startidx is None:
+    raise RuntimeError("Can't find datablock for CMT: {} in {}".format(cmtkey, afile))
 
   end = None
 
@@ -215,11 +217,17 @@ def parse_header_line(linedata):
   return cmtkey, cmtname, cmtcomment
 
 
-def get_pft_verbose_name(cmtkey=None, pftkey=None, cmtnum=None, pftnum=None):
-  path2params = os.path.join(os.path.split(os.path.dirname(os.path.realpath(__file__)))[0], 'parameters/')
+def get_pft_verbose_name(cmtkey=None, pftkey=None, cmtnum=None, pftnum=None, lookup_path=None):
+  if lookup_path is "relative_to_dvmdostem":
+    path2params = os.path.join(os.path.split(os.path.dirname(os.path.realpath(__file__)))[0], 'parameters/')
+  elif lookup_path is "relative_to_curdir":
+    path2params = os.path.join(os.path.abspath(os.path.curdir), 'parameters/')
+  else:
+    msg = "ERROR!: lookup_path parameter must be one of 'relative_to_dvmdostem' or 'relative_to_curdir', not {}".format(lookup_path))
+    raise ValueError(msg)
 
   if cmtkey and cmtnum:
-    raise ValueError("you must provide only one of you cmtkey or cmtnumber")
+    raise ValueError("you must provide only one of cmtkey or cmtnumber")
 
   if pftkey and pftnum:
     raise ValueError("you must provide only one of pftkey or pftnumber")

--- a/scripts/setup_working_directory.py
+++ b/scripts/setup_working_directory.py
@@ -48,6 +48,10 @@ if __name__ == '__main__':
   parser.add_argument('--input-data-path', default="<placeholder>",
       help=textwrap.dedent("""Path to the input data"""))
 
+  parser.add_argument('--no-cal-targets', action='store_true',
+      help=textwrap.dedent("""Do NOT copy the calibration_targets.py file into
+        the new working directory."""))
+
   args = parser.parse_args()
   print args
 
@@ -59,7 +63,15 @@ if __name__ == '__main__':
   # like the config and parameters to come from.
   # Alternatively: os.path.split(os.path.dirname(os.path.realpath(__file__)))[0]
   ddt_dir = os.path.dirname(os.path.dirname(os.path.realpath(__file__)))
- 
+
+  if args.no_cal_targets:
+    pass
+  else:
+    mkdir_p(os.path.join(args.new_directory, 'calibration'))
+    shutil.copy( os.path.join(ddt_dir, 'calibration', 'calibration_targets.py'), 
+                 os.path.join(args.new_directory, 'calibration'))
+
+
   # Copy over the config and parameters directories
   shutil.copytree(os.path.join(ddt_dir, 'config'), os.path.join(args.new_directory, 'config'))
   shutil.copytree(os.path.join(ddt_dir, 'parameters'), os.path.join(args.new_directory, 'parameters'))

--- a/scripts/setup_working_directory.py
+++ b/scripts/setup_working_directory.py
@@ -99,11 +99,7 @@ if __name__ == '__main__':
   # NOTE: Seems like when the user runs the calibration-viewer.py and specifies
   # --data-path, they for some reason have to include dvmdostem, like this:
   # --data-path /tmp/args.new_directory/dvmdostem
-  if os.path.isabs(args.new_directory):
-    config['calibration-IO']['caldata_tree_loc'] = os.path.join('/tmp', args.new_directory.lstrip(os.path.sep))
-  else:
-    config['calibration-IO']['caldata_tree_loc'] = os.path.join('/tmp', args.new_directory)
-  
+  config['calibration-IO']['caldata_tree_loc'] = os.path.join('/tmp', os.path.basename(os.path.abspath(args.new_directory)))
 
   # Match the default config file shipped with the code, except we move runmask
   # to the end of the file listings


### PR DESCRIPTION
Change calibration-viewer.py to add new features and fix bugs:
 * Changes viewer so there is no longer a default location to look for the 
json data files; user must now specify location when starting the viewer.
 * Fix bug in setup_working_directory.py, now uses absolute path to set calibration json data path.
 * Changes parameter utils so that it raises exception if it can't find a block
of CMT data.
 * Param utils file now smart enough to be able to look for files in more than one
location.
 * Changes setup_working_directory.py script so that it can copy the 
calibration targets file into the new working directory.
 * Change Calibration viewer so that it can look for a "reference set" of calibration targets in a different location (supplied by the user on the command line). Allows users to create new communities and test them (using the setup_working_directory.py workflow) without needing the changes added to the upstream parameter and targets files.