### PR TITLE
Fixing the algorithm to compute soil organic carbon in mineral layers

### DIFF
--- a/src/Ground.cpp
+++ b/src/Ground.cpp
@@ -274,7 +274,7 @@ void Ground::initParameter() {
   soildimpar.minshlwthick = 0.010;   // meters
   soildimpar.coefshlwa  = chtlu->coefshlwa;
   soildimpar.coefshlwb  = chtlu->coefshlwb;
-  soildimpar.minshlwthick = 0.005;   // meters
+  soildimpar.mindeepthick = 0.005;   // meters
   soildimpar.coefdeepa  = chtlu->coefdeepa;
   soildimpar.coefdeepb  = chtlu->coefdeepb;
   soildimpar.coefminea  = chtlu->coefminea;

--- a/src/Soil_Bgc.cpp
+++ b/src/Soil_Bgc.cpp
@@ -525,14 +525,14 @@ void Soil_Bgc::initMslayerCarbon(double & minec) {
   double prevcumcarbon = 0.;
   double cumcarbon = 0.;
   double ca =  ground->soildimpar.coefminea;
-  double cb = -ground->soildimpar.coefmineb;
+  double cb = ground->soildimpar.coefmineb;
   Layer* currl = ground->fstminel;
   double totsomc = 0.0;
 
   while(currl!=NULL) {
     if(currl->isSoil) {
       dbm += currl->dz;
-      cumcarbon = ca/cb*(exp(cb*dbm*100)-1.0)*10000 + 0.0025*dbm*100*10000;
+      cumcarbon = ca*(pow(dbm*100,cb))*10000;
 
       if(cumcarbon-prevcumcarbon>0.01 && dbm<=2.0) {  // somc will not exist more than 2 m intially
         currl->rawc  = bgcpar.eqrawc * (cumcarbon -prevcumcarbon);


### PR DESCRIPTION
(1) fix a minor typo in Ground.cpp that set minimum values of a
deep organic layer thickness
(2) update the algorithm that compute soil organic carbon stock
in mineral layers. For some reason, the original algorithm was
set from Shuhua Yi's 2009 paper. But this algorithm was updated
in 2013 by H. Genet re-analyzing new pedon database produced
by Kris Johnson (2009, Geoderma paper).