### PR TITLE
Params to files

### DIFF
--- a/include/CohortLookup.h
+++ b/include/CohortLookup.h
@@ -136,6 +136,15 @@ public:
   // Solid thermal conductivity parameters
   double tcsolid_moss, tcsolid_f, tcsolid_h;
 
+  // Layer porosity parameters
+  double poro_moss, poro_f, poro_h;
+
+  // Soil bulk density parameters
+  double bulkden_moss, bulkden_f, bulkden_h;
+
+  // Hydraulic conductivity at saturation parameters
+  double hksat_moss, hksat_f, hksat_h;
+
   // inital thermal/water states of snow/soil
   double initsnwtem; //1 snow input: initial snow temperature
                      //  (note: initial water of snow can be from

--- a/include/CohortLookup.h
+++ b/include/CohortLookup.h
@@ -136,6 +136,9 @@ public:
   // Solid thermal conductivity parameters
   double tcsolid_moss, tcsolid_f, tcsolid_h;
 
+  // Summer and winter nfactor
+  double nfactor_s, nfactor_w;
+
   // Layer porosity parameters
   double poro_moss, poro_f, poro_h;
 

--- a/include/CohortLookup.h
+++ b/include/CohortLookup.h
@@ -133,6 +133,9 @@ public:
   // parameter for soil drainage
   double drainmax;
 
+  // Solid thermal conductivity parameters
+  double tcsolid_moss, tcsolid_f, tcsolid_h;
+
   // inital thermal/water states of snow/soil
   double initsnwtem; //1 snow input: initial snow temperature
                      //  (note: initial water of snow can be from

--- a/include/Ground.h
+++ b/include/Ground.h
@@ -62,10 +62,10 @@ public :
   Layer* fstmossl; // first moss layer
   Layer* lstmossl; // last moss layer
   Layer* fstshlwl; // first fibric os layer
-  Layer* lstshlwl; // last firbric os layer
+  Layer* lstshlwl; // last fibric os layer
   Layer* fstdeepl; // first amorphous os layer
   Layer* lstdeepl; // last amorphous os layer
-  Layer* fstminel; // first mineral layer*/
+  Layer* fstminel; // first mineral layer
   Layer* lstminel; // last mineral layer
 
   // freezing/thawing fronts
@@ -76,10 +76,10 @@ public :
   deque<int> frontstype; //fronts type in order as above:
                          //  1 = freezing front - front with upper
                          //    frozen/lower unfrozen,
-                         //  -1 = thawing front - frotn with upper
+                         //  -1 = thawing front - front with upper
                          //    unfrozen/lower frozen.
   // SO freezing/thawing fronts are alternatively in order,
-  // i.e., a freezing front must be followed by a thawign front, or vice versa
+  // i.e., a freezing front must be followed by a thawing front, or vice versa
 
   Layer* fstfntl; /*! first snow/soil layer containing phase change front */
   Layer* lstfntl; /*! last snow/soil layer containing phase change front */

--- a/include/Layer.h
+++ b/include/Layer.h
@@ -57,9 +57,9 @@ public:
   double tcsatunf; //< saturated unfrozen soil thermal conductivity
   double vhcsolid; //< solid volumetric heat capacity
 
-  double albdryvis;  //< visiable light albedo at dry
+  double albdryvis;  //< visible light albedo at dry
   double albdrynir;  //< nir light albedo at dry
-  double albsatvis;  //< visiable light albedo at saturation
+  double albsatvis;  //< visible light albedo at saturation
   double albsatnir;  //< nir light albedo at saturation
 
   double minliq; //< minimum liq water content
@@ -68,7 +68,7 @@ public:
 
   double psisat; //< saturated matric potential
   double hksat;  //< saturated matric potential
-  double bsw;    //< Clap and Hornberger consant
+  double bsw;    //< Clap and Hornberger constant
 
   // thermal status
   int frozen;        //< thermal state of a layer, 0: partially frozen, 1: frozen, -1: unfrozen

--- a/include/MossLayer.h
+++ b/include/MossLayer.h
@@ -4,12 +4,13 @@
 #ifndef MOSSLAYER_H_
 #define MOSSLAYER_H_
 #include "SoilLayer.h"
+#include "CohortLookup.h"
 #include "cohortconst.h"
 
 using namespace std;
 class MossLayer: public SoilLayer {
 public:
-  MossLayer(const double &pdz, const int & mosstype);
+  MossLayer(const double &pdz, const int & mosstype, const CohortLookup * chtlu);
   ~MossLayer();
 
   int mosstype;  // moss types: 1: sphagnum; 2: feathermoss; 3: other (including lichen)

--- a/include/OrganicLayer.h
+++ b/include/OrganicLayer.h
@@ -15,7 +15,7 @@ public:
 
   OrganicLayer(const double & pdz, const int & type, const CohortLookup * chtlu);
   ~OrganicLayer();
-  void humify();
+  void humify(const CohortLookup * chtlu);
 
 };
 #endif /*ORGANICLAYER_H_*/

--- a/include/OrganicLayer.h
+++ b/include/OrganicLayer.h
@@ -4,6 +4,7 @@
 #ifndef ORGANICLAYER_H_
 #define ORGANICLAYER_H_
 #include "SoilLayer.h"
+#include "CohortLookup.h"
 
 #include <string>
 #include <cmath>
@@ -12,7 +13,7 @@ using namespace std;
 class OrganicLayer: public SoilLayer {
 public:
 
-  OrganicLayer(const double & pdz, const int & type);
+  OrganicLayer(const double & pdz, const int & type, const CohortLookup * chtlu);
   ~OrganicLayer();
   void humify();
 

--- a/include/parameters.h
+++ b/include/parameters.h
@@ -185,9 +185,12 @@ struct soipar_env {
   double psimax;
   double evapmin;
 
+  double nfactor_s;
+  double nfactor_w;
+
   double drainmax;
   
-  soipar_env():rtdp4gdd(UIN_D), psimax(UIN_D), evapmin(UIN_D), drainmax(UIN_D){}
+  soipar_env():rtdp4gdd(UIN_D), psimax(UIN_D), evapmin(UIN_D), nfactor_s(UIN_D), nfactor_w(UIN_D), drainmax(UIN_D){}
 
 };
 

--- a/parameters/cmt_envground.txt
+++ b/parameters/cmt_envground.txt
@@ -8,6 +8,20 @@
 0.08               // evapmin:
 0.04               // drainmax
 0.20               // rtdp4gdd: root depth for estimating growing degree day
+0.25               // tcsolid(m): Soil thermal conductivity for moss (W/mK)
+0.25               // tcsolid(f): Soil thermal conductivity for fibric (W/mK)
+0.25               // tcsolid(h): Soil thermal conductivity for humic (W/mK)
+0.98               // porosity(m): porosity for moss layers
+0.95               // porosity(f): porosity for fibric layers
+0.8                // porosity(h): porosity for humic layers
+25000              // bulkden(m): bulk density for moss (g/m3)
+51000              // bulkden(f): bulk density for fibric (g/m3)
+176000             // bulkden(h): bulk density for humic (g/m3)
+0.15               // hksat(m): hydraulic conductivity at saturation for moss (mm/s?)
+0.28               // hksat(f): hydraulic conductivity at saturation for fibric
+0.002              // hksat(h): hydraulic conductivity at saturation for humic
+1.5                // nfactor(s): Summer nfactor
+1.0                // nfactor(w): Winter nfactor
 -1.0               // initsnwtem: initial snow temperature (oC)
 -1.0               // initts(0): initial soil temperature at 10 cm interval (oC)
 -1.0               // initts(1): initial soil temperature at 10 cm interval (oC)
@@ -37,6 +51,20 @@
 0.08               // evapmin:
 0.04               // drainmax
 0.2                // rtdp4gdd: root depth for estimating growing degree day
+0.25               // tcsolid(m): Soil thermal conductivity for moss (W/mK)
+0.25               // tcsolid(f): Soil thermal conductivity for fibric (W/mK)
+0.25               // tcsolid(h): Soil thermal conductivity for humic (W/mK)
+0.98               // porosity(m): porosity for moss layers
+0.95               // porosity(f): porosity for fibric layers
+0.8                // porosity(h): porosity for humic layers
+25000              // bulkden(m): bulk density for moss (g/m3)
+51000              // bulkden(f): bulk density for fibric (g/m3)
+176000             // bulkden(h): bulk density for humic (g/m3)
+0.15               // hksat(m): hydraulic conductivity at saturation for moss (mm/s?)
+0.28               // hksat(f): hydraulic conductivity at saturation for fibric
+0.002              // hksat(h): hydraulic conductivity at saturation for humic
+1.5                // nfactor(s): Summer nfactor
+1.0                // nfactor(w): Winter nfactor
 -1.0               // initsnwtem: initial snow temperature (oC)
 -1.0               // initts(0): initial soil temperature at 10 cm interval (oC)
 -1.0               // initts(1): initial soil temperature at 10 cm interval (oC)
@@ -66,6 +94,20 @@
 0.08               // evapmin:
 0.04               // drainmax
 0.2                // rtdp4gdd: root depth for estimating growing degree day
+0.25               // tcsolid(m): Soil thermal conductivity for moss (W/mK)
+0.25               // tcsolid(f): Soil thermal conductivity for fibric (W/mK)
+0.25               // tcsolid(h): Soil thermal conductivity for humic (W/mK)
+0.98               // porosity(m): porosity for moss layers
+0.95               // porosity(f): porosity for fibric layers
+0.8                // porosity(h): porosity for humic layers
+25000              // bulkden(m): bulk density for moss (g/m3)
+51000              // bulkden(f): bulk density for fibric (g/m3)
+176000             // bulkden(h): bulk density for humic (g/m3)
+0.15               // hksat(m): hydraulic conductivity at saturation for moss (mm/s?)
+0.28               // hksat(f): hydraulic conductivity at saturation for fibric
+0.002              // hksat(h): hydraulic conductivity at saturation for humic
+1.5                // nfactor(s): Summer nfactor
+1.0                // nfactor(w): Winter nfactor
 -1.0               // initsnwtem: initial snow temperature (oC)
 -1.0               // initts(0): initial soil temperature at 10 cm interval (oC)
 -1.0               // initts(1): initial soil temperature at 10 cm interval (oC)
@@ -95,6 +137,20 @@
 0.08               // evapmin:
 0.04               // drainmax
 0.2                // rtdp4gdd: root depth for estimating growing degree day
+0.25               // tcsolid(m): Soil thermal conductivity for moss (W/mK)
+0.25               // tcsolid(f): Soil thermal conductivity for fibric (W/mK)
+0.25               // tcsolid(h): Soil thermal conductivity for humic (W/mK)
+0.98               // porosity(m): porosity for moss layers
+0.95               // porosity(f): porosity for fibric layers
+0.8                // porosity(h): porosity for humic layers
+25000              // bulkden(m): bulk density for moss (g/m3)
+51000              // bulkden(f): bulk density for fibric (g/m3)
+176000             // bulkden(h): bulk density for humic (g/m3)
+0.15               // hksat(m): hydraulic conductivity at saturation for moss (mm/s?)
+0.28               // hksat(f): hydraulic conductivity at saturation for fibric
+0.002              // hksat(h): hydraulic conductivity at saturation for humic
+1.5                // nfactor(s): Summer nfactor
+1.0                // nfactor(w): Winter nfactor
 -1.0               // initsnwtem: initial snow temperature (oC)
 -1.0               // initts(0): initial soil temperature at 10 cm interval (oC)
 -1.0               // initts(1): initial soil temperature at 10 cm interval (oC)
@@ -124,6 +180,20 @@
 0.08               // evapmin:
 0.04               // drainmax
 0.20               // rtdp4gdd: root depth for estimating growing degree day
+0.25               // tcsolid(m): Soil thermal conductivity for moss (W/mK)
+0.25               // tcsolid(f): Soil thermal conductivity for fibric (W/mK)
+0.25               // tcsolid(h): Soil thermal conductivity for humic (W/mK)
+0.98               // porosity(m): porosity for moss layers
+0.95               // porosity(f): porosity for fibric layers
+0.8                // porosity(h): porosity for humic layers
+25000              // bulkden(m): bulk density for moss (g/m3)
+51000              // bulkden(f): bulk density for fibric (g/m3)
+176000             // bulkden(h): bulk density for humic (g/m3)
+0.15               // hksat(m): hydraulic conductivity at saturation for moss (mm/s?)
+0.28               // hksat(f): hydraulic conductivity at saturation for fibric
+0.002              // hksat(h): hydraulic conductivity at saturation for humic
+1.5                // nfactor(s): Summer nfactor
+1.0                // nfactor(w): Winter nfactor
 -1.0               // initsnwtem: initial snow temperature (oC)
 -1.0               // initts(0): initial soil temperature at 10 cm interval (oC)
 -1.0               // initts(1): initial soil temperature at 10 cm interval (oC)
@@ -197,6 +267,20 @@
 0.08               // evapmin:
 0.04               // drainmax
 0.20               // rtdp4gdd: root depth for estimating growing degree day
+0.25               // tcsolid(m): Soil thermal conductivity for moss (W/mK)
+0.25               // tcsolid(f): Soil thermal conductivity for fibric (W/mK)
+0.25               // tcsolid(h): Soil thermal conductivity for humic (W/mK)
+0.98               // porosity(m): porosity for moss layers
+0.95               // porosity(f): porosity for fibric layers
+0.8                // porosity(h): porosity for humic layers
+25000              // bulkden(m): bulk density for moss (g/m3)
+51000              // bulkden(f): bulk density for fibric (g/m3)
+176000             // bulkden(h): bulk density for humic (g/m3)
+0.15               // hksat(m): hydraulic conductivity at saturation for moss (mm/s?)
+0.28               // hksat(f): hydraulic conductivity at saturation for fibric
+0.002              // hksat(h): hydraulic conductivity at saturation for humic
+1.5                // nfactor(s): Summer nfactor
+1.0                // nfactor(w): Winter nfactor
 -1.0               // initsnwtem: initial snow temperature (oC)
 -1.0               // initts(0): initial soil temperature at 10 cm interval (oC)
 -1.0               // initts(1): initial soil temperature at 10 cm interval (oC)
@@ -226,6 +310,20 @@
 0.08               // evapmin:
 0.04               // drainmax
 0.20               // rtdp4gdd: root depth for estimating growing degree day
+0.25               // tcsolid(m): Soil thermal conductivity for moss (W/mK)
+0.25               // tcsolid(f): Soil thermal conductivity for fibric (W/mK)
+0.25               // tcsolid(h): Soil thermal conductivity for humic (W/mK)
+0.98               // porosity(m): porosity for moss layers
+0.95               // porosity(f): porosity for fibric layers
+0.8                // porosity(h): porosity for humic layers
+25000              // bulkden(m): bulk density for moss (g/m3)
+51000              // bulkden(f): bulk density for fibric (g/m3)
+176000             // bulkden(h): bulk density for humic (g/m3)
+0.15               // hksat(m): hydraulic conductivity at saturation for moss (mm/s?)
+0.28               // hksat(f): hydraulic conductivity at saturation for fibric
+0.002              // hksat(h): hydraulic conductivity at saturation for humic
+1.5                // nfactor(s): Summer nfactor
+1.0                // nfactor(w): Winter nfactor
 -1.0               // initsnwtem: initial snow temperature (oC)
 -1.0               // initts(0): initial soil temperature at 10 cm interval (oC)
 -1.0               // initts(1): initial soil temperature at 10 cm interval (oC)
@@ -255,6 +353,20 @@
 0.08               // evapmin:
 0.04               // drainmax
 0.20               // rtdp4gdd: root depth for estimating growing degree day
+0.25               // tcsolid(m): Soil thermal conductivity for moss (W/mK)
+0.25               // tcsolid(f): Soil thermal conductivity for fibric (W/mK)
+0.25               // tcsolid(h): Soil thermal conductivity for humic (W/mK)
+0.98               // porosity(m): porosity for moss layers
+0.95               // porosity(f): porosity for fibric layers
+0.8                // porosity(h): porosity for humic layers
+25000              // bulkden(m): bulk density for moss (g/m3)
+51000              // bulkden(f): bulk density for fibric (g/m3)
+176000             // bulkden(h): bulk density for humic (g/m3)
+0.15               // hksat(m): hydraulic conductivity at saturation for moss (mm/s?)
+0.28               // hksat(f): hydraulic conductivity at saturation for fibric
+0.002              // hksat(h): hydraulic conductivity at saturation for humic
+1.5                // nfactor(s): Summer nfactor
+1.0                // nfactor(w): Winter nfactor
 -1.0               // initsnwtem: initial snow temperature (oC)
 -1.0               // initts(0): initial soil temperature at 10 cm interval (oC)
 -1.0               // initts(1): initial soil temperature at 10 cm interval (oC)
@@ -284,6 +396,20 @@
 0.08               // evapmin:
 0.04               // drainmax
 0.20               // rtdp4gdd: root depth for estimating growing degree day
+0.25               // tcsolid(m): Soil thermal conductivity for moss (W/mK)
+0.25               // tcsolid(f): Soil thermal conductivity for fibric (W/mK)
+0.25               // tcsolid(h): Soil thermal conductivity for humic (W/mK)
+0.98               // porosity(m): porosity for moss layers
+0.95               // porosity(f): porosity for fibric layers
+0.8                // porosity(h): porosity for humic layers
+25000              // bulkden(m): bulk density for moss (g/m3)
+51000              // bulkden(f): bulk density for fibric (g/m3)
+176000             // bulkden(h): bulk density for humic (g/m3)
+0.15               // hksat(m): hydraulic conductivity at saturation for moss (mm/s?)
+0.28               // hksat(f): hydraulic conductivity at saturation for fibric
+0.002              // hksat(h): hydraulic conductivity at saturation for humic
+1.5                // nfactor(s): Summer nfactor
+1.0                // nfactor(w): Winter nfactor
 -1.0               // initsnwtem: initial snow temperature (oC)
 -1.0               // initts(0): initial soil temperature at 10 cm interval (oC)
 -1.0               // initts(1): initial soil temperature at 10 cm interval (oC)
@@ -313,6 +439,20 @@
 0.08               // evapmin:
 0.04               // drainmax
 0.20               // rtdp4gdd: root depth for estimating growing degree day
+0.25               // tcsolid(m): Soil thermal conductivity for moss (W/mK)
+0.25               // tcsolid(f): Soil thermal conductivity for fibric (W/mK)
+0.25               // tcsolid(h): Soil thermal conductivity for humic (W/mK)
+0.98               // porosity(m): porosity for moss layers
+0.95               // porosity(f): porosity for fibric layers
+0.8                // porosity(h): porosity for humic layers
+25000              // bulkden(m): bulk density for moss (g/m3)
+51000              // bulkden(f): bulk density for fibric (g/m3)
+176000             // bulkden(h): bulk density for humic (g/m3)
+0.15               // hksat(m): hydraulic conductivity at saturation for moss (mm/s?)
+0.28               // hksat(f): hydraulic conductivity at saturation for fibric
+0.002              // hksat(h): hydraulic conductivity at saturation for humic
+1.5                // nfactor(s): Summer nfactor
+1.0                // nfactor(w): Winter nfactor
 -1.0               // initsnwtem: initial snow temperature (oC)
 -1.0               // initts(0): initial soil temperature at 10 cm interval (oC)
 -1.0               // initts(1): initial soil temperature at 10 cm interval (oC)
@@ -342,6 +482,20 @@
 0.08               // evapmin:
 0.04               // drainmax
 0.20               // rtdp4gdd: root depth for estimating growing degree day
+0.25               // tcsolid(m): Soil thermal conductivity for moss (W/mK)
+0.25               // tcsolid(f): Soil thermal conductivity for fibric (W/mK)
+0.25               // tcsolid(h): Soil thermal conductivity for humic (W/mK)
+0.98               // porosity(m): porosity for moss layers
+0.95               // porosity(f): porosity for fibric layers
+0.8                // porosity(h): porosity for humic layers
+25000              // bulkden(m): bulk density for moss (g/m3)
+51000              // bulkden(f): bulk density for fibric (g/m3)
+176000             // bulkden(h): bulk density for humic (g/m3)
+0.15               // hksat(m): hydraulic conductivity at saturation for moss (mm/s?)
+0.28               // hksat(f): hydraulic conductivity at saturation for fibric
+0.002              // hksat(h): hydraulic conductivity at saturation for humic
+1.5                // nfactor(s): Summer nfactor
+1.0                // nfactor(w): Winter nfactor
 -1.0               // initsnwtem: initial snow temperature (oC)
 -1.0               // initts(0): initial soil temperature at 10 cm interval (oC)
 -1.0               // initts(1): initial soil temperature at 10 cm interval (oC)

--- a/parameters/cmt_envground.txt
+++ b/parameters/cmt_envground.txt
@@ -153,6 +153,9 @@
 0.08               // evapmin:
 0.04               // drainmax
 0.20               // rtdp4gdd: root depth for estimating growing degree day
+0.25               // tcsolid(m): Soil thermal conductivity for moss (W/mK)
+0.25               // tcsolid(f): Soil thermal conductivity for fibric (W/mK)
+0.25               // tcsolid(h): Soil thermal conductivity for humic (W/mK)
 -1.0               // initsnwtem: initial snow temperature (oC)
 -1.0               // initts(0): initial soil temperature at 10 cm interval (oC)
 -1.0               // initts(1): initial soil temperature at 10 cm interval (oC)

--- a/parameters/cmt_envground.txt
+++ b/parameters/cmt_envground.txt
@@ -165,6 +165,8 @@
 0.15               // hksat(m): hydraulic conductivity at saturation for moss (mm/s?)
 0.28               // hksat(f): hydraulic conductivity at saturation for fibric
 0.002              // hksat(h): hydraulic conductivity at saturation for humic
+1.5                // nfactor(s): Summer nfactor
+1.0                // nfactor(w): Winter nfactor
 -1.0               // initsnwtem: initial snow temperature (oC)
 -1.0               // initts(0): initial soil temperature at 10 cm interval (oC)
 -1.0               // initts(1): initial soil temperature at 10 cm interval (oC)

--- a/parameters/cmt_envground.txt
+++ b/parameters/cmt_envground.txt
@@ -156,6 +156,15 @@
 0.25               // tcsolid(m): Soil thermal conductivity for moss (W/mK)
 0.25               // tcsolid(f): Soil thermal conductivity for fibric (W/mK)
 0.25               // tcsolid(h): Soil thermal conductivity for humic (W/mK)
+0.98               // porosity(m): porosity for moss layers
+0.95               // porosity(f): porosity for fibric layers
+0.8                // porosity(h): porosity for humic layers
+25000              // bulkden(m): bulk density for moss (g/m3)
+51000              // bulkden(f): bulk density for fibric (g/m3)
+176000             // bulkden(h): bulk density for humic (g/m3)
+0.15               // hksat(m): hydraulic conductivity at saturation for moss (mm/s?)
+0.28               // hksat(f): hydraulic conductivity at saturation for fibric
+0.002              // hksat(h): hydraulic conductivity at saturation for humic
 -1.0               // initsnwtem: initial snow temperature (oC)
 -1.0               // initts(0): initial soil temperature at 10 cm interval (oC)
 -1.0               // initts(1): initial soil temperature at 10 cm interval (oC)

--- a/src/Cohort.cpp
+++ b/src/Cohort.cpp
@@ -440,7 +440,7 @@ void Cohort::updateMonthly_Env(const int & currmind, const int & dinmcurr) {
   //might be more accurate if done correctly, that code had been commented 
   //out for years, and so was removed. 
   //Value from Klene 2001 (summer values) and Kade 2006.
-  //edall->d_soid.nfactor = 0.9; //using seaonally dynamic nfactors (below)
+  //edall->d_soid.nfactor = 0.9; //using seasonally dynamic nfactors (below)
 
   // (ii)Initialize the yearly/monthly accumulators, which are accumulating at the end of month/day in 'ed'
   for (int ip=0; ip<NUM_PFT; ip++) {
@@ -493,12 +493,11 @@ void Cohort::updateMonthly_Env(const int & currmind, const int & dinmcurr) {
     // proxy for snow surface temperature. In the future we can bring in
     // that calculation; for now, just use air surface temp in winter (Raleigh
     // shows it's well-correlated but air tends to be warmer by ~5 deg C).
-    double nfactor_summer_max = 1.5;
-    double nfactor_winter = 1.0;
-    edall->d_soid.nfactor = nfactor_summer_max; //summer nfactor (max nfactor)
+
+    edall->d_soid.nfactor = soilenv.envpar.nfactor_s; //summer nfactor (max nfactor)
     //If airtemp is freezing, use winter nfactor
     if(tdrv <= 0.0){
-      edall->d_soid.nfactor = nfactor_winter;
+      edall->d_soid.nfactor = soilenv.envpar.nfactor_w;
     }
 
 

--- a/src/CohortLookup.cpp
+++ b/src/CohortLookup.cpp
@@ -416,7 +416,7 @@ void CohortLookup::assignEnv4Ground(string &dircmt) {
 
   // get a list of data for the cmt number
   std::list<std::string> datalist = temutil::parse_parameter_file(
-      dircmt + "cmt_envground.txt", temutil::cmtcode2num(this->cmtcode), 27
+      dircmt + "cmt_envground.txt", temutil::cmtcode2num(this->cmtcode), 30
   );
 
   // pop each line off the front of the list
@@ -427,6 +427,9 @@ void CohortLookup::assignEnv4Ground(string &dircmt) {
   temutil::pfll2data(datalist, evapmin);
   temutil::pfll2data(datalist, drainmax);
   temutil::pfll2data(datalist, rtdp4gdd);
+  temutil::pfll2data(datalist, tcsolid_moss);
+  temutil::pfll2data(datalist, tcsolid_f);
+  temutil::pfll2data(datalist, tcsolid_h);
   temutil::pfll2data(datalist, initsnwtem);
 
   for (int i = 0; i < 10; i++) {

--- a/src/CohortLookup.cpp
+++ b/src/CohortLookup.cpp
@@ -416,7 +416,7 @@ void CohortLookup::assignEnv4Ground(string &dircmt) {
 
   // get a list of data for the cmt number
   std::list<std::string> datalist = temutil::parse_parameter_file(
-      dircmt + "cmt_envground.txt", temutil::cmtcode2num(this->cmtcode), 30
+      dircmt + "cmt_envground.txt", temutil::cmtcode2num(this->cmtcode), 39
   );
 
   // pop each line off the front of the list
@@ -430,6 +430,15 @@ void CohortLookup::assignEnv4Ground(string &dircmt) {
   temutil::pfll2data(datalist, tcsolid_moss);
   temutil::pfll2data(datalist, tcsolid_f);
   temutil::pfll2data(datalist, tcsolid_h);
+  temutil::pfll2data(datalist, poro_moss);
+  temutil::pfll2data(datalist, poro_f);
+  temutil::pfll2data(datalist, poro_h);
+  temutil::pfll2data(datalist, bulkden_moss);
+  temutil::pfll2data(datalist, bulkden_f);
+  temutil::pfll2data(datalist, bulkden_h);
+  temutil::pfll2data(datalist, hksat_moss);
+  temutil::pfll2data(datalist, hksat_f);
+  temutil::pfll2data(datalist, hksat_h);
   temutil::pfll2data(datalist, initsnwtem);
 
   for (int i = 0; i < 10; i++) {

--- a/src/CohortLookup.cpp
+++ b/src/CohortLookup.cpp
@@ -416,7 +416,7 @@ void CohortLookup::assignEnv4Ground(string &dircmt) {
 
   // get a list of data for the cmt number
   std::list<std::string> datalist = temutil::parse_parameter_file(
-      dircmt + "cmt_envground.txt", temutil::cmtcode2num(this->cmtcode), 39
+      dircmt + "cmt_envground.txt", temutil::cmtcode2num(this->cmtcode), 41
   );
 
   // pop each line off the front of the list
@@ -439,6 +439,8 @@ void CohortLookup::assignEnv4Ground(string &dircmt) {
   temutil::pfll2data(datalist, hksat_moss);
   temutil::pfll2data(datalist, hksat_f);
   temutil::pfll2data(datalist, hksat_h);
+  temutil::pfll2data(datalist, nfactor_s);
+  temutil::pfll2data(datalist, nfactor_w);
   temutil::pfll2data(datalist, initsnwtem);
 
   for (int i = 0; i < 10; i++) {

--- a/src/Ground.cpp
+++ b/src/Ground.cpp
@@ -910,7 +910,7 @@ bool Ground::constructSnowLayers(const double & dsmass, const double & tdrv) {
                             //      snow-melting/sublimating when calling
                             //      this function
 
-  if(snow.extramass>0) { // accumlate
+  if(snow.extramass>0) { // accumulate
     double density = snowdimpar.newden;
     double thick = snow.extramass/density;
 
@@ -1112,7 +1112,7 @@ void Ground::updateSnowLayerPropertiesDaily() {
   while(currl!= NULL) {
     if(currl->isSnow) {
       currl->advanceOneDay();
-      dynamic_cast<SnowLayer*>(currl)->updateDensity(&snowdimpar);   // this will compact snow layer basd on snowlayer age
+      dynamic_cast<SnowLayer*>(currl)->updateDensity(&snowdimpar);   // this will compact snow layer based on snowlayer age
       dynamic_cast<SnowLayer*>(currl)->updateThick();
     } else {
       break;
@@ -1159,8 +1159,8 @@ void Ground::retrieveSnowDimension(snwstate_dim * snowdim) {
 ////////////////////////////////////////////////////////////////////////////////
 // Basically, here will not do thickness change, which will carry out in
 // 'updateOslThickness5Carbon', therefore, any new layer creation, will have
-// to originate from neibouring layer, otherwise mathematic error will occur
-// execept for create new moss/fibrous organic layer from none.
+// to originate from neighbouring layer, otherwise mathematic error will occur
+// except for create new moss/fibrous organic layer from none.
 void  Ground::redivideSoilLayers() {
   redivideMossLayers(moss.type);
   redivideShlwLayers();
@@ -1234,7 +1234,7 @@ void Ground::redivideShlwLayers() {
     SoilLayer* upsl ;
     SoilLayer* lwsl;
     organic.shlwchanged =true;
-    // first, comine all layer into one
+    // first, combine all layers into one
 COMBINEBEGIN:
     currl =fstshlwl;
 
@@ -1363,7 +1363,7 @@ void Ground::redivideDeepLayers() {
   ////////// IF there exists 'deep' layer(s) ////////////////
   if(fstdeepl != NULL) {
     Layer * currl = fstdeepl;
-    // Adjusting the OS horion's layer division/combination
+    // Adjusting the OS horizon's layer division/combination
     SoilLayer* upsl ;
     SoilLayer* lwsl;
 
@@ -1976,7 +1976,7 @@ void Ground::updateWholeFrozenStatus() {
   if(fstfntl==NULL && lstfntl==NULL) {
     ststate = fstsoill->frozen;
   } else {
-    ststate = 0; // partitally frozen
+    ststate = 0; // partially frozen
   }
 
   checkFrontsValidity();

--- a/src/Ground.cpp
+++ b/src/Ground.cpp
@@ -405,7 +405,7 @@ void Ground::initSnowSoilLayers() {
 
       for(int il = moss.num-1; il >= 0; il--) {
         // moss type (1- sphagnum, 2- feathermoss), which needs input
-        MossLayer* ml = new MossLayer(moss.dz[il], moss.type);
+        MossLayer* ml = new MossLayer(moss.dz[il], moss.type, chtlu);
         insertFront(ml);
       }
     }
@@ -495,7 +495,7 @@ void Ground::set_state_from_restartdata(snwstate_dim *snowdim,
   moss.setThicknesses(soiltype, dzsoil, MAX_SOI_LAY);
 
   for(int il = moss.num-1; il>=0; il--) {
-    MossLayer* ml = new MossLayer(moss.dz[il], moss.type);
+    MossLayer* ml = new MossLayer(moss.dz[il], moss.type, chtlu);
     ml->age = soilage[il];
     ml->frozen = frozen[il];
     insertFront(ml);
@@ -1182,7 +1182,7 @@ void  Ground::redivideMossLayers(const int &mosstype) {
     //Create live moss
     moss.thick = 0.01;
     BOOST_LOG_SEV(glg, debug)<<"Creating new moss layer, type: "<<moss.type<<", thickness: "<<moss.thick;
-    MossLayer* ml = new MossLayer(moss.thick, moss.type);
+    MossLayer* ml = new MossLayer(moss.thick, moss.type, chtlu);
     moss.num = 1;
     ml->tem = fstsoill->tem;
     ml->z = 0.0;
@@ -1711,7 +1711,7 @@ double Ground::adjustSoilAfterburn() {
   while (currl!=NULL) {
     if(currl->isFibric) {
       OrganicLayer * pl = dynamic_cast<OrganicLayer*>(currl);
-      pl->humify(); //here only update 'physical' properties, but not states
+      pl->humify(chtlu); //here only update 'physical' properties, but not states
                     //  (will do below when adjusting 'dz'
       pl->somcr += pl->rawc; //assuming all 'raw material' converted into
                              //  'chemically-resistant' SOM

--- a/src/Ground.cpp
+++ b/src/Ground.cpp
@@ -374,12 +374,12 @@ void Ground::initSnowSoilLayers() {
   // but for insertion of layers into the double-linked matrix, do the
   //   deep organic first
   for(int il = organic.deepnum-1; il >=  0; il--) {
-    OrganicLayer* pl = new OrganicLayer(organic.deepdz[il], 2); //2 means deep organic
+    OrganicLayer* pl = new OrganicLayer(organic.deepdz[il], 2, chtlu); //2 means deep organic
     insertFront(pl);
   }
 
   for(int il = organic.shlwnum-1; il >= 0; il--) {
-    OrganicLayer* pl = new OrganicLayer(organic.shlwdz[il], 1); //1 means shallow organic
+    OrganicLayer* pl = new OrganicLayer(organic.shlwdz[il], 1, chtlu); //1 means shallow organic
     insertFront(pl);
   }
 
@@ -477,7 +477,7 @@ void Ground::set_state_from_restartdata(snwstate_dim *snowdim,
   organic.assignDeepThicknesses(soiltype, dzsoil, MAX_SOI_LAY);
 
   for(int il = organic.deepnum-1; il>=0; il--) {
-    OrganicLayer* pl = new OrganicLayer(organic.deepdz[il], 2); //2 means deep organic
+    OrganicLayer* pl = new OrganicLayer(organic.deepdz[il], 2, chtlu); //2 means deep organic
     pl->age = soilage[il];
     pl->frozen = frozen[il];
     insertFront(pl);
@@ -486,7 +486,7 @@ void Ground::set_state_from_restartdata(snwstate_dim *snowdim,
   organic.assignShlwThicknesses(soiltype, dzsoil, MAX_SOI_LAY);
 
   for(int il =organic.shlwnum-1; il>=0; il--) {
-    OrganicLayer* pl = new OrganicLayer(organic.shlwdz[il], 1);//1 means shallow organic
+    OrganicLayer* pl = new OrganicLayer(organic.shlwdz[il], 1, chtlu);//1 means shallow organic
     pl->age = soilage[il];
     pl->frozen = frozen[il];
     insertFront(pl);
@@ -1272,7 +1272,7 @@ COMBINEBEGIN:
       OrganicLayer* plnew;
 
       for (int i=organic.shlwnum-1; i>0; i--) {
-        plnew = new OrganicLayer(organic.shlwdz[i], 1);
+        plnew = new OrganicLayer(organic.shlwdz[i], 1, chtlu);
         SoilLayer* shlwsl = dynamic_cast<SoilLayer*>(fstshlwl);
         //split 'plnew' from bottom of 'shlwsl'
         splitOneSoilLayer(shlwsl, plnew, 0., organic.shlwdz[i]);
@@ -1314,7 +1314,7 @@ COMBINEBEGIN:
       double thick = thicknessFromCarbon(abvgfallC, soildimpar.coefshlwa, soildimpar.coefshlwb);
       //organic.ShlwThickScheme(MINSLWTHICK);
       organic.ShlwThickScheme(thick);
-      OrganicLayer* plnew = new OrganicLayer(organic.shlwdz[0], 1);
+      OrganicLayer* plnew = new OrganicLayer(organic.shlwdz[0], 1, chtlu);
       //plnew->dz= MINSLWTHICK;
       plnew->dz= thick;
       //double frac = MINSLWTHICK/nextsl->dz;
@@ -1419,7 +1419,7 @@ void Ground::redivideDeepLayers() {
       OrganicLayer* plnew;
 
       for (int i=organic.deepnum-1; i>0; i--) {
-        plnew = new OrganicLayer(organic.deepdz[i], 2);
+        plnew = new OrganicLayer(organic.deepdz[i], 2, chtlu);
         SoilLayer* deepsl = dynamic_cast<SoilLayer*>(fstdeepl);
         // split 'plnew' from bottom of 'deepsl'
         splitOneSoilLayer(deepsl, plnew, 0., organic.deepdz[i]);
@@ -1444,7 +1444,7 @@ void Ground::redivideDeepLayers() {
 
     if (somc>=deepcmin) {
       organic.DeepThickScheme(MINDEPTHICK);
-      OrganicLayer* plnew = new OrganicLayer(organic.deepdz[0], 2);
+      OrganicLayer* plnew = new OrganicLayer(organic.deepdz[0], 2, chtlu);
       double frac = plnew->dz/lfibl->dz;
       // assign properties for the new-created 'deep' layer
       plnew->ice = lfibl->ice*frac;

--- a/src/MossLayer.cpp
+++ b/src/MossLayer.cpp
@@ -6,7 +6,7 @@
 #include "../include/TEMLogger.h"
 extern src::severity_logger< severity_level > glg;
 
-MossLayer::MossLayer(const double &pdz, const int & newmosstype) {
+MossLayer::MossLayer(const double &pdz, const int & newmosstype, const CohortLookup* chtlu) {
   BOOST_LOG_SEV(glg, debug) << "==> ==> Creating a MossLayer...";
   tkey=I_MOSS;
   isMoss    = true;
@@ -26,7 +26,7 @@ MossLayer::MossLayer(const double &pdz, const int & newmosstype) {
   albdryvis = 0.18;
   albdrynir = 0.36;
   // thermal properties
-  tcsolid = 0.25;
+  tcsolid = chtlu->tcsolid_moss;
   vhcsolid=2.5e6; //J/m3K
 
   // hydraulic properties

--- a/src/MossLayer.cpp
+++ b/src/MossLayer.cpp
@@ -18,8 +18,8 @@ MossLayer::MossLayer(const double &pdz, const int & newmosstype, const CohortLoo
   age = 0;
   mosstype = newmosstype;
   dz       = pdz;
-  poro     = 0.98;
-  bulkden  = 25000; // g/m3
+  poro     = chtlu->poro_moss;
+  bulkden  = chtlu->bulkden_moss; // g/m3
   // light properties
   albsatvis = 0.09;
   albsatnir = 0.18;
@@ -33,15 +33,15 @@ MossLayer::MossLayer(const double &pdz, const int & newmosstype, const CohortLoo
   //bsw should be 1, but is set to 1.01 in order
   // to avoid NaNs in hydraulic calculations (see Richards)
   if(mosstype ==1) {
-    hksat  = 0.15; //mm/s
+    hksat  = chtlu->hksat_moss; //mm/s
     psisat = -10; // mm
     bsw = 1.01;
   } else if(mosstype ==2) {
-    hksat  = 0.15; //mm/s
+    hksat  = chtlu->hksat_moss; //mm/s
     psisat = -120; // mm
     bsw = 1.01;
   } else {
-    hksat = 0.15; //mm/s
+    hksat = chtlu->hksat_moss; //mm/s
     psisat = -50; // mm
     bsw = 1.01;
   }

--- a/src/OrganicLayer.cpp
+++ b/src/OrganicLayer.cpp
@@ -18,23 +18,23 @@ OrganicLayer::OrganicLayer(const double & pdz, const int & type, const CohortLoo
   if(type==1) {
     tkey=I_FIB;
     isFibric =true;
-    poro = 0.95;
-    bulkden = 51000; // g/m3
+    poro = chtlu->poro_f;
+    bulkden = chtlu->bulkden_f; // g/m3
     albsatvis = 0.075;
     albsatnir = 0.15;
     albdryvis = 0.15;
     albdrynir = 0.3;
     tcsolid = chtlu->tcsolid_f;
     vhcsolid= 2.5e6; //J/m3K
-    hksat = 0.28;
+    hksat = chtlu->hksat_f;
     bsw=2.7;
     psisat =-10.0;
     cfrac = 44.2; // %
   } else if (type==2) {
     tkey=I_HUM;
     isHumic =true;
-    poro = 0.8;
-    bulkden = 176000; // g/m3
+    poro = chtlu->poro_h;
+    bulkden = chtlu->bulkden_h; // g/m3
     albsatvis = 0.075;
     albsatnir = 0.15;
     albdryvis = 0.15;
@@ -42,7 +42,7 @@ OrganicLayer::OrganicLayer(const double & pdz, const int & type, const CohortLoo
     tcsolid = chtlu->tcsolid_h;
     vhcsolid= 2.5e6; //J/m3K
     bsw=8;
-    hksat  =0.002;
+    hksat = chtlu->hksat_h;
     psisat =-12;
     cfrac = 35.2; // %
   }
@@ -58,8 +58,8 @@ void OrganicLayer::humify(const CohortLookup* chtlu) {
   tkey=I_HUM;
   isHumic =true;
   isFibric=false;
-  poro = 0.8;
-  bulkden = 176000; // g/m3
+  poro = chtlu->poro_h;
+  bulkden = chtlu->bulkden_h; // g/m3
   albsatvis = 0.075;
   albsatnir = 0.15;
   albdryvis = 0.15;
@@ -67,7 +67,7 @@ void OrganicLayer::humify(const CohortLookup* chtlu) {
   tcsolid = chtlu->tcsolid_h;
   vhcsolid= 2.5e6; //J/m3K
   bsw=8;
-  hksat  =0.002;
+  hksat  = chtlu->hksat_h;
   psisat =-12;
   cfrac = 35.2; // %
   derivePhysicalProperty();

--- a/src/OrganicLayer.cpp
+++ b/src/OrganicLayer.cpp
@@ -25,7 +25,6 @@ OrganicLayer::OrganicLayer(const double & pdz, const int & type, const CohortLoo
     albdryvis = 0.15;
     albdrynir = 0.3;
     tcsolid = chtlu->tcsolid_f;
-    //tcsolid = 0.25;
     vhcsolid= 2.5e6; //J/m3K
     hksat = 0.28;
     bsw=2.7;
@@ -40,7 +39,7 @@ OrganicLayer::OrganicLayer(const double & pdz, const int & type, const CohortLoo
     albsatnir = 0.15;
     albdryvis = 0.15;
     albdrynir = 0.3;
-    tcsolid = 0.25;
+    tcsolid = chtlu->tcsolid_h;
     vhcsolid= 2.5e6; //J/m3K
     bsw=8;
     hksat  =0.002;
@@ -55,7 +54,7 @@ OrganicLayer::~OrganicLayer(){
   BOOST_LOG_SEV(glg, debug) << "--> --> Deleting an OrganicLayer object...";
 }
 
-void OrganicLayer::humify() {
+void OrganicLayer::humify(const CohortLookup* chtlu) {
   tkey=I_HUM;
   isHumic =true;
   isFibric=false;
@@ -65,7 +64,7 @@ void OrganicLayer::humify() {
   albsatnir = 0.15;
   albdryvis = 0.15;
   albdrynir = 0.3;
-  tcsolid = 0.25;
+  tcsolid = chtlu->tcsolid_h;
   vhcsolid= 2.5e6; //J/m3K
   bsw=8;
   hksat  =0.002;

--- a/src/OrganicLayer.cpp
+++ b/src/OrganicLayer.cpp
@@ -6,7 +6,7 @@
 #include "../include/TEMLogger.h"
 extern src::severity_logger< severity_level > glg;
 
-OrganicLayer::OrganicLayer(const double & pdz, const int & type) {
+OrganicLayer::OrganicLayer(const double & pdz, const int & type, const CohortLookup* chtlu) {
   BOOST_LOG_SEV(glg, debug) << "==> ==> Creating an OrganicLayer object...";
   isMoss    = false;
   isMineral = false;
@@ -24,7 +24,8 @@ OrganicLayer::OrganicLayer(const double & pdz, const int & type) {
     albsatnir = 0.15;
     albdryvis = 0.15;
     albdrynir = 0.3;
-    tcsolid = 0.25;
+    tcsolid = chtlu->tcsolid_f;
+    //tcsolid = 0.25;
     vhcsolid= 2.5e6; //J/m3K
     hksat = 0.28;
     bsw=2.7;

--- a/src/Soil_Env.cpp
+++ b/src/Soil_Env.cpp
@@ -44,6 +44,8 @@ Soil_Env::~Soil_Env() {
 void Soil_Env::initializeParameter() {
   envpar.psimax  = chtlu->psimax;
   envpar.evapmin = chtlu->evapmin;
+  envpar.nfactor_s = chtlu->nfactor_s;
+  envpar.nfactor_w = chtlu->nfactor_w;
   envpar.drainmax = chtlu->drainmax;
   envpar.rtdp4gdd = chtlu->rtdp4gdd;
 };


### PR DESCRIPTION
This changes tcsolid, porosity, bulk density, hksat, and nfactor from hard-coded to parameters read in from file.

Testing included producing a set of output variables from master and from the tip of the branch and directly comparing them. Variables produced:
ALD yearly
GPP monthly
Layer depth yearly
Layer thickness yearly
Moss thickness yearly
RH monthly
Shallow thickness yearly
TCLAYER monthly
TLAYER monthly
Water table monthly
YSD yearly
All comparisons were successful.

Secondary testing was to launch a very short run with each CMT specified in order to check the parameter loading. This was mostly successful, although there were issues with cmt_bgcvegetation which could have masked problems with the new parameters. The vegetation issues occurred with CMT00, CMT12, and CMT21. CMT00 isn't a problem because it's known to be an invalid CMT and CMT21 has already been addressed in a separate branch, but CMT12 should be reviewed.