### PR TITLE
Update fire parameters for CMT31

### DIFF
--- a/parameters/cmt_firepar.txt
+++ b/parameters/cmt_firepar.txt
@@ -235,17 +235,17 @@
 0.10   //r_retain_n://  // ratio of burning residue N (retained into soil) //
 //===========================================================
 // CMT31 // Boreal Bog
-//DecShrub   EvrShrub     DecTree      EvrTree      Forbs        Gram         Feather      Lichen       Equisetum    Misc.     // name: units // description // comment // refs
-0.00         0.00         0.00         0.00         0.00         0.00         0.00         0.00         0.00         0.00      //fvcomb_sev1://  // fraction of PFT vegetation combusted for severity 1 // 
-0.15         0.15         0.15         0.15         0.15         0.70         0.70         0.80         1.00         0.00      //fvcomb_sev2://  // fraction of PFT vegetation combusted for severity 2 // 
-0.25         0.25         0.25         0.25         0.25         0.80         0.80         0.90         1.00         0.00      //fvcomb_sev3://  // fraction of PFT vegetation combusted for severity 3 // 
-0.30         0.30         0.30         0.30         0.30         0.90         0.90         1.00         1.00         0.00      //fvcomb_sev4://  // fraction of PFT vegetation combusted for severity 4 // 
-0.35         0.35         0.35         0.35         0.35         1.00         1.00         1.00         1.00         0.00      //fvcomb_sev5://  // fraction of PFT vegetation combusted for severity 5 // 
-0.00         0.00         0.00         0.00         0.00         0.00         0.00         0.00         0.00         0.00      //fvdead_sev1://  // fraction of PFT vegetation killed for severity 1 // 
-0.50         0.50         0.50         0.50         0.50         0.20         0.20         0.00         0.00         0.00      //fvdead_sev2://  // fraction of PFT vegetation killed for severity 2 // 
-0.60         0.60         0.60         0.60         0.60         0.00         0.00         0.00         0.00         0.00      //fvdead_sev3://  // fraction of PFT vegetation killed for severity 3 // 
-0.64         0.64         0.64         0.64         0.64         0.00         0.00         0.00         0.00         0.00      //fvdead_sev4://  // fraction of PFT vegetation killed for severity 4 // 
-0.64         0.64         0.64         0.64         0.64         0.00         0.00         0.00         0.00         0.00      //fvdead_sev5://  // fraction of PFT vegetation killed for severity 5 // 
+//Sphagnum   Sedge        DecShrub     EvrShrub     Forbs        Moss         PFT6         PFT7         PFT8         PFT9             // names: comments
+0.6          0.6          0.00         0.00         0.00         0.6          0.0          0.0          0.0          0.0              //fvcomb_sev1://  // fraction of PFT vegetation combusted for severity 1 //
+0.7          0.7          0.15         0.15         0.15         0.7          0.0          0.0          0.0          0.0              //fvcomb_sev2://  // fraction of PFT vegetation combusted for severity 2 //
+0.8          0.8          0.25         0.25         0.25         0.8          0.0          0.0          0.0          0.0              //fvcomb_sev3://  // fraction of PFT vegetation combusted for severity 3 //
+0.9          0.9          0.30         0.30         0.30         0.9          0.0          0.0          0.0          0.0              //fvcomb_sev4://  // fraction of PFT vegetation combusted for severity 4 //
+1.0          1.0          0.35         0.35         0.35         1.0          0.0          0.0          0.0          0.0              //fvcomb_sev5://  // fraction of PFT vegetation combusted for severity 5 //
+0.2          0.2          0.00         0.00         0.00         0.2          0.0          0.0          0.0          0.0              //fvdead_sev1://  // fraction of PFT vegetation killed for severity 1 //
+0.4          0.4          0.50         0.50         0.50         0.4          0.0          0.0          0.0          0.0              //fvdead_sev2://  // fraction of PFT vegetation killed for severity 2 //
+0.6          0.6          0.60         0.60         0.60         0.6          0.0          0.0          0.0          0.0              //fvdead_sev3://  // fraction of PFT vegetation killed for severity 3 //
+0.8          0.8          0.64         0.64         0.64         0.8          0.0          0.0          0.0          0.0              //fvdead_sev4://  // fraction of PFT vegetation killed for severity 4 //
+1.0          1.0          0.64         0.64         0.64         1.0          0.0          0.0          0.0          0.0              //fvdead_sev5://  // fraction of PFT vegetation killed for severity 5 //
 0.00    //foslburn_sev1://  // fraction of OS layer burned for severity 1 //
 0.48    //foslburn_sev2://  // fraction of OS layer burned for severity 2 //
 0.54    //foslburn_sev3://  // fraction of OS layer burned for severity 3 //


### PR DESCRIPTION
The fire parameter file contained the wrong number of PFTs with the wrong names for the CMT31 (Boreal Bog).

Fixed with this commit to the correct number of PFTs and the correct names.

WARNING: For Spahgnum, Sedge and Moss, which did not exist directly in the file, the values are set to a simple linear ramp from 0.6-1 or 0-1. In otherwords these are not calibrated or researched values!