### PR TITLE
Fixes an error in the order of function calls.

### DIFF
--- a/src/Runner.cpp
+++ b/src/Runner.cpp
@@ -914,13 +914,16 @@ void Runner::output_nc_3dim(OutputSpec* out_spec, std::string stage_suffix,
 
 #ifdef WITHMPI
   temutil::nc( nc_open_par(output_filename.c_str(), NC_WRITE|NC_MPIIO, MPI_COMM_SELF, MPI_INFO_NULL, &ncid) );
-  temutil::nc( nc_var_par_access(ncid, cv, NC_INDEPENDENT) );
 #else
   temutil::nc( nc_open(output_filename.c_str(), NC_WRITE, &ncid) );
 #endif
 
   temutil::nc( nc_inq_varid(ncid, out_spec->var_name.c_str(), &cv) );
   BOOST_LOG_SEV(glg, debug)<<"inq_varid completed";
+
+#ifdef WITHMPI
+  temutil::nc( nc_var_par_access(ncid, cv, NC_INDEPENDENT) );
+#endif
 
   temutil::nc( nc_put_vara(ncid, cv, datastart, datacount, data) );
   BOOST_LOG_SEV(glg, debug)<<"put_vara completed";
@@ -953,12 +956,15 @@ void Runner::output_nc_4dim(OutputSpec* out_spec, std::string stage_suffix,
 
 #ifdef WITHMPI
   temutil::nc( nc_open_par(output_filename.c_str(), NC_WRITE|NC_MPIIO, MPI_COMM_SELF, MPI_INFO_NULL, &ncid) );
-  temutil::nc( nc_var_par_access(ncid, cv, NC_INDEPENDENT) );
 #else
   temutil::nc( nc_open(output_filename.c_str(), NC_WRITE, &ncid) );
 #endif
 
   temutil::nc( nc_inq_varid(ncid, out_spec->var_name.c_str(), &cv) );
+
+#ifdef WITHMPI
+  temutil::nc( nc_var_par_access(ncid, cv, NC_INDEPENDENT) );
+#endif
 
   temutil::nc( nc_put_vara(ncid, cv, datastart, datacount, data) );
 
@@ -992,12 +998,15 @@ void Runner::output_nc_5dim(OutputSpec* out_spec, std::string stage_suffix,
 
 #ifdef WITHMPI
   temutil::nc( nc_open_par(output_filename.c_str(), NC_WRITE|NC_MPIIO, MPI_COMM_SELF, MPI_INFO_NULL, &ncid) );
-  temutil::nc( nc_var_par_access(ncid, cv, NC_INDEPENDENT) );
 #else
   temutil::nc( nc_open(output_filename.c_str(), NC_WRITE, &ncid) );
 #endif
 
   temutil::nc( nc_inq_varid(ncid, out_spec->var_name.c_str(), &cv) );
+
+#ifdef WITHMPI
+  temutil::nc( nc_var_par_access(ncid, cv, NC_INDEPENDENT) );
+#endif
 
   temutil::nc( nc_put_vara(ncid, cv, datastart, datacount, data) );
 


### PR DESCRIPTION
This prevents nc_var_par_access() from being called with an invalid
variable id (cv) when running with MPI.