### PR TITLE
Qcal netcdf fix

### DIFF
--- a/config/output_spec.csv
+++ b/config/output_spec.csv
@@ -13,6 +13,7 @@ BURNVEG2SOIABVC,Burned vegetation C to soil above,g/m2/time,,,invalid,invalid,in
 BURNVEG2SOIABVN,Burned vegetation N to soil above,g/m2/time,,,invalid,invalid,invalid,invalid,double,
 BURNVEG2SOIBLWC,Burned vegetation C to soil below,g/m2/time,,,invalid,invalid,invalid,invalid,double,
 BURNVEG2SOIBLWN,Burned vegetation N to soil below,g/m2/time,,,invalid,invalid,invalid,invalid,double,
+CMTNUM,Community Type Number,m,,invalid,invalid,invalid,invalid,invalid,int,
 DEADC,Standing dead C,g/m2/time,,,invalid,invalid,invalid,invalid,double,
 DEADN,Standing dead N,g/m2/time,,,invalid,invalid,invalid,invalid,double,
 DEEPC,Amorphous SOM C,g/m2,,,invalid,invalid,invalid,invalid,double,

--- a/scripts/outspec_utils.py
+++ b/scripts/outspec_utils.py
@@ -361,6 +361,8 @@ if __name__ == '__main__':
     for v in "VEGC VEGN".split():
       data = toggle_on_variable(data, v, 'yearly pft compartment')
 
+    data = toggle_on_variable(data, 'CMTNUM', 'yearly')
+
     write_data_to_csv(data, args.file)
 
     print "NOTE: Make sure to enable 'eq' outputs in the config file!!!"

--- a/src/Runner.cpp
+++ b/src/Runner.cpp
@@ -1369,6 +1369,22 @@ void Runner::output_netCDF(std::map<std::string, OutputSpec> &netcdf_outputs, in
   }//end BURNVEG2SOIBLWN
   map_itr = netcdf_outputs.end();
 
+  //Community Type Code (CMT NUMBER)
+  map_itr = netcdf_outputs.find("CMTNUM");
+  if(map_itr != netcdf_outputs.end()) {
+    BOOST_LOG_SEV(glg, debug) << "NetCDF output: CMTNUM";
+    curr_spec = map_itr->second;
+    #pragma omp critical(outputCMTNUM)
+    {
+
+      int cmtnum;
+      cmtnum = temutil::cmtcode2num(this->cohort.chtlu.cmtcode);
+
+      output_nc_3dim(&curr_spec, file_stage_suffix, &cmtnum, 1, year, 1);
+
+    } //end critical(outputCMTNUM)
+  } //end CMTNUM
+  map_itr = netcdf_outputs.end();
 
   //Standing dead C
   map_itr = netcdf_outputs.find("DEADC");

--- a/src/TEM.cpp
+++ b/src/TEM.cpp
@@ -294,6 +294,21 @@ int main(int argc, char* argv[]){
     modeldata.create_netCDF_output_files(num_rows, num_cols, "sc", modeldata.sc_yrs, copy_gm);
   }
 
+  // Warn if CMTNUM output is not enabled.
+  bool cmtoutput_enabled = false;
+  boost::filesystem::directory_iterator end;
+  for (boost::filesystem::directory_iterator fsdi(boost::filesystem::path(modeldata.output_dir)); fsdi != end; ++fsdi) {
+    if ((*fsdi).path().string().find("CMTNUM") != std::string::npos) {
+      BOOST_LOG_SEV(glg, info) << "Looks good, CMTNUM output is enabled: " << *fsdi;
+      cmtoutput_enabled = true;
+      break;
+    }
+  }
+  if (!cmtoutput_enabled) {
+    BOOST_LOG_SEV(glg, err) << "Looks like CMTNUM output is NOT enabled."
+                            << " Strongly recommended to enable this output!"
+                            << " Use outspec_utils.py to turn on the CMTNUM output!";
+  }
 
   // Work on checking that the particular configuration will not result in too
   // much output.


### PR DESCRIPTION
Adds the CMTNUM outputs to the netcdf files. This was necessary to finish the qcal functionality for netcdf.
