### PR TITLE
Custom baseline climate

### DIFF
--- a/include/Climate.h
+++ b/include/Climate.h
@@ -10,6 +10,11 @@ public:
   Climate();
   Climate(const std::string& fname, const std::string& co2fname, int y, int x);
 
+  // misc climate variables
+  // This value will change during a run when switching from
+  //  historic to projected climate data
+  int tseries_start_year;
+
   // driving variables
   std::vector<float> co2;
   std::vector<float> tair;

--- a/include/Climate.h
+++ b/include/Climate.h
@@ -81,7 +81,7 @@ private:
 
   void split_precip();
 
-  std::vector<float> avg_over(const std::vector<float> & var, const int window);
+  std::vector<float> avg_over(const std::vector<float> & var, const int start_yr, const int end_yr);
   std::vector<float> rpt_years(const std::vector<float> &, const int);
 
   std::vector<float> interpolate_daily(const std::vector<float> & var);

--- a/include/TEMUtilityFunctions.h
+++ b/include/TEMUtilityFunctions.h
@@ -141,6 +141,7 @@ namespace temutil {
                                     const std::string &var,
                                     const int y, const int x);
 
+  int get_timeseries_start_year(const std::string &filename);
 
   // draft - reads all timesteps co2 data
   std::vector<float> get_timeseries(const std::string &filename,

--- a/src/Climate.cpp
+++ b/src/Climate.cpp
@@ -403,6 +403,9 @@ void Climate::load_from_file(const std::string& fname, int y, int x) {
     vapo = temutil::get_timeseries<float>(fname, "vapor_press", y, x);
     prec = temutil::get_timeseries<float>(fname, "precip", y, x);
     nirr = temutil::get_timeseries<float>(fname, "nirr", y, x);
+
+    tseries_start_year = temutil::get_timeseries_start_year(fname);
+
   }//End critical(load_climate)
 
   // Report on sizes...

--- a/src/Climate.cpp
+++ b/src/Climate.cpp
@@ -453,12 +453,16 @@ void Climate::load_from_file(const std::string& fname, int y, int x) {
   }
   BOOST_LOG_SEV(glg, debug) << "par = [" << temutil::vec2csv(par) << "]";
 
-  // create the simplified climate by averaging the first X years of data
-  avgX_tair = avg_over(tair, 30);
-  avgX_prec = avg_over(prec, 30);
-  avgX_nirr = avg_over(nirr, 30);
-  avgX_vapo = avg_over(vapo, 30);
- 
+  // Create a simplified historic climate for EQ by averaging input data
+  // over a year range specified here. The year choices should be exposed
+  // in the config file eventually. TODO
+  if(fname.find("historic") != std::string::npos){
+    avgX_tair = avg_over(tair, 1901, 1931);
+    avgX_prec = avg_over(prec, 1901, 1931);
+    avgX_nirr = avg_over(nirr, 1901, 1931);
+    avgX_vapo = avg_over(vapo, 1901, 1931);
+  }
+
   // Do we need simplified 'avgX_' values for par, and cld??
   // ===> YES: the derived variables should probably be based off the avgX
   //      containers...
@@ -481,28 +485,33 @@ void Climate::load_proj_co2(const std::string& fname){
   this->co2 = temutil::get_timeseries(fname, "co2");
 }
 
-std::vector<float> Climate::avg_over(const std::vector<float> & var, const int window) {
+std::vector<float> Climate::avg_over(const std::vector<float> & var, const int start_yr, const int end_yr) {
+
+  int window_length = end_yr - start_yr;
+
+  int start_idx = start_yr - tseries_start_year;
+  int end_idx = end_yr - tseries_start_year;
 
   assert(var.size() % 12 == 0 && "The data vector is the wrong size! var.size() should be an even multiple of 12.");
-  assert(var.size() >= 12*window && "The data vector is too short to average over the window!");
+  assert(var.size() >= 12*window_length && "The data vector is too short to average over the window!");
 
   // make space for the result - one number for each month
   std::vector<float> result(12, 0);
 
   for (int im = 0; im < 12; ++im) {
     // make space for a month's data over the averaging window
-    std::vector<float> mdata(window, 0);
+    std::vector<float> mdata(window_length, 0);
 
     // gather up the data for this month over the averaging window
-    for (int iy = 0; iy < window; ++iy) {
-      mdata[iy] = var[iy*12 + im];
+    for (int iy = start_idx; iy < end_idx; ++iy) {
+      mdata[iy-start_idx] = var[iy*12 + im];
     }
 
     // average the data for the month
     float sum = std::accumulate(mdata.begin(), mdata.end(), 0.0);
 
     // put the value in the result vector for this month
-    result[im] = sum / window; // ?? should window be a float??
+    result[im] = sum / window_length; // ?? should window be a float??
 
     //BOOST_LOG_SEV(glg, debug) << "result = [" << temutil::vec2csv(result) << "]";
 


### PR DESCRIPTION
This switches the averaging of EQ climate from the first thirty years of the historic climate to a calendar year range specified by the user. Currently the values are hard-coded, as pulling them out to a config file would require some rearranging of either the Climate or ModelData classes. If this change proves useful we will revisit how the years are specified.

From master (automatic first thirty years):
tair = [-24.130373, -25.4619064, -24.3164234, -15.0833101, -1.12805164, 8.10580921, 10.6123066, 8.88959217, -1.72176635, -14.1386127, -18.3729153, -26.4659309]
prec = [20.0347233, 18.1906681, 17.5368481, 10.9298162, 15.6702776, 30.2642879, 67.3214798, 66.3478088, 29.6546726, 25.8326817, 17.8337746, 20.0318737]
nirr = [1.01365709, 17.5644417, 66.1893616, 130.317703, 179.362015, 202.11293, 183.464584, 124.914818, 68.4005585, 22.2963142, 2.7131145, 0]
vapo = [0.513333321, 0.569999993, 0.529999971, 1.31333339, 3.54999995, 6.74666643, 9.16666698, 8.83666706, 4.3166666, 1.80333328, 1.07333338, 0.379999995]

If this branch is passed the values 1901 and 1931 it produces averaged climate values identical to master. Given the values 1990 and 2015 it produces the following:
tair = [-22.2550907, -23.8499031, -22.4464188, -12.0111351, 0.481617659, 9.31902218, 11.7937717, 9.99920368, -0.218563884, -12.7768908, -17.0048046, -24.4955616]
prec = [16.8757973, 15.1542368, 10.1218052, 9.87578011, 14.9200001, 31.8469944, 64.9291687, 59.5883636, 31.314373, 23.520153, 20.372961, 19.5589523]
nirr = [0.995956421, 18.542614, 69.2170868, 136.92688, 192.94342, 216.171967, 190.968872, 126.524696, 71.8444214, 23.7901154, 2.89282703, 0]
vapo = [0.680000007, 0.755999982, 0.74000001, 1.76800001, 3.90400004, 7.19599962, 9.73600006, 9.51599979, 4.76000023, 2.06399989, 1.352, 0.588]
