### PR TITLE
Print file path when handling NetCDF errors

### DIFF
--- a/include/TEMUtilityFunctions.h
+++ b/include/TEMUtilityFunctions.h
@@ -141,9 +141,9 @@ namespace temutil {
 
   int get_nc_timedim_len(const int& ncid);
 
-  void handle_error(int status);
+  void handle_error(int status, const std::string& filepath = "");
   
-  void nc(int status);
+  void nc(int status, const std::string& filepath = "");
   
   double interpolate(double value_1, double value_2, double position_1, double position_2, double position_new, int method);
 
@@ -213,7 +213,7 @@ namespace temutil {
     BOOST_LOG_SEV(glg, debug) << "Opening dataset: " << filename;
 
     int ncid;
-    temutil::nc( nc_open(filename.c_str(), NC_NOWRITE, &ncid) );
+    temutil::nc( nc_open(filename.c_str(), NC_NOWRITE, &ncid), filename );
 
     int timeseries_var;
     temutil::nc( nc_inq_varid(ncid, var.c_str(), &timeseries_var) );

--- a/src/ModelData.cpp
+++ b/src/ModelData.cpp
@@ -462,11 +462,11 @@ void ModelData::create_netCDF_output_files(int ysize, int xsize,
 #ifdef WITHMPI
       // Creating PARALLEL NetCDF file
       BOOST_LOG_SEV(glg, debug)<<"Creating a parallel output NetCDF file " << creation_filestr;
-      temutil::nc( nc_create_par(creation_filestr.c_str(), NC_CLOBBER|NC_NETCDF4|NC_MPIIO, MPI_COMM_WORLD, MPI_INFO_NULL, &ncid) );
+      temutil::nc( nc_create_par(creation_filestr.c_str(), NC_CLOBBER|NC_NETCDF4|NC_MPIIO, MPI_COMM_WORLD, MPI_INFO_NULL, &ncid), creation_filestr );
 #else
       // Creating NetCDF file
       BOOST_LOG_SEV(glg, debug) << "Creating an output NetCDF file " << creation_filestr;
-      temutil::nc( nc_create(creation_filestr.c_str(), NC_CLOBBER|NC_NETCDF4, &ncid) );
+      temutil::nc( nc_create(creation_filestr.c_str(), NC_CLOBBER|NC_NETCDF4, &ncid), creation_filestr );
 #endif
 
       BOOST_LOG_SEV(glg, debug) << "Adding file-level attributes";
@@ -587,7 +587,7 @@ void ModelData::create_netCDF_output_files(int ysize, int xsize,
 
         BOOST_LOG_SEV(glg, debug) << "Opening historic climate file: "
                                   << this->hist_climate_file;
-        temutil::nc( nc_open(this->hist_climate_file.c_str(), NC_NOWRITE, &hist_climate_ncid) );
+        temutil::nc( nc_open(this->hist_climate_file.c_str(), NC_NOWRITE, &hist_climate_ncid), this->hist_climate_file );
         temutil::nc( nc_inq_varid(hist_climate_ncid, "time", &hist_climate_tcV));
 
         // Copy attributes for time variable
@@ -609,7 +609,7 @@ void ModelData::create_netCDF_output_files(int ysize, int xsize,
 
         BOOST_LOG_SEV(glg, debug) << "Opening projected climate file: "
                                   << this->proj_climate_file;
-        temutil::nc( nc_open(this->proj_climate_file.c_str(), NC_NOWRITE, &proj_climate_ncid) );
+        temutil::nc( nc_open(this->proj_climate_file.c_str(), NC_NOWRITE, &proj_climate_ncid), this->proj_climate_file );
         temutil::nc( nc_inq_varid(proj_climate_ncid, "time", &proj_climate_tcV));
 
         temutil::nc( nc_copy_att(proj_climate_ncid, proj_climate_tcV, "units", ncid, tcVar));
@@ -657,7 +657,7 @@ void ModelData::create_netCDF_output_files(int ysize, int xsize,
         int gmsrcid;
         BOOST_LOG_SEV(glg, debug) << "Opening vegetation file: "
                                   << this->veg_class_file;
-        temutil::nc( nc_open(this->veg_class_file.c_str(), NC_NOWRITE, &gmsrcid) );
+        temutil::nc( nc_open(this->veg_class_file.c_str(), NC_NOWRITE, &gmsrcid), this->veg_class_file );
 
         // Figure out which id is for grid mapping variable
         int srcgmvid = -1;

--- a/src/RestartData.cpp
+++ b/src/RestartData.cpp
@@ -555,7 +555,7 @@ void RestartData::read_px_vars(const std::string& fname, const int rowidx, const
   BOOST_LOG_SEV(glg, debug) << "Opening restart: " << fname;
  
   int ncid;
-  temutil::nc( nc_open(fname.c_str(), NC_NOWRITE, &ncid) );
+  temutil::nc( nc_open(fname.c_str(), NC_NOWRITE, &ncid), fname );
 
   // Check dimension presence? length? size?
 
@@ -614,7 +614,7 @@ void RestartData::read_px_pft_vars(const std::string& fname, const int rowidx, c
   BOOST_LOG_SEV(glg, debug) << "Opening restart: " << fname;
 
   int ncid;
-  temutil::nc( nc_open(fname.c_str(), NC_NOWRITE, &ncid) );
+  temutil::nc( nc_open(fname.c_str(), NC_NOWRITE, &ncid), fname );
 
   // Check dimension presence? length? size?
 
@@ -678,7 +678,7 @@ void RestartData::read_px_pftpart_pft_vars(const std::string& fname, const int r
   BOOST_LOG_SEV(glg, debug) << "Opening restart: " << fname;
 
   int ncid;
-  temutil::nc( nc_open(fname.c_str(), NC_NOWRITE, &ncid) );
+  temutil::nc( nc_open(fname.c_str(), NC_NOWRITE, &ncid), fname );
 
   int cv; // a reusable variable handle
   
@@ -713,7 +713,7 @@ void RestartData::read_px_snow_vars(const std::string& fname, const int rowidx, 
   BOOST_LOG_SEV(glg, debug) << "Opening restart: " << fname;
 
   int ncid;
-  temutil::nc( nc_open(fname.c_str(), NC_NOWRITE, &ncid) );
+  temutil::nc( nc_open(fname.c_str(), NC_NOWRITE, &ncid), fname );
 
   // Check dimension presence? length? size?
 
@@ -752,7 +752,7 @@ void RestartData::read_px_root_pft_vars(const std::string& fname, const int rowi
   BOOST_LOG_SEV(glg, debug) << "Opening restart: " << fname;
 
   int ncid;
-  temutil::nc( nc_open(fname.c_str(), NC_NOWRITE, &ncid) );
+  temutil::nc( nc_open(fname.c_str(), NC_NOWRITE, &ncid), fname );
 
   int cv; // a reusable variable handle
 
@@ -781,7 +781,7 @@ void RestartData::read_px_soil_vars(const std::string& fname, const int rowidx, 
   BOOST_LOG_SEV(glg, debug) << "Opening restart: " << fname;
 
   int ncid;
-  temutil::nc( nc_open(fname.c_str(), NC_NOWRITE, &ncid) );
+  temutil::nc( nc_open(fname.c_str(), NC_NOWRITE, &ncid), fname );
 
   int cv; // a reusable variable handle
 
@@ -834,7 +834,7 @@ void RestartData::read_px_rock_vars(const std::string& fname, const int rowidx, 
   BOOST_LOG_SEV(glg, debug) << "Opening restart: " << fname;
 
   int ncid;
-  temutil::nc( nc_open(fname.c_str(), NC_NOWRITE, &ncid) );
+  temutil::nc( nc_open(fname.c_str(), NC_NOWRITE, &ncid), fname );
 
   // Check dimension presence? length? size?
 
@@ -865,7 +865,7 @@ void RestartData::read_px_front_vars(const std::string& fname, const int rowidx,
   BOOST_LOG_SEV(glg, debug) << "Opening restart: " << fname;
 
   int ncid;
-  temutil::nc( nc_open(fname.c_str(), NC_NOWRITE, &ncid) );
+  temutil::nc( nc_open(fname.c_str(), NC_NOWRITE, &ncid), fname );
 
   int cv; // a reusable variable handle
 
@@ -900,7 +900,7 @@ void RestartData::read_px_prev_pft_vars(const std::string& fname, const int rowi
   BOOST_LOG_SEV(glg, debug) << "Opening restart: " << fname;
 
   int ncid;
-  temutil::nc( nc_open(fname.c_str(), NC_NOWRITE, &ncid) );
+  temutil::nc( nc_open(fname.c_str(), NC_NOWRITE, &ncid), fname );
 
   int cv; // a reusable variable handle
 
@@ -947,9 +947,9 @@ void RestartData::create_empty_file(const std::string& fname,
 
 #ifdef WITHMPI
   BOOST_LOG_SEV(glg, debug) << "Creating new parallel restart file: "<<fname;
-  temutil::nc( nc_create_par(fname.c_str(), NC_CLOBBER|NC_NETCDF4|NC_MPIIO, MPI_COMM_WORLD, MPI_INFO_NULL, &ncid) );
+  temutil::nc( nc_create_par(fname.c_str(), NC_CLOBBER|NC_NETCDF4|NC_MPIIO, MPI_COMM_WORLD, MPI_INFO_NULL, &ncid), fname );
 #else
-  temutil::nc( nc_create(fname.c_str(), NC_CLOBBER, &ncid) );
+  temutil::nc( nc_create(fname.c_str(), NC_CLOBBER, &ncid), fname );
 #endif
 
   //int old_fill_mode;
@@ -1305,9 +1305,9 @@ void RestartData::write_px_vars(const std::string& fname, const int rowidx, cons
   int ncid;
 
 #ifdef WITHMPI
-  temutil::nc( nc_open_par(fname.c_str(), NC_WRITE|NC_MPIIO, MPI_COMM_SELF, MPI_INFO_NULL, &ncid) );
+  temutil::nc( nc_open_par(fname.c_str(), NC_WRITE|NC_MPIIO, MPI_COMM_SELF, MPI_INFO_NULL, &ncid), fname );
 #else
-  temutil::nc( nc_open(fname.c_str(), NC_WRITE, &ncid) );
+  temutil::nc( nc_open(fname.c_str(), NC_WRITE, &ncid), fname );
 #endif
 
   // Check dimension presence? length? size?
@@ -1368,9 +1368,9 @@ void RestartData::write_px_pft_vars(const std::string& fname, const int rowidx, 
   int ncid;
 
 #ifdef WITHMPI
-  temutil::nc( nc_open_par(fname.c_str(), NC_WRITE|NC_MPIIO, MPI_COMM_SELF, MPI_INFO_NULL, &ncid) );
+  temutil::nc( nc_open_par(fname.c_str(), NC_WRITE|NC_MPIIO, MPI_COMM_SELF, MPI_INFO_NULL, &ncid), fname );
 #else
-  temutil::nc( nc_open(fname.c_str(), NC_WRITE, &ncid) );
+  temutil::nc( nc_open(fname.c_str(), NC_WRITE, &ncid), fname );
 #endif
 
   // Check dimension presence? length? size?
@@ -1436,9 +1436,9 @@ void RestartData::write_px_pftpart_pft_vars(const std::string& fname, const int 
   int ncid;
 
 #ifdef WITHMPI
-  temutil::nc( nc_open_par(fname.c_str(), NC_WRITE|NC_MPIIO, MPI_COMM_SELF, MPI_INFO_NULL, &ncid) );
+  temutil::nc( nc_open_par(fname.c_str(), NC_WRITE|NC_MPIIO, MPI_COMM_SELF, MPI_INFO_NULL, &ncid), fname );
 #else
-  temutil::nc( nc_open(fname.c_str(), NC_WRITE, &ncid) );
+  temutil::nc( nc_open(fname.c_str(), NC_WRITE, &ncid), fname );
 #endif
 
   int cv; // a reusable variable handle
@@ -1475,9 +1475,9 @@ void RestartData::write_px_snow_vars(const std::string& fname, const int rowidx,
   int ncid;
 
 #ifdef WITHMPI
-  temutil::nc( nc_open_par(fname.c_str(), NC_WRITE|NC_MPIIO, MPI_COMM_SELF, MPI_INFO_NULL, &ncid) );
+  temutil::nc( nc_open_par(fname.c_str(), NC_WRITE|NC_MPIIO, MPI_COMM_SELF, MPI_INFO_NULL, &ncid), fname );
 #else
-  temutil::nc( nc_open(fname.c_str(), NC_WRITE, &ncid) );
+  temutil::nc( nc_open(fname.c_str(), NC_WRITE, &ncid), fname );
 #endif
 
   // Check dimension presence? length? size?
@@ -1518,9 +1518,9 @@ void RestartData::write_px_root_pft_vars(const std::string& fname, const int row
   int ncid;
 
 #ifdef WITHMPI
-  temutil::nc( nc_open_par(fname.c_str(), NC_WRITE|NC_MPIIO, MPI_COMM_SELF, MPI_INFO_NULL, &ncid) );
+  temutil::nc( nc_open_par(fname.c_str(), NC_WRITE|NC_MPIIO, MPI_COMM_SELF, MPI_INFO_NULL, &ncid), fname );
 #else
-  temutil::nc( nc_open(fname.c_str(), NC_WRITE, &ncid) );
+  temutil::nc( nc_open(fname.c_str(), NC_WRITE, &ncid), fname );
 #endif
 
   int cv; // a reusable variable handle
@@ -1551,9 +1551,9 @@ void RestartData::write_px_soil_vars(const std::string& fname, const int rowidx,
   int ncid;
 
 #ifdef WITHMPI
-  temutil::nc( nc_open_par(fname.c_str(), NC_WRITE|NC_MPIIO, MPI_COMM_SELF, MPI_INFO_NULL, &ncid) );
+  temutil::nc( nc_open_par(fname.c_str(), NC_WRITE|NC_MPIIO, MPI_COMM_SELF, MPI_INFO_NULL, &ncid), fname );
 #else
-  temutil::nc( nc_open(fname.c_str(), NC_WRITE, &ncid) );
+  temutil::nc( nc_open(fname.c_str(), NC_WRITE, &ncid), fname );
 #endif
 
   int cv; // a reusable variable handle
@@ -1608,9 +1608,9 @@ void RestartData::write_px_rock_vars(const std::string& fname, const int rowidx,
   int ncid;
 
 #ifdef WITHMPI
-  temutil::nc( nc_open_par(fname.c_str(), NC_WRITE|NC_MPIIO, MPI_COMM_SELF, MPI_INFO_NULL, &ncid) );
+  temutil::nc( nc_open_par(fname.c_str(), NC_WRITE|NC_MPIIO, MPI_COMM_SELF, MPI_INFO_NULL, &ncid), fname );
 #else
-  temutil::nc( nc_open(fname.c_str(), NC_WRITE, &ncid) );
+  temutil::nc( nc_open(fname.c_str(), NC_WRITE, &ncid), fname );
 #endif
 
   // Check dimension presence? length? size?
@@ -1643,9 +1643,9 @@ void RestartData::write_px_front_vars(const std::string& fname, const int rowidx
   int ncid;
 
 #ifdef WITHMPI
-  temutil::nc( nc_open_par(fname.c_str(), NC_WRITE|NC_MPIIO, MPI_COMM_SELF, MPI_INFO_NULL, &ncid) );
+  temutil::nc( nc_open_par(fname.c_str(), NC_WRITE|NC_MPIIO, MPI_COMM_SELF, MPI_INFO_NULL, &ncid), fname );
 #else
-  temutil::nc( nc_open(fname.c_str(), NC_WRITE, &ncid) );
+  temutil::nc( nc_open(fname.c_str(), NC_WRITE, &ncid), fname );
 #endif
 
   int cv; // a reusable variable handle
@@ -1682,9 +1682,9 @@ void RestartData::write_px_prev_pft_vars(const std::string& fname, const int row
   int ncid;
 
 #ifdef WITHMPI
-  temutil::nc( nc_open_par(fname.c_str(), NC_WRITE|NC_MPIIO, MPI_COMM_SELF, MPI_INFO_NULL, &ncid) );
+  temutil::nc( nc_open_par(fname.c_str(), NC_WRITE|NC_MPIIO, MPI_COMM_SELF, MPI_INFO_NULL, &ncid), fname );
 #else
-  temutil::nc( nc_open(fname.c_str(), NC_WRITE, &ncid) );
+  temutil::nc( nc_open(fname.c_str(), NC_WRITE, &ncid), fname );
 #endif
 
   int cv; // a reusable variable handle

--- a/src/Runner.cpp
+++ b/src/Runner.cpp
@@ -969,9 +969,9 @@ void Runner::output_nc_3dim(OutputSpec* out_spec, std::string stage_suffix,
   BOOST_LOG_SEV(glg, debug) << "Opening output file: " << output_filename;
 
 #ifdef WITHMPI
-  temutil::nc( nc_open_par(output_filename.c_str(), NC_WRITE|NC_MPIIO, MPI_COMM_SELF, MPI_INFO_NULL, &ncid) );
+  temutil::nc( nc_open_par(output_filename.c_str(), NC_WRITE|NC_MPIIO, MPI_COMM_SELF, MPI_INFO_NULL, &ncid), output_filename );
 #else
-  temutil::nc( nc_open(output_filename.c_str(), NC_WRITE, &ncid) );
+  temutil::nc( nc_open(output_filename.c_str(), NC_WRITE, &ncid), output_filename );
 #endif
 
   temutil::nc( nc_inq_varid(ncid, out_spec->var_name.c_str(), &cv) );
@@ -1013,9 +1013,9 @@ void Runner::output_nc_4dim(OutputSpec* out_spec, std::string stage_suffix,
   BOOST_LOG_SEV(glg, debug) << "Opening output file: " << output_filename;
 
 #ifdef WITHMPI
-  temutil::nc( nc_open_par(output_filename.c_str(), NC_WRITE|NC_MPIIO, MPI_COMM_SELF, MPI_INFO_NULL, &ncid) );
+  temutil::nc( nc_open_par(output_filename.c_str(), NC_WRITE|NC_MPIIO, MPI_COMM_SELF, MPI_INFO_NULL, &ncid), output_filename );
 #else
-  temutil::nc( nc_open(output_filename.c_str(), NC_WRITE, &ncid) );
+  temutil::nc( nc_open(output_filename.c_str(), NC_WRITE, &ncid), output_filename );
 #endif
 
   temutil::nc( nc_inq_varid(ncid, out_spec->var_name.c_str(), &cv) );
@@ -1057,9 +1057,9 @@ void Runner::output_nc_5dim(OutputSpec* out_spec, std::string stage_suffix,
   BOOST_LOG_SEV(glg, debug) << "Opening output file: " << output_filename;
 
 #ifdef WITHMPI
-  temutil::nc( nc_open_par(output_filename.c_str(), NC_WRITE|NC_MPIIO, MPI_COMM_SELF, MPI_INFO_NULL, &ncid) );
+  temutil::nc( nc_open_par(output_filename.c_str(), NC_WRITE|NC_MPIIO, MPI_COMM_SELF, MPI_INFO_NULL, &ncid), output_filename );
 #else
-  temutil::nc( nc_open(output_filename.c_str(), NC_WRITE, &ncid) );
+  temutil::nc( nc_open(output_filename.c_str(), NC_WRITE, &ncid), output_filename );
 #endif
 
   temutil::nc( nc_inq_varid(ncid, out_spec->var_name.c_str(), &cv) );

--- a/src/TEM.cpp
+++ b/src/TEM.cpp
@@ -548,7 +548,7 @@ std::vector<float> read_new_co2_file(const std::string &filename) {
   int ncid;
   
   BOOST_LOG_SEV(glg, debug) << "Opening dataset: " << filename;
-  temutil::nc( nc_open(filename.c_str(), NC_NOWRITE, &ncid) );
+  temutil::nc( nc_open(filename.c_str(), NC_NOWRITE, &ncid), filename );
   
   BOOST_LOG_SEV(glg, debug) << "Find out how much data there is...";
   int yearD;
@@ -953,14 +953,14 @@ void create_empty_run_status_file(const std::string& fname,
   MPI_Comm_size(MPI_COMM_WORLD, &ntasks);
 
                             // path            c mode               mpi comm obj     mpi info netcdfid
-  temutil::nc( nc_create_par(fname.c_str(), NC_CLOBBER|NC_NETCDF4|NC_MPIIO, MPI_COMM_WORLD, MPI_INFO_NULL, &ncid) );
+  temutil::nc( nc_create_par(fname.c_str(), NC_CLOBBER|NC_NETCDF4|NC_MPIIO, MPI_COMM_WORLD, MPI_INFO_NULL, &ncid), fname );
 
   BOOST_LOG_SEV(glg, debug) << "(MPI " << id << "/" << ntasks << ") Creating PARALLEL run_status file! \n";
 
 #else
 
   BOOST_LOG_SEV(glg, debug) << "Opening new file with 'NC_CLOBBER'";
-  temutil::nc( nc_create(fname.c_str(), NC_CLOBBER, &ncid) );
+  temutil::nc( nc_create(fname.c_str(), NC_CLOBBER, &ncid), fname );
 
 #endif
 
@@ -1037,7 +1037,7 @@ void write_status_info(const std::string fname, std::string varname, int row, in
   MPI_Comm_size(MPI_COMM_WORLD, &ntasks);
 
   // Open dataset
-  temutil::nc( nc_open_par(fname.c_str(), NC_WRITE|NC_MPIIO, MPI_COMM_SELF, MPI_INFO_NULL, &ncid) );
+  temutil::nc( nc_open_par(fname.c_str(), NC_WRITE|NC_MPIIO, MPI_COMM_SELF, MPI_INFO_NULL, &ncid), fname );
   //temutil::nc( nc_inq_varid(ncid, "run_status", &statusV) );
   temutil::nc( nc_inq_varid(ncid, varname.c_str(), &statusV) );
   temutil::nc( nc_var_par_access(ncid, statusV, NC_INDEPENDENT) );
@@ -1052,7 +1052,7 @@ void write_status_info(const std::string fname, std::string varname, int row, in
 #else
 
   // Open dataset
-  temutil::nc( nc_open(fname.c_str(), NC_WRITE, &ncid) );
+  temutil::nc( nc_open(fname.c_str(), NC_WRITE, &ncid), fname );
   temutil::nc( nc_inq_varid(ncid, varname.c_str(), &statusV) );
   
   // Write data


### PR DESCRIPTION
I've been dealing with `No such file or directory found` error a lot lately. That error is useless when we don't know which file NetCDF is trying to access to.

With this PR, we will be able to know which file the model is tripping on.