### PR TITLE
Upgrades base docker container to Ubuntu 24 LTS

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -46,7 +46,8 @@ ARG GID=1000
 
 # === IMAGE FOR GENERAL C++ DEVELOPMENT =======================================
 # General development tools, compilers, text editors, etc
-FROM ubuntu:jammy AS cpp-dev
+FROM ubuntu:noble AS cpp-dev
+RUN userdel -r ubuntu
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update -y --fix-missing && apt-get install -y \
     build-essential \
@@ -150,6 +151,7 @@ ENV SITE_SPECIFIC_LIBS="-I/usr/lib"
 ENV PATH="/work:$PATH"
 ENV PATH="/work/scripts:$PATH"
 ENV PATH="/work/scripts/util:$PATH"
+ENV PYTHONPATH="/work/scripts:$PYTHONPATH"
 WORKDIR /work
 # or use command
 #ENTRYPOINT [ "tail", "-f", "/dev/null" ]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,7 +19,7 @@ services:
     build: .
     image: cpp-dev:${V_TAG}
 
-  # The general dvmdostem dev enviorment. Intented to be used for 
+  # The general dvmdostem dev environment. Intended to be used for 
   # most development work by mounting volumes of source code into 
   # the resulting container - essentially sharing the source code
   # folders from the host to the container so they can be edited 


### PR DESCRIPTION
- Upgrades container base to Ubuntu 24
- Removes default 'ubuntu' user
- Adds /work/scripts to PYTHONPATH
- Fixes typos

The default 'ubuntu' user was added in version
24 and uses the UID 1000 which conflicts with our
Docker environment setup.